### PR TITLE
Add omp critical section to PlmBar

### DIFF
--- a/src/PlmBar.f95
+++ b/src/PlmBar.f95
@@ -120,6 +120,7 @@ subroutine PlmBar(p, lmax, z, csphase, cnorm)
             
     scalef = 1.0d-280
     
+!$omp critical (PlmBar_init)
     if (lmax > lmax_old) then
         if (allocated (sqr)) deallocate (sqr)
         if (allocated (f1)) deallocate (f1)
@@ -175,6 +176,7 @@ subroutine PlmBar(p, lmax, z, csphase, cnorm)
         lmax_old = lmax
     
     end if
+!$omp end critical (PlmBar_init)
     
     !---------------------------------------------------------------------------
     !   


### PR DESCRIPTION
I've been starting to port some SHTOOLS using code to use OpenMP.  I had to add this section to PlmBar() to avoid multiple runs of the init code.  It seems to work reasonably well for me.  I've not looked at any other of the SHTOOLS routines.

Locally we are now building a separate copy of SHTOOLS (libSHTOOLS_thread.a) with OpenMP enabled.