### PR TITLE
Update pyshtools classes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-Copyright (c) 2005-2014, Mark A. Wieczorek.
-All rights reserved.
+Copyright (c) 2005-2016, SHTOOLS
+All rights reserved
 
 * Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions

--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ endif
 
 python2: pyshtools/_SHTOOLS.so pyshtools/_constant.so
 	mkdir -p pyshtools/doc
-	./pyshtools/make_docs.py . .
+	$(PYTHON) ./pyshtools/make_docs.py .
 	@echo
 	@echo MAKE SUCCESSFUL!
 	@echo

--- a/examples/python/ClassInterface/ClassExample.py
+++ b/examples/python/ClassInterface/ClassExample.py
@@ -13,7 +13,7 @@ import matplotlib as mpl
 
 # import shtools:
 sys.path.append(os.path.join(os.path.dirname(__file__), "../../.."))
-from pyshtools import SHCoeffs
+import pyshtools as shtools
 
 # set shtools plot style:
 sys.path.append(os.path.join(os.path.dirname(__file__), "../Common"))
@@ -25,7 +25,6 @@ mpl.rcParams.update(style_shtools)
 
 def main():
     example1()
-    example2()
 
 def example1():
     # generate random spherical harmonics coefficients with a given
@@ -34,34 +33,20 @@ def example1():
     scale = 10
     power = 1. / (1. + (degrees / scale)**2)**2
 
-    coeffs = SHCoeffs.from_random(power)
+    coeffs = shtools.SHCoeffs.from_random(power)
     coeffs.plot_powerperband(show=False, fname='power.png')
 
     # expand coefficients into a spatial grid and plot it
-    grid1 = coeffs.expand(kind='DH1')
+    grid1 = coeffs.expand(grid='DH1')
     grid1.plot_rawdata(show=False, fname='DHGrid_unrotated.png')
+    
+    grid2 = coeffs.expand(grid='GLQ')
+    grid2.plot_rawdata(show=False, fname='GLQGrid.png')
 
     # rotate coefficients, expand to grid and plot again
     coeffs.rotate(40., 0., 0., degrees=True)
-    grid2 = coeffs.expand(kind='DH1')
-    grid2.plot_rawdata(show=False, fname='DHGrid_rotated.png')
-
-def example2():
-    # generate random spherical harmonics coefficients with a given
-    # power spectrum and plot its bandspectrum
-    degrees = np.arange(201)
-    scale = 10
-    power = 1. / (1. + (degrees / scale)**2)**2
-
-    coeffs = SHCoeffs.from_random(power)
-    coeffs.plot_powerperband(show=False, fname='power.png')
-
-    # expand coefficients into two different spatial grids and plot it
-    grid1 = coeffs.expand(kind='GLQ')
-    grid1.plot_rawdata(show=False, fname='GLQGrid.png')
-
-    grid2 = coeffs.expand(kind='DH1')
-    grid2.plot_rawdata(show=False,fname='DHGrid.png')
+    grid3 = coeffs.expand(grid='DH1')
+    grid3.plot_rawdata(show=False, fname='DHGrid_rotated.png')
 
 
 #==== EXECUTE SCRIPT ====

--- a/examples/python/ClassInterface/WindowExample.py
+++ b/examples/python/ClassInterface/WindowExample.py
@@ -14,7 +14,7 @@ import matplotlib.pyplot as plt
 
 # import shtools:
 sys.path.append(os.path.join(os.path.dirname(__file__), "../../.."))
-from pyshtools import SHWindow
+import pyshtools as shtools
 
 # set shtools plot style:
 sys.path.append(os.path.join(os.path.dirname(__file__), "../Common"))
@@ -33,7 +33,7 @@ def example1():
     lmax  = 20
     nwins = 20
     theta = 25.
-    cap = SHWindow.from_cap(lmax,nwins,theta)
+    cap = shtools.SHWindow.from_cap(lmax,nwins,theta)
     cap.info()
     cap.plot(20,show=False,fname='cap_tapers.png')
     cap.plot_couplingmatrix(30,5,show=False,fname='cap_coupling.png')
@@ -47,7 +47,7 @@ def example2():
     topo = np.loadtxt('topo.dat.gz')
     dh_mask = topo > 0.
     print(dh_mask.shape)
-    region = SHWindow.from_mask(lmax, nwins, dh_mask, sampling=2)
+    region = shtools.SHWindow.from_mask(lmax, nwins, dh_mask, sampling=2)
     region.info()
     region.plot(nwins,show=False,fname='continent_tapers.png')
     region.plot_couplingmatrix(30,5,show=False,fname='continent_coupling.png')

--- a/pyshtools/__init__.py
+++ b/pyshtools/__init__.py
@@ -90,14 +90,6 @@ def _load_documentation():
     """
     import os
 
-    # import _SHTOOLS functions to add documentation
-    # the _SHTOOLS functions are later imported into
-    # the main namespace
-
-    # bind Python functions to _SHTOOLS
-    _SHTOOLS.PlmIndex = PlmIndex
-    _SHTOOLS.YilmIndexVector = YilmIndexVector
-
     print('Loading SHTOOLS -- version', __version__)
     pydocfolder = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                   'doc'))
@@ -127,11 +119,12 @@ def _load_documentation():
             print(msg)
 
 
-# --- Import all functions into pyshtools namespace ----
-from ._SHTOOLS import *  # NOQA
+#---- Bind Python functions to _SHTOOLS ----
+_SHTOOLS.PlmIndex = PlmIndex
+_SHTOOLS.YilmIndexVector = YilmIndexVector
 
-# --- Import planetary constants into pyshtools namespace ----
-from . import _constant  # NOQA
+#---- Import planetary constants into pyshtools namespace ----
+from . import _constant
 
 constant = _ConstantClass()
 
@@ -143,9 +136,7 @@ _load_documentation()
 
 # ---- Define __all__ for use with 'from pyshtools import *' ----
 __all__ = ['_ndarrayinfo', '_ConstantClass', 'constant', 'classes']
-__all__ += ['SHCoeffs', 'SHRealCoefficients', 'SHComplexCoefficients',
-            'SHGrid', 'DHGrid', 'GLQGrid', 'SHWindow', 'SHSymmetricWindow',
-            'SHAsymmetricWindow']
+__all__ += ['SHCoeffs', 'SHGrid', 'SHWindow']
 
 
 for _name, _func in _SHTOOLS.__dict__.items():

--- a/pyshtools/__init__.py
+++ b/pyshtools/__init__.py
@@ -37,7 +37,7 @@ from . import _constant
 from ._SHTOOLS import *
 
 # ---- Import classes into pyshtools namespace
-from .classes import SHCoeffs, SHGrid, SHWindow
+from .shclasses import SHCoeffs, SHGrid, SHWindow
 
 
 # ---------------------------------------------------------------------
@@ -109,8 +109,9 @@ for _name, _value in _constant.planetsconstants.__dict__.items():
 # ---- formatted text files.
 # ---------------------------------------------------------------------
 print('Loading SHTOOLS -- version', __version__)
+
 _pydocfolder = _os.path.abspath(_os.path.join(_os.path.dirname(__file__),
-                                             'doc'))
+                                              'doc'))
 
 for _name, _func in _SHTOOLS.__dict__.items():
     if callable(_func):
@@ -127,7 +128,7 @@ for _name, _func in _SHTOOLS.__dict__.items():
 for _name in _constant.planetsconstants.__dict__.keys():
     try:
         _path = _os.path.join(_pydocfolder, 'constant_' + _name.lower() +
-                             '.doc')
+                              '.doc')
 
         with open(_path) as _pydocfile:
             _pydoc = _pydocfile.read()
@@ -139,10 +140,8 @@ for _name in _constant.planetsconstants.__dict__.keys():
 
 
 # ---- Define __all__ for use with: from pyshtools import * ----
-__all__ = ['_ndarrayinfo', '_ConstantClass', 'constant', 'classes']
-__all__ += ['SHCoeffs', 'SHRealCoefficients', 'SHComplexCoefficients',
-            'SHGrid', 'DHGrid', 'GLQGrid', 'SHWindow', 'SHSymmetricWindow',
-            'SHAsymmetricWindow']
+__all__ = ['_ndarrayinfo', '_ConstantClass', 'constant', 'shclasses']
+__all__ += ['SHCoeffs', 'SHGrid', 'SHWindow']
 
 for _name, _func in _SHTOOLS.__dict__.items():
     if callable(_func):

--- a/pyshtools/__init__.py
+++ b/pyshtools/__init__.py
@@ -2,12 +2,13 @@
 pyshtools
 =========
 
-pyshtools is an archive of scientific routines that can be used to perform
-spherical harmonic transforms and reconstructions, rotations of data expressed
-in spherical harmonics, and multitaper spectral analyses on the sphere.
+pyshtools is an archive of scientific routines that can be used to
+perform spherical harmonic transforms and reconstructions, rotations
+of data expressed in spherical harmonics, and multitaper spectral
+analyses on the sphere.
 
-This module makes use of Python-wrapped Fortran 95 routines. For further
-information, consult the web documentation at
+This module makes use of Python-wrapped Fortran 95 routines. For
+further information, consult the web documentation at
 
    http://shtools.ipgp.fr/
 
@@ -19,32 +20,47 @@ and the GitHub project page at
 from __future__ import absolute_import as _absolute_import
 from __future__ import division as _division
 from __future__ import print_function as _print_function
-import numpy as _np
-
-# ---- Import class interface into pyshtools namespace ----
-from .classes import SHCoeffs, SHGrid, SHWindow
-
-from . import _SHTOOLS
 
 __version__ = '3.3-beta'
+__author__ = 'SHTOOLS developers'
+
+import os as _os
+import numpy as _np
+
+# ---- Import wrapped SHTOOLS functions into _SHTOOLS
+from . import _SHTOOLS
+
+# ---- Import SHTOOLS constants into _constant
+from . import _constant
+
+# ---- Import wrapped SHTOOLS functions into pyshtools namespace
+from ._SHTOOLS import *
+
+# ---- Import classes into pyshtools namespace
+from .classes import SHCoeffs, SHGrid, SHWindow
 
 
 # ---------------------------------------------------------------------
 # --- Define two Python functions that replace their Fortran
-# --- equivalents that use different indexing conventions.
+# --- equivalents that use different indexing conventions, then
+# --- bind these function to _SHTOOLS.
 # ---------------------------------------------------------------------
 def PlmIndex(l, m):
     return (l * (l + 1)) // 2 + m
 
 
 def YilmIndexVector(i, l, m):
-    return l**2 + (i-1)*l + m
+    return l**2 + (i - 1) * l + m
+
+_SHTOOLS.PlmIndex = PlmIndex
+_SHTOOLS.YilmIndexVector = YilmIndexVector
 
 
-# ----------------------------------------------------------------------
-# --- Define a subclass of ndarray that adds an info() method for
-# --- displaying documentation about a pyshtools constant.
-# ----------------------------------------------------------------------
+# ---------------------------------------------------------------------
+# --- Define a subclass of numpy.ndarray that adds an info() method for
+# --- displaying documentation about a pyshtools constant. Then define
+# --- ConstantClass that holds these objects.
+# ---------------------------------------------------------------------
 class _ndarrayinfo(_np.ndarray):
     """
     To view information about a pyshtools constant, use
@@ -80,74 +96,53 @@ class _ConstantClass():
     """
     pass
 
-
-def _load_documentation():
-    """
-    Fill the pyshtools module __doc__ strings and pyshtoools constant
-    _infostrings with documentation from external files. The doc files
-    are generated during intitial compilation of pyshtools from md
-    formatted text files.
-    """
-    import os
-
-    # import _SHTOOLS functions to add documentation
-    # the _SHTOOLS functions are later imported into
-    # the main namespace
-
-    # bind Python functions to _SHTOOLS
-    _SHTOOLS.PlmIndex = PlmIndex
-    _SHTOOLS.YilmIndexVector = YilmIndexVector
-
-    print('Loading SHTOOLS -- version', __version__)
-    pydocfolder = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                  'doc'))
-    for name, func in _SHTOOLS.__dict__.items():
-        if callable(func):
-            try:
-                path = os.path.join(pydocfolder, name.lower() + '.doc')
-
-                with open(path) as pydocfile:
-                    pydoc = pydocfile.read()
-
-                func.__doc__ = pydoc
-            except IOError as msg:
-                print(msg)
-
-    for name in _constant.planetsconstants.__dict__.keys():
-        try:
-            path = os.path.join(pydocfolder, 'constant_' + name.lower() +
-                                '.doc')
-
-            with open(path) as pydocfile:
-                pydoc = pydocfile.read()
-
-            setattr(getattr(constant, name), '_infostring', pydoc)
-
-        except IOError as msg:
-            print(msg)
-
-
-# --- Import all functions into pyshtools namespace ----
-from ._SHTOOLS import *  # NOQA
-
-# --- Import planetary constants into pyshtools namespace ----
-from . import _constant  # NOQA
-
 constant = _ConstantClass()
 
 for _name, _value in _constant.planetsconstants.__dict__.items():
-    constant._name = _value.view(_ndarrayinfo)
+    setattr(constant, _name, _value.view(_ndarrayinfo))
 
-# ---- Load documentation that was generated at compile time ----
-_load_documentation()
 
-# ---- Define __all__ for use with 'from pyshtools import *' ----
+# ---------------------------------------------------------------------
+# ---- Fill the pyshtools module doc strings and pyshtools constant
+# ---- infostrings with documentation from external files. The doc files
+# ---- are generated during intitial compilation of pyshtools from md
+# ---- formatted text files.
+# ---------------------------------------------------------------------
+print('Loading SHTOOLS -- version', __version__)
+_pydocfolder = _os.path.abspath(_os.path.join(_os.path.dirname(__file__),
+                                             'doc'))
+
+for _name, _func in _SHTOOLS.__dict__.items():
+    if callable(_func):
+        try:
+            _path = _os.path.join(_pydocfolder, _name.lower() + '.doc')
+
+            with open(_path) as _pydocfile:
+                _pydoc = _pydocfile.read()
+
+            _func.__doc__ = _pydoc
+        except IOError as msg:
+            print(msg)
+
+for _name in _constant.planetsconstants.__dict__.keys():
+    try:
+        _path = _os.path.join(_pydocfolder, 'constant_' + _name.lower() +
+                             '.doc')
+
+        with open(_path) as _pydocfile:
+            _pydoc = _pydocfile.read()
+
+        setattr(getattr(constant, _name), '_infostring', _pydoc)
+
+    except IOError as msg:
+        print(msg)
+
+
+# ---- Define __all__ for use with: from pyshtools import * ----
 __all__ = ['_ndarrayinfo', '_ConstantClass', 'constant', 'classes']
 __all__ += ['SHCoeffs', 'SHRealCoefficients', 'SHComplexCoefficients',
             'SHGrid', 'DHGrid', 'GLQGrid', 'SHWindow', 'SHSymmetricWindow',
             'SHAsymmetricWindow']
-
-
 
 for _name, _func in _SHTOOLS.__dict__.items():
     if callable(_func):

--- a/pyshtools/__init__.py
+++ b/pyshtools/__init__.py
@@ -90,6 +90,14 @@ def _load_documentation():
     """
     import os
 
+    # import _SHTOOLS functions to add documentation
+    # the _SHTOOLS functions are later imported into
+    # the main namespace
+
+    # bind Python functions to _SHTOOLS
+    _SHTOOLS.PlmIndex = PlmIndex
+    _SHTOOLS.YilmIndexVector = YilmIndexVector
+
     print('Loading SHTOOLS -- version', __version__)
     pydocfolder = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                   'doc'))
@@ -119,12 +127,11 @@ def _load_documentation():
             print(msg)
 
 
-#---- Bind Python functions to _SHTOOLS ----
-_SHTOOLS.PlmIndex = PlmIndex
-_SHTOOLS.YilmIndexVector = YilmIndexVector
+# --- Import all functions into pyshtools namespace ----
+from ._SHTOOLS import *  # NOQA
 
-#---- Import planetary constants into pyshtools namespace ----
-from . import _constant
+# --- Import planetary constants into pyshtools namespace ----
+from . import _constant  # NOQA
 
 constant = _ConstantClass()
 
@@ -136,7 +143,10 @@ _load_documentation()
 
 # ---- Define __all__ for use with 'from pyshtools import *' ----
 __all__ = ['_ndarrayinfo', '_ConstantClass', 'constant', 'classes']
-__all__ += ['SHCoeffs', 'SHGrid', 'SHWindow']
+__all__ += ['SHCoeffs', 'SHRealCoefficients', 'SHComplexCoefficients',
+            'SHGrid', 'DHGrid', 'GLQGrid', 'SHWindow', 'SHSymmetricWindow',
+            'SHAsymmetricWindow']
+
 
 
 for _name, _func in _SHTOOLS.__dict__.items():

--- a/pyshtools/classes.py
+++ b/pyshtools/classes.py
@@ -28,9 +28,9 @@ from __future__ import absolute_import as _absolute_import
 from __future__ import division as _division
 from __future__ import print_function as _print_function
 
-import numpy as np
-import matplotlib as mpl
-import matplotlib.pyplot as plt
+import numpy as _np
+import matplotlib as _mpl
+import matplotlib.pyplot as _plt
 
 from . import _SHTOOLS as _shtools
 
@@ -589,7 +589,7 @@ class SHCoeffs(object):
         power = self.get_powerperdegree()
         ls = self.get_degrees()
 
-        fig, ax = plt.subplots(1, 1)
+        fig, ax = _plt.subplots(1, 1)
         ax.set_xlabel('degree l')
         ax.set_ylabel('power per degree')
         if loglog:
@@ -598,7 +598,7 @@ class SHCoeffs(object):
             ax.grid(True, which='both')
             ax.plot(ls[1:], power[1:], label='power per degree l')
         if show:
-            plt.show()
+            _plt.show()
         if fname is not None:
             fig.savefig(fname)
 
@@ -622,7 +622,7 @@ class SHCoeffs(object):
         power = self.get_powerperband(bandwidth)
         ls = self.get_degrees()
 
-        fig, ax = plt.subplots(1, 1)
+        fig, ax = _plt.subplots(1, 1)
         ax.set_xlabel('degree l')
         ax.set_ylabel('bandpower')
         ax.set_xscale('log', basex=bandwidth)
@@ -631,7 +631,7 @@ class SHCoeffs(object):
         ax.plot(ls[1:], power[1:], label='power per degree l')
         fig.tight_layout(pad=0.1)
         if show:
-            plt.show()
+            _plt.show()
         if fname is not None:
             fig.savefig(fname)
 
@@ -1169,7 +1169,7 @@ class SHGrid(object):
         """
         fig, ax = self._plot_rawdata()
         if show:
-            plt.show()
+            _plt.show()
         if fname is not None:
             fig.savefig(fname)
 
@@ -1291,7 +1291,7 @@ class DHRealGrid(SHGrid):
 
     def _plot_rawdata(self):
         """Plot the raw data using a simply cylindrical projection."""
-        fig, ax = plt.subplots(1, 1)
+        fig, ax = _plt.subplots(1, 1)
         ax.imshow(self.data, origin='top', extent=(0., 360., -90., 90.))
         ax.set_title('Driscoll and Healy Grid')
         ax.set_xlabel('longitude')
@@ -1377,7 +1377,7 @@ class DHComplexGrid(SHGrid):
 
     def _plot_rawdata(self):
         """Plot the raw data using a simply cylindrical projection."""
-        fig, ax = plt.subplots(2, 1)
+        fig, ax = _plt.subplots(2, 1)
         ax.flat[0].imshow(self.data.real, origin='top',
                           extent=(0., 360., -90., 90.))
         ax.flat[0].set_title('Driscoll and Healy Grid (real component)')
@@ -1468,7 +1468,7 @@ class GLQRealGrid(SHGrid):
     def _plot_rawdata(self):
         """Plot the raw data using a simply cylindrical projection."""
 
-        fig, ax = plt.subplots(1, 1)
+        fig, ax = _plt.subplots(1, 1)
         ax.imshow(self.data, origin='top')
         ax.set_title('Gauss-Legendre Quadrature Grid')
         ax.set_xlabel('longitude index')
@@ -1553,7 +1553,7 @@ class GLQComplexGrid(SHGrid):
     def _plot_rawdata(self):
         """Plot the raw data using a simply cylindrical projection."""
 
-        fig, ax = plt.subplots(2, 1)
+        fig, ax = _plt.subplots(2, 1)
         ax.flat[0].imshow(self.data.real, origin='top')
         ax.flat[0].set_title('Gauss-Legendre Quadrature Grid (real component)')
         ax.flat[0].set_xlabel('longitude index')
@@ -1607,7 +1607,7 @@ class SHWindow(object):
         ncolumns = min(maxcolumns, nwins)
         nrows = np.ceil(nwins / ncolumns).astype(int)
         figsize = ncolumns * 1.2, nrows * 1.2 + 0.5
-        fig, axes = plt.subplots(nrows, ncolumns, figsize=figsize)
+        fig, axes = _plt.subplots(nrows, ncolumns, figsize=figsize)
         for ax in axes[:-1, :].flatten():
             for xlabel_i in ax.get_xticklabels():
                 xlabel_i.set_visible(False)
@@ -1626,7 +1626,7 @@ class SHWindow(object):
         fig.tight_layout(pad=0.5)
 
         if show:
-            plt.show()
+            _plt.show()
         if fname is not None:
             fig.savefig(fname)
 
@@ -1653,9 +1653,9 @@ class SHWindow(object):
 
     def plot_couplingmatrix(self, lmax, nwins, show=True, fname=None):
         """plots the window's coupling strength"""
-        figsize = mpl.rcParams['figure.figsize']
+        figsize = _mpl.rcParams['figure.figsize']
         figsize[0] = figsize[1]
-        fig = plt.figure(figsize=figsize)
+        fig = _plt.figure(figsize=figsize)
         ax = fig.add_subplot(111)
         coupling_matrix = self.get_couplingmatrix(lmax, nwins)
         ax.imshow(coupling_matrix)
@@ -1664,7 +1664,7 @@ class SHWindow(object):
         fig.tight_layout(pad=0.1)
 
         if show:
-            plt.show()
+            _plt.show()
         if fname is not None:
             fig.savefig(fname)
 

--- a/pyshtools/classes.py
+++ b/pyshtools/classes.py
@@ -717,7 +717,7 @@ class DHRealGrid(SHGrid):
                 "Normalization must be '4pi', 'ortho', or 'schmidt'")
 
         cilm = _shtools.SHExpandDH(self.data, norm=norm, csphase=csphase)
-        coeffs = SHCoeffs.from_array(cilm, kind='real',
+        coeffs = SHCoeffs.from_array(cilm,
                                      normalization=normalization.lower(),
                                      csphase=csphase)
         return coeffs
@@ -798,7 +798,7 @@ class DHComplexGrid(SHGrid):
                 "Normalization must be '4pi', 'ortho', or 'schmidt'")
 
         cilm = _shtools.SHExpandDHC(self.data, norm=norm, csphase=csphase)
-        coeffs = SHCoeffs.from_array(cilm, kind='complex',
+        coeffs = SHCoeffs.from_array(cilm,
                                      normalization=normalization.lower(),
                                      csphase=csphase)
         return coeffs
@@ -845,11 +845,11 @@ class GLQRealGrid(SHGrid):
                                      2*self.lmax+1)
                              )
 
-        if zeros is None and weights is None:
-            self.zeros, weights = _shtools.SHGLQ(self.lmax)
+        if zeros is None or weights is None:
+            self.zeros, self.weights = _shtools.SHGLQ(self.lmax)
         else:
             self.zeros = zeros
-            self.weights.weights
+            self.weights = weights
 
         self.data = array
         self.grid = 'GLQ'
@@ -868,16 +868,16 @@ class GLQRealGrid(SHGrid):
         Return a vector containing the longitudes (in degrees) of each column
         of the gridded data.
         """
-        lons = np.linspace(0., 360.-360./self.nlon, num=self.nlon)
+        lons = np.linspace(0.0, 360.0 - 360.0 / self.nlon, num=self.nlon)
         return lons
 
     def _expand(self, normalization, csphase):
         """Expand the grid into real spherical harmonics."""
-        if normalization == '4pi':
+        if normalization.lower() == '4pi':
             norm = 1
-        elif normalization == 'schmidt' or normalization == 'Schmidt':
+        elif normalization.lower() == 'schmidt':
             norm = 2
-        elif normalization == 'ortho':
+        elif normalization.lower() == 'ortho':
             norm = 4
         else:
             raise NotImplementedError(
@@ -885,8 +885,8 @@ class GLQRealGrid(SHGrid):
 
         cilm = _shtools.SHExpandGLQ(self.data, self.weights, self.zeros,
                                     norm=norm, csphase=csphase)
-        coeffs = SHCoeffs.from_array(cilm, kind='real',
-                                     normalization=normalization,
+        coeffs = SHCoeffs.from_array(cilm,
+                                     normalization=normalization.lower(),
                                      csphase=csphase)
         return coeffs
 
@@ -927,11 +927,11 @@ class GLQComplexGrid(SHGrid):
                                      2*self.lmax+1)
                              )
 
-        if zeros is None and weights is None:
-            self.zeros, weights = _shtools.SHGLQ(self.lmax)
+        if zeros is None or weights is None:
+            self.zeros, self.weights = _shtools.SHGLQ(self.lmax)
         else:
             self.zeros = zeros
-            self.weights.weights
+            self.weights = weights
 
         self.data = array
         self.grid = 'GLQ'
@@ -950,16 +950,16 @@ class GLQComplexGrid(SHGrid):
         Return a vector containing the longitudes (in degrees) of each column
         of the gridded data.
         """
-        lons = np.linspace(0., 360.-360./self.nlon, num=self.nlon)
+        lons = np.linspace(0., 360. - 360. / self.nlon, num=self.nlon)
         return lons
 
     def _expand(self, normalization, csphase):
         """Expand the grid into real spherical harmonics."""
-        if normalization == '4pi':
+        if normalization.lower() == '4pi':
             norm = 1
-        elif normalization == 'schmidt' or normalization == 'Schmidt':
+        elif normalization.lower() == 'schmidt':
             norm = 2
-        elif normalization == 'ortho':
+        elif normalization.lower() == 'ortho':
             norm = 4
         else:
             raise NotImplementedError(
@@ -967,8 +967,8 @@ class GLQComplexGrid(SHGrid):
 
         cilm = _shtools.SHExpandGLQC(self.data, self.weights, self.zeros,
                                      norm=norm, csphase=csphase)
-        coeffs = SHCoeffs.from_array(cilm, kind='real',
-                                     normalization=normalization,
+        coeffs = SHCoeffs.from_array(cilm,
+                                     normalization=normalization.lower(),
                                      csphase=csphase)
         return coeffs
 
@@ -976,11 +976,11 @@ class GLQComplexGrid(SHGrid):
         """Plot the raw data using a simply cylindrical projection."""
 
         fig, ax = plt.subplots(2, 1)
-        ax.flat[0].imshow(self.data, origin='top')
+        ax.flat[0].imshow(self.data.real, origin='top')
         ax.flat[0].set_title('Gauss-Legendre Quadrature Grid (real component')
         ax.flat[0].set_xlabel('longitude index')
         ax.flat[0].set_ylabel('latitude index')
-        ax.flat[1].imshow(self.data, origin='top')
+        ax.flat[1].imshow(self.data.imag, origin='top')
         ax.flat[1].set_title('Gauss-Legendre Quadrature Grid ' +
                              '(imaginary component')
         ax.flat[1].set_xlabel('longitude index')

--- a/pyshtools/classes.py
+++ b/pyshtools/classes.py
@@ -1585,8 +1585,8 @@ class SHWindow(object):
         if degrees:
             theta = np.radians(theta)
 
-        tapers, eigenvalues, taper_order = SHReturnTapers(theta, lmax)
-        return _shtools.SHSymmetricWindow(tapers, eigenvalues, taper_order,
+        tapers, eigenvalues, taper_order = _shtools.SHReturnTapers(theta, lmax)
+        return SHSymmetricWindow(tapers, eigenvalues, taper_order,
                                           clat=clat, clon=clon)
 
     @classmethod
@@ -1596,7 +1596,7 @@ class SHWindow(object):
         """
         tapers, eigenvalues = _shtools.SHReturnTapersMap(
             dh_mask, lmax, sampling=sampling, Ntapers=nwins)
-        return _shtools.SHAsymmetricWindow(tapers, eigenvalues)
+        return SHAsymmetricWindow(tapers, eigenvalues)
 
     def plot(self, nwins, show=True, fname=None):
         """
@@ -1620,7 +1620,7 @@ class SHWindow(object):
             evalue = self.eigenvalues[itaper]
             coeffs = self._coeffs(itaper)
             ax = axes.flatten()[itaper]
-            grid = MakeGridDH(coeffs)
+            grid = _shtools.MakeGridDH(coeffs)
             ax.imshow(grid)
             ax.set_title('concentration: {:2.2f}'.format(evalue))
         fig.tight_layout(pad=0.5)

--- a/pyshtools/classes.py
+++ b/pyshtools/classes.py
@@ -5,7 +5,8 @@ spherical harmonic coefficients. Subclasses are used to handle different
 internal data types and superclasses are used to implement interface
 functions and the documentation.
 
-The following classes and subclasses are defined:
+For more information, see the documentation for the following classes
+and subclasses:
 
     SHCoeffs
         SHRealCoefficients
@@ -39,12 +40,57 @@ from . import _SHTOOLS as _shtools
 
 class SHCoeffs(object):
     """
-    Spherical Harmonics Coefficient class. Coefficients can be initialized
-    using one of the three constructor methods:
+    Spherical Harmonics Coefficient class.
+
+    The coefficients of this class can be initialized using one of the
+    three constructor methods:
 
     >> x = SHCoeffs.from_array(numpy.zeros((2, lmax+1, lmax+1)))
-    >> x = SHCoeffs.from_random(numpy.exp(-ls**2))
+    >> x = SHCoeffs.from_random(powerspectrum[0:lmax+1])
     >> x = SHCoeffs.from_file('fname.dat')
+
+    The normalization convention of the input coefficents is specified
+    by the normalization and csphase parameters, which can take the following
+    values:
+
+    normalization : '4pi' (default), geodesy 4-pi normalized
+                  : 'ortho', orthonormalized
+                  : 'schmidt', Schmidt semi-normalized
+
+    csphase       : 1 (default), exlcude the Condon-Shortley phase factor
+                  : -1, include the Condon-Shortley phase factor
+
+    See the documentation for each constructor method for further options.
+
+    The class instance defines the following class attributes:
+
+    lmax          : The maximum spherical harmonic degree of the
+                    coefficients.
+    coeffs        : The raw coefficients with the specified normalization and
+                    phase conventions.
+    mask          : A boolean mask that is True for the allowable values of
+                    degree l and order m.
+    kind          : Either 'complex' or 'real' for the coefficient data type.
+    normalization : The normalization of the coefficients, which is '4pi',
+                    'ortho', or 'schmidt'.
+    csphse        : Defines whether the Condon-Shortley phase is used (1)
+                    or not (-1).
+
+    Each class instance also provides the following methods:
+
+    get_degrees()         : Return an array listing the spherical harmonic
+                            degrees from 0 to lmax.
+    get_powerperdegree()  : Return the power per degree l spectrum.
+    get_powerperband()    : Return the power per log_{bandwidth} l spectrum.
+    get_coeffs()          : Return spherical harmonics coefficients with
+                            a different normalization convention.
+    rotate()              : Rotate the coordinate system used to express the
+                            spherical harmonics coefficients.
+    expand()              : Evaluate the coefficients on a spherical grid.
+    plot_powerperdegree() : Plot the power per degree spectrum.
+    plot_powerperband()   : Plot the power per log_{bandwidth} l spectrum.
+    make_complex()        : Convert real coefficients to complex form.
+    make_real()           : Convert complex coefficients to real form.
     """
 
     def __init__(self):
@@ -54,8 +100,23 @@ class SHCoeffs(object):
     @classmethod
     def from_array(self, coeffs, normalization='4pi', csphase=1):
         """
-        Initialize the spherical harmonic coefficients of the object
-        using an input ndarray dimensioned as (2, lmax+1, lmax+1).
+        Initialize the spherical harmonic coefficients of the object from
+        an input array.
+
+        Usage
+        -----
+
+        x = SHCoeffs.from_array(array, [normalization, csphase])
+
+        Parameters
+        ----------
+
+        array         : numpy array of size (2, lmax+1, lmax+1)
+        normalization : '4pi' (default), geodesy 4-pi normlized
+                      : 'ortho', orthonormalized
+                      : 'schmidt', Schmidt semi-normalized
+        csphase       : 1 (default), exlcude the Condon-Shortley phase factor
+                      : -1, include the Condon-Shortley phase factor
         """
         if np.iscomplexobj(coeffs):
             kind = 'complex'
@@ -85,6 +146,22 @@ class SHCoeffs(object):
         """
         Initialize the spherical harmonic coefficients using Gaussian
         random variables and a given input power spectrum.
+
+        Usage
+        -----
+
+        x = SHCoeffs.from_random(power, [kind, normalization, csphase])
+
+        Parameters
+        ----------
+
+        power         : numpy array of the power spectrum of size (lmax+1)
+        kind          : 'real' (default) or 'complex' output coefficients
+        normalization : '4pi' (default), geodesy 4-pi normalized
+                      : 'ortho', orthonormalized
+                      : 'schmidt', Schmidt semi-normalized
+        csphase       : 1 (default) exlcude the Condon-Shortley phase factor
+                      : -1, include the Condon-Shortley phase factor
         """
         if normalization.lower() not in set(['4pi', 'ortho', 'schmidt']):
             raise ValueError(
@@ -99,7 +176,7 @@ class SHCoeffs(object):
                 .format(csphase)
                 )
 
-        if kind not in set(['real', 'complex']):
+        if kind.lower() not in set(['real', 'complex']):
             raise ValueError(
                 "kind must be 'real' or 'complex'. " +
                 "Input value was '{:s}'.".format(str(kind)))
@@ -107,9 +184,9 @@ class SHCoeffs(object):
         nl = len(power)
         l = np.arange(nl)
 
-        if kind == 'real':
+        if kind.lower() == 'real':
             coeffs = np.random.normal(size=(2, nl, nl))
-        elif kind == 'complex':
+        elif kind.lower() == 'complex':
             coeffs = (np.random.normal(size=(2, nl, nl)) +
                       1j * np.random.normal(size=(2, nl, nl)))
 
@@ -130,10 +207,48 @@ class SHCoeffs(object):
 
     @classmethod
     def from_file(self, fname, lmax, format='shtools', kind='real',
-                  normalization='4pi', csphase=1):
+                  normalization='4pi', csphase=1, **kwargs):
         """
         Initialize the spherical harmonic coefficients by reading the
         coefficients from a specified file.
+
+        Usage
+        -----
+
+        x = SHCoeffs.from_file(filename, lmax, [format, kind, normalization,
+                                                csphase, skip])
+
+        Parameters
+        ----------
+
+        filename      : name of the file
+        lmax          : maximum spherical harmonic degree to read from the file
+        format        : 'shtools' (default)
+        kind          : Output 'real' (default) or 'complex' coefficients
+        normalization : '4pi' (default), geodesy 4-pi normalized
+                      : 'ortho', orthonormalized
+                      : 'schmidt', Schmidt semi-normalized)
+        csphase       : 1  (default), exlcude the Condon-Shortley phase factor
+                      : -1, include the Condon-Shortley phase factor
+        skip          : Number of lines to skip at the beginning of the file
+
+        Description
+        -----------
+
+        If format='shtools' spherical harmonic coefficients from an
+        ascii-formatted file. The maximum spherical harmonic degree that is
+        read is determined by the input value lmax. If the optional value skip
+        is specified, parsing of the file will commence after the first skip
+        lines.
+
+        The spherical harmonic coefficients in the file are assumed to be
+        ordered by increasing degree l and angular order m according to the
+        format
+
+        l, m, cilm[0, l, m], cilm[1, l, m]
+
+        For each value of increasing l, all the angular orders are listed
+        in inceasing order.
         """
         if normalization.lower() not in set(['4pi', 'ortho', 'schmidt']):
             raise ValueError(
@@ -149,7 +264,7 @@ class SHCoeffs(object):
 
         if format == 'shtools':
             if kind == 'real':
-                coeffs, lmax = _shtools.SHRead(fname, lmax)
+                coeffs, lmax = _shtools.SHRead(fname, lmax, **kwargs)
             else:
                 raise NotImplementedError(
                     "kind='{:s}' not yet implemented".format(str(kind)))
@@ -167,23 +282,75 @@ class SHCoeffs(object):
         """
         Return an array listing the spherical harmonic degrees
         from 0 to lmax.
+
+        Usage
+        -----
+
+        degrees = x.get_degrees()
+
+        Returns
+        -------
+
+        degrees : ndarray of size (lmax+1)
         """
         return np.arange(self.lmax + 1)
 
     def get_powerperdegree(self):
-        """Return the power per degree l spectrum."""
+        """
+        Return the power per degree l spectrum.
+
+        Usage
+        -----
+
+        power = x.get_powerperdegree()
+
+        Returns
+        -------
+
+        power : ndarray of size (lmax+1)
+        """
         return self._powerperdegree()
 
     def get_powerperband(self, bandwidth):
-        """Return the power per log_{bandwidth} l spectrum"""
+        """
+        Return the power per log_{bandwidth} l spectrum.
+
+        Usage
+        -----
+
+        power = x.get_powerperband()
+
+        Returns
+        -------
+
+        power : ndarray of size (lmax+1)
+        """
         ls = self.get_degrees()
         return self._powerperdegree() * ls * np.log(bandwidth)
 
     # ---- Return coefficients with a different normalization convention ----
     def get_coeffs(self, normalization='4pi', csphase=1):
         """
-        Return spherical harmonics coefficients as an ndarray with
-        a different normalization convention.
+        Return spherical harmonics coefficients with a different
+        normalization convention.
+
+        Usage
+        -----
+
+        power = x.get_coeffs([normalization, csphase])
+
+        Returns
+        -------
+
+        power : ndarray of size (lmax+1)
+
+        Parameters
+        ----------
+
+        normalization : '4pi' (default), geodesy 4-pi normalized
+                      : 'ortho', orthonormalized
+                      : 'schmidt', Schmidt semi-normalized)
+        csphase       : 1  (default), exlcude the Condon-Shortley phase factor
         """
         if normalization.lower() not in set(['4pi', 'ortho', 'schmidt']):
             raise ValueError(
@@ -207,29 +374,56 @@ class SHCoeffs(object):
         Rotate the coordinate system used to express the spherical
         harmonics coefficients by the Euler angles alpha, beta, gamma,
         and output as a new class instance.
+
+        Usage
+        -----
+
+        SHCoeffsInstance = x.rotate(alpha, beta, gamma, [degrees, dj_matrix])
+
+        Parameters
+        ----------
+
+        alpha, beta, gamma : Euler rotation angles in degrees.
+        degrees            : True (default) to use degrees, False for radians
+        dj_matrix          : The djpi2 rotation matrix (default=None)
         """
         if degrees:
             angles = np.radians([alpha, beta, gamma])
         else:
             angles = np.array([alpha, beta, gamma])
 
-        self._rotate(angles, dj_matrix)
+        rot = self._rotate(angles, dj_matrix)
+        return rot
 
     # ---- Expand the coefficients onto a grid ----
-    def expand(self, grid='DH'):
+    def expand(self, grid='DH', **kwargs):
         """
         Evaluate the coefficients on a spherical grid.
-        Available grid types are:
-           grid = 'DH' or 'DH1': equisampled lat/lon grid with nlat=nlon
-           grid = 'DH2': equidistant lat/lon grid with nlon=2*nlat
-           grid = 'GLQ': Gauss-Legendre quadrature grid
+
+        Usage
+        -----
+
+        SHGridInstance = x.expand([grid, lmax, lmax_calc, zeros])
+
+        Parameters
+        ----------
+
+        grid      : 'DH' or 'DH1', equisampled lat/lon grid with nlat=nlon
+                  : 'DH2', equidistant lat/lon grid with nlon=2*nlat
+                  : 'GLQ', Gauss-Legendre quadrature grid
+        lmax      : maximum spherical harmonic degree, which determines the
+                    grid spacing of the output grid. Default is x.lmax.
+        lmax_calc : maximum spherical harmonic degree to use when evaluating
+                    the function. Default is x.lmax.
+        zeros      : The cos(colatitude) nodes used in Gauss-Legendre
+                    Quadrature grids. Default is None
         """
-        if grid == 'DH' or grid == 'DH1':
-            gridout = self._expandDH(sampling=1)
-        elif grid == 'DH2':
-            gridout = self._expandDH(sampling=2)
-        elif grid == 'GLQ':
-            gridout = self._expandGLQ(zero=None)
+        if grid.upper() == 'DH' or grid.upper() == 'DH1':
+            gridout = self._expandDH(sampling=1, **kwargs)
+        elif grid.upper() == 'DH2':
+            gridout = self._expandDH(sampling=2, **kwargs)
+        elif grid.upper() == 'GLQ':
+            gridout = self._expandGLQ(zeros=None, **kwargs)
         else:
             raise ValueError(
                 "grid must be 'DH', 'DH1', 'DH2', or 'GLQ'. " +
@@ -241,6 +435,18 @@ class SHCoeffs(object):
     def plot_powerperdegree(self, loglog=True, show=True, fname=None):
         """
         Plot the power per degree spectrum.
+
+        Usage
+        -----
+
+        x.plot_powerperdegree([loglog, show, fname])
+
+        Parameters
+        ----------
+
+        loglog : if True (default), use log-log axis
+        show   : if True (default), plot to the screen.
+        fname  : if present, image will be saved to the file
         """
         power = self.get_powerperdegree()
         ls = self.get_degrees()
@@ -261,6 +467,18 @@ class SHCoeffs(object):
     def plot_powerperband(self, bandwidth=2, show=True, fname=None):
         """
         Plots the power per log_{bandwidth}(degree) spectrum.
+
+        Usage
+        -----
+
+        x.plot_powerperdegree([loglog, show, fname])
+
+        Parameters
+        ----------
+
+        loglog : if True (default), use log-log axis
+        show   : if True (default), plot to the screen.
+        fname  : if present, image will be saved to the file
         """
         power = self.get_powerperband(bandwidth)
         ls = self.get_degrees()
@@ -307,17 +525,29 @@ class SHRealCoefficients(SHCoeffs):
         self.normalization = normalization.lower()
         self.csphase = csphase
 
-    def make_complex(self, convention=1, switchcs=0):
+    def make_complex(self):
         """
         Convert the real coefficient class to the complex harmonic
-        coefficient class.
+        coefficient class with the same normalization and csphase
+        conventions.
         """
-        raise NotImplementedError('Not implemented yet!')
+        rcomplex_coeffs = _shtools.SHrtoc(self.coeffs,
+                                          convention=1, switchcs=0)
 
-        complex_coeffs = _shtools.SHrtoc(self.coeffs, convention=convention,
-                                         switchcs=switchcs)
-        # NOT DONE. THESE COEFFICIENTS ARE STILL REAL FLOATS!
-#        return SHCoeffs.from_array(complex_coeffs, kind='complex')
+        # These coefficients are using real floats, and need to be
+        # converted to complex form.
+        complex_coeffs = np.zeros((2, self.lmax+1, self.lmax+1),
+                                  dtype='complex')
+        complex_coeffs[0, :, :] = (rcomplex_coeffs[0, :, :] + 1j *
+                                   rcomplex_coeffs[1, :, :])
+        complex_coeffs[1, :, :] = complex_coeffs[0, :, :].conjugate()
+        for m in self.get_degrees():
+            if m % 2 == 1:
+                complex_coeffs[1, :, m] = - complex_coeffs[1, :, m]
+
+        return SHCoeffs.from_array(complex_coeffs,
+                                   normalization=self.normalization,
+                                   csphase=self.csphase)
 
     def _powerperdegree(self):
         """Return the power per degree l spectrum."""
@@ -386,7 +616,7 @@ class SHRealCoefficients(SHCoeffs):
 
         # Convert 4pi normalized coefficients to the same normalization
         # as the unrotated coefficients.
-        if self.normalization != '4pi' or csphase != 1:
+        if self.normalization != '4pi' or self.csphase != 1:
             temp = SHCoeffs.from_array(coeffs, kind='real')
             tempcoeffs = temp.get_coeffs(
                 normalization=self.normalization, csphase=self.csphase)
@@ -396,7 +626,7 @@ class SHRealCoefficients(SHCoeffs):
         else:
             return SHCoeffs.from_array(coeffs)
 
-    def _expandDH(self, sampling):
+    def _expandDH(self, sampling, **kwargs):
         """
         Evaluate the coefficients on a Driscoll and Healy (1994)
         sampled grid.
@@ -412,7 +642,7 @@ class SHRealCoefficients(SHCoeffs):
                 "Normalization must be '4pi', 'ortho', or 'schmidt'")
 
         data = _shtools.MakeGridDH(self.coeffs, sampling=sampling, norm=norm,
-                                   csphase=self.csphase)
+                                   csphase=self.csphase, **kwargs)
         gridout = SHGrid.from_array(data, grid='DH')
         return gridout
 
@@ -432,7 +662,7 @@ class SHRealCoefficients(SHCoeffs):
             zeros, weights = _shtools.SHGLQ(self.lmax)
 
         data = _shtools.MakeGridGLQ(self.coeffs, zeros, norm=norm,
-                                    csphase=self.csphase)
+                                    csphase=self.csphase, **kwargs)
         gridout = SHGrid.from_array(data, grid='GLQ')
         return gridout
 
@@ -465,18 +695,43 @@ class SHComplexCoefficients(SHCoeffs):
         self.normalization = normalization.lower()
         self.csphase = csphase
 
-    def make_real(self, convention=1, switchcs=0):
+    def make_real(self):
         """
         Convert the complex coefficient class to the real harmonic
         coefficient class.
         """
-        raise NotImplementedError('Not implemented yet!')
+        # First test if the coefficients correspond to a real grid.
+        # This is not very elegant. Also, the equality condition for
+        # is probably not robust to round off errors.
+        for l in self.get_degrees():
+            if self.coeffs[0, l, 0] != self.coeffs[0, l, 0].conjugate():
+                raise Error('Complex coefficients do not correspond to a ' +
+                            'real field. l={:d}, m=0: {:c}'
+                            .format(l, self.coeffs[0, l, 0]))
+            for m in np.arange(1, l+1):
+                if m % 2 == 1:
+                    if (self.coeffs[0, l, m] != -
+                            self.coeffs[1, l, m].conjugate()):
+                        raise Error('Complex coefficients do not correspond ' +
+                                    'to a real field. ' +
+                                    'l={:d}, m={:d}: {:c}, {:c}'
+                                    .format(l, m, self.coeffs[0, l, 0],
+                                            self.coeffs[1, l, 0]))
+                else:
+                    if (self.coeffs[0, l, m] !=
+                            self.coeffs[1, l, m].conjugate()):
+                        raise Error('Complex coefficients do not correspond ' +
+                                    'to a real field. ' +
+                                    'l={:d}, m={:d}: {:c}, {:c}'
+                                    .format(l, m, self.coeffs[0, l, 0],
+                                            self.coeffs[1, l, 0]))
 
-        # NOT CORRECT. ONLY WORKS IF THE GRID IS REAL!
-        # First need to check that the grid is in fact real.
-        complex_coeffs = _shtools.SHctor(self.coeffs, convention=convention,
-                                         switchcs=switchcs)
-        return SHCoeffs.from_array(complex_coeffs, kind='real')
+            coeffs_rc = np.zeros((2, self.lmax + 1, self.lmax + 1))
+            coeffs_rc[0, :, :] = self.coeffs[0, :, :].real
+            coeffs_rc[1, :, :] = self.coeffs[0, :, :].imag
+            real_coeffs = _shtools.SHctor(coeffs_rc, convention=1,
+                                          switchcs=0)
+            return SHCoeffs.from_array(real_coeffs)
 
     def _powerperdegree(self):
         """Return the power per degree l spectrum."""
@@ -536,10 +791,47 @@ class SHComplexCoefficients(SHCoeffs):
         Rotate the coordinate system used to express the spherical
         harmonics coefficients by the Euler angles alpha, beta, gamma.
         """
-        raise NotImplementedError('Not implemented yet')
-        
+        # Note that the current method is EXTREMELY inefficient. The complex
+        # coefficients are expanded onto real and imaginary grids, each of
+        # the two components are rotated separately as real data, they rotated
+        # real data are re-expanded on new real and complex grids, they are
+        # combined to make a complex grid, and the resultant is expanded
+        # in complex spherical harmonics.
         if dj_matrix is None:
             dj_matrix = _shtools.djpi2(self.lmax + 1)
+
+        cgrid = self.expand(grid='DH')
+        rgrid, igrid = cgrid.data.real, cgrid.data.imag
+        rgridcoeffs = _shtools.SHExpandDH(rgrid, norm=1, sampling=1, csphase=1)
+        igridcoeffs = _shtools.SHExpandDH(igrid, norm=1, sampling=1, csphase=1)
+
+        rgridcoeffs_rot = _shtools.SHRotateRealCoef(
+            rgridcoeffs, angles, dj_matrix)
+        igridcoeffs_rot = _shtools.SHRotateRealCoef(
+            igridcoeffs, angles, dj_matrix)
+
+        rgrid_rot = _shtools.MakeGridDH(rgridcoeffs_rot, norm=1,
+                                        sampling=1, csphase=1)
+        igrid_rot = _shtools.MakeGridDH(igridcoeffs_rot, norm=1,
+                                        sampling=1, csphase=1)
+        grid_rot = rgrid_rot + 1j * igrid_rot
+
+        if self.normalization == '4pi':
+            norm = 1
+        elif self.normalization == 'schmidt':
+            norm = 2
+        elif self.normalization == 'ortho':
+            norm = 4
+        else:
+            raise ValueError(
+                "Normalization must be '4pi', 'ortho', or 'schmidt'")
+
+        coeffs_rot = _shtools.SHExpandDHC(grid_rot, norm=norm,
+                                          csphase=self.csphase)
+
+        return SHCoeffs.from_array(coeffs_rot,
+                                   normalization=self.normalization,
+                                   csphase=self.csphase)
 
     def _expandDH(self, sampling):
         """
@@ -557,7 +849,7 @@ class SHComplexCoefficients(SHCoeffs):
                 "Normalization must be '4pi', 'ortho', or 'schmidt'")
 
         data = _shtools.MakeGridDHC(self.coeffs, sampling=sampling,
-                                    norm=norm, csphase=self.csphase)
+                                    norm=norm, csphase=self.csphase, **kwargs)
         gridout = SHGrid.from_array(data, grid='DH')
         return gridout
 
@@ -577,7 +869,7 @@ class SHComplexCoefficients(SHCoeffs):
             zeros, weights = _shtools.SHGLQ(self.lmax)
 
         data = _shtools.MakeGridGLQ(self.coeffs, zeros, norm=norm,
-                                    csphase=self.csphase)
+                                    csphase=self.csphase, **kwargs)
         gridout = SHGrid.from_array(data, grid='GLQ')
         return gridout
 
@@ -591,8 +883,33 @@ class SHGrid(object):
     Grid Class for global gridded data on the sphere. Grids can be
     initialized from:
 
-    >> x = SHGrid.from_array(numpy.array([...]))
+    >> x = SHGrid.from_array(array)
     >> x = SHGrid.from_file('fname.dat')
+
+    The class instance defines the following class attributes:
+
+    data       : Gridded array of the data.
+    nlat, nlon : The number of latitude and longitude bands in the grid.
+    lmax       : The maximum spherical harmonic degree that can be resolved
+                 by the grid sampling.
+    sampling   : For Driscoll and Healy grids, the longitudinal sampling
+                 of the grid. Either nlong = nlat or nlong = 2 * nlat.
+    kind       : Either 'complex' or 'real' for the data type.
+    grid       : 'DH' or 'GLQ' for Driscoll and Healy grids or Gauss
+                 Legendre quadrature grids.
+    zeros      : The cos(colatitude) nodes used with Gauss-Legendre
+                 Quadrature grids. Default is None.
+    weights    : The latitudinal weights used with Gauss-Legendre
+                 Quadrature grids. Default is None.
+
+    Each class instance also provides the following methods:
+
+    get_lats()     : Return a vector containing the latitudes of each row
+                     of the gridded data.
+    get_lons()     : Return a vector containing the longitudes of each row
+                     of the gridded data.
+    plot_rawdata() : Plot the raw data using a simply cylindrical projection.
+    expand()       : Expand the grid into spherical harmonics.
     """
 
     def __init__():
@@ -601,6 +918,21 @@ class SHGrid(object):
     # ---- factory methods
     @classmethod
     def from_array(self, array, grid='DH'):
+        """
+        Initialize the grid of the object from an input array.
+
+        Usage
+        -----
+
+        x = SHGrid.from_array(array, [grid])
+
+        Parameters
+        ----------
+
+        array : numpy array of size (nlat, nlon)
+        grid : 'DH' (default) or 'GLQ' for Driscoll and Healy grids or Gauss
+                Legendre quadrature grids, respectively.
+        """
         if np.iscomplexobj(array):
             kind = 'complex'
         else:
@@ -612,20 +944,25 @@ class SHGrid(object):
 
     @classmethod
     def from_file(self, fname, kind='real', grid='DH'):
-
+        """Initialize the grid of the object from a file."""
         raise NotImplementedError('Not implemented yet')
-
-        # need to open and read grid, and specify binary, ascii
-        # nlat and nlong
-        for cls in self.__subclasses__():
-            if cls.istype(kind) and cls.isgrid(grid):
-                return cls(grid)
 
     # ---- Extract grid properties ----
     def get_lats():
         """
         Return a vector containing the latitudes (in degrees) of each row
         of the gridded data.
+
+        Usage
+        -----
+
+        lats = SHGrid.get_lats()
+
+        Returns
+        -------
+
+        lats : numpy array of size nlat containing the latitude (in degrees)
+               of each row of the gridded data.
         """
         return self._get_lats()
 
@@ -633,6 +970,17 @@ class SHGrid(object):
         """
         Return a vector containing the longitudes (in degrees) of each
         column of the gridded data.
+
+        Usage
+        -----
+
+        lons = SHGrid.get_lon()
+
+        Returns
+        -------
+
+        lons : numpy array of size nlon containing the longitude (in degrees)
+               of each column of the gridded data.
         """
         return self._get_lats()
 
@@ -640,6 +988,17 @@ class SHGrid(object):
     def plot_rawdata(self, show=True, fname=None):
         """
         Plot the raw data using a simply cylindrical projection.
+
+        Usage
+        -----
+
+        x.plot_rawdata([show, fname])
+
+        Parameters
+        ----------
+
+        show   : if True (default), plot to the screen
+        fname  : if present, image will be saved to the file
         """
         fig, ax = self._plot_rawdata()
         if show:
@@ -647,9 +1006,27 @@ class SHGrid(object):
         if fname is not None:
             fig.savefig(fname)
 
-    def expand(self):
-        """Expand the grid into spherical harmonics."""
-        return self._expand(normalization='4pi', csphase=1)
+    def expand(self, normalization='4pi', csphase=1, **kwargs):
+        """
+        Expand the grid into spherical harmonics.
+
+        Usage
+        -----
+
+        SHCoeffsInstance = x.expand([normalization, csphase, lmax_calc])
+
+        Parameters
+        ----------
+
+        normalization : '4pi' (default), geodesy 4-pi normalized
+                      : 'ortho', orthonormalized
+                      : 'schmidt', Schmidt semi-normalized)
+        csphase       : 1  (default), exlcude the Condon-Shortley phase factor
+        lmax_calc     : maximum spherical harmonic degree to return.
+                        Default is x.lmax.
+        """
+        return self._expand(normalization=normalization, csphase=csphase,
+                            **kwargs)
 
 
 # ---- Real Driscoll and Healy grid class ----
@@ -684,6 +1061,7 @@ class DHRealGrid(SHGrid):
                              .format(self.nlat, self.nlon)
                              )
 
+        self.lmax = self.nlat / 2 -1
         self.data = array
         self.grid = 'DH'
         self.kind = 'real'
@@ -704,7 +1082,7 @@ class DHRealGrid(SHGrid):
         lons = np.linspace(0.0, 360.0 - 360.0 / self.nlon, num=self.nlon)
         return lons
 
-    def _expand(self, normalization, csphase):
+    def _expand(self, normalization, csphase, **kwargs):
         """Expand the grid into real spherical harmonics."""
         if normalization.lower() == '4pi':
             norm = 1
@@ -716,7 +1094,8 @@ class DHRealGrid(SHGrid):
             raise NotImplementedError(
                 "Normalization must be '4pi', 'ortho', or 'schmidt'")
 
-        cilm = _shtools.SHExpandDH(self.data, norm=norm, csphase=csphase)
+        cilm = _shtools.SHExpandDH(self.data, norm=norm, csphase=csphase,
+                                   **kwargs)
         coeffs = SHCoeffs.from_array(cilm,
                                      normalization=normalization.lower(),
                                      csphase=csphase)
@@ -765,6 +1144,7 @@ class DHComplexGrid(SHGrid):
                              .format(self.nlat, self.nlon)
                              )
 
+        self.lmax = self.nlat / 2 -1
         self.data = array
         self.grid = 'DH'
         self.kind = 'complex'
@@ -785,7 +1165,7 @@ class DHComplexGrid(SHGrid):
         lons = np.linspace(0., 360.0 - 360.0 / self.nlon, num=self.nlon)
         return lons
 
-    def _expand(self, normalization, csphase):
+    def _expand(self, normalization, csphase, **kwargs):
         """Expand the grid into real spherical harmonics."""
         if normalization.lower() == '4pi':
             norm = 1
@@ -797,7 +1177,8 @@ class DHComplexGrid(SHGrid):
             raise NotImplementedError(
                 "Normalization must be '4pi', 'ortho', or 'schmidt'")
 
-        cilm = _shtools.SHExpandDHC(self.data, norm=norm, csphase=csphase)
+        cilm = _shtools.SHExpandDHC(self.data, norm=norm, csphase=csphase,
+                                    **kwargs)
         coeffs = SHCoeffs.from_array(cilm,
                                      normalization=normalization.lower(),
                                      csphase=csphase)
@@ -871,7 +1252,7 @@ class GLQRealGrid(SHGrid):
         lons = np.linspace(0.0, 360.0 - 360.0 / self.nlon, num=self.nlon)
         return lons
 
-    def _expand(self, normalization, csphase):
+    def _expand(self, normalization, csphase, **kwargs):
         """Expand the grid into real spherical harmonics."""
         if normalization.lower() == '4pi':
             norm = 1
@@ -884,7 +1265,7 @@ class GLQRealGrid(SHGrid):
                 "Normalization must be '4pi', 'ortho', or 'schmidt'")
 
         cilm = _shtools.SHExpandGLQ(self.data, self.weights, self.zeros,
-                                    norm=norm, csphase=csphase)
+                                    norm=norm, csphase=csphase, **kwargs)
         coeffs = SHCoeffs.from_array(cilm,
                                      normalization=normalization.lower(),
                                      csphase=csphase)
@@ -953,7 +1334,7 @@ class GLQComplexGrid(SHGrid):
         lons = np.linspace(0., 360. - 360. / self.nlon, num=self.nlon)
         return lons
 
-    def _expand(self, normalization, csphase):
+    def _expand(self, normalization, csphase, **kwargs):
         """Expand the grid into real spherical harmonics."""
         if normalization.lower() == '4pi':
             norm = 1
@@ -966,7 +1347,7 @@ class GLQComplexGrid(SHGrid):
                 "Normalization must be '4pi', 'ortho', or 'schmidt'")
 
         cilm = _shtools.SHExpandGLQC(self.data, self.weights, self.zeros,
-                                     norm=norm, csphase=csphase)
+                                     norm=norm, csphase=csphase, **kwargs)
         coeffs = SHCoeffs.from_array(cilm,
                                      normalization=normalization.lower(),
                                      csphase=csphase)

--- a/pyshtools/shclasses/SHCoeffs.py
+++ b/pyshtools/shclasses/SHCoeffs.py
@@ -1,43 +1,15 @@
-"""
-pyshtools defines several classes that facilitate the interactive
-examination of geographical gridded data and their associated
-spherical harmonic coefficients. Subclasses are used to handle different
-internal data types and superclasses are used to implement interface
-functions and documentation.
-
-pyshtools class structure:
-
-    SHCoeffs
-        SHRealCoefficients
-        SHComplexCoefficients
-
-    SHGrid
-        DHRealGrid
-        DHComplexGrid
-        GLQRealGrid
-        GLQComplexGrid
-
-    SHWindow
-        SymmetricWindow
-        AsymmetricWindow
-
-For more information, see the documentation for the top level classes.
-"""
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
-import numpy as _np
-import matplotlib as _mpl
-import matplotlib.pyplot as _plt
-
-from . import _SHTOOLS as _shtools
-
-
 # =============================================================================
 # =========    COEFFICIENT CLASSES    =========================================
 # =============================================================================
+
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+
+from .. import _SHTOOLS as shtools
+
 
 class SHCoeffs(object):
     """
@@ -128,7 +100,7 @@ class SHCoeffs(object):
         csphase       : 1 (default) if the coefficients exclude the Condon-
                         Shortley phase factor, or -1 if they include it.
         """
-        if np.iscomplexobj(coeffs):
+        if iscomplexobj(coeffs):
             kind = 'complex'
         else:
             kind = 'real'
@@ -291,7 +263,7 @@ class SHCoeffs(object):
 
         if format.lower() == 'shtools':
             if kind.lower() == 'real':
-                coeffs, lmax = _shtools.SHRead(fname, lmax, **kwargs)
+                coeffs, lmax = shtools.SHRead(fname, lmax, **kwargs)
             else:
                 raise NotImplementedError(
                     "kind={:s} not yet implemented".format(repr(kind)))
@@ -589,7 +561,7 @@ class SHCoeffs(object):
         power = self.get_powerperdegree()
         ls = self.get_degrees()
 
-        fig, ax = _plt.subplots(1, 1)
+        fig, ax = plt.subplots(1, 1)
         ax.set_xlabel('degree l')
         ax.set_ylabel('power per degree')
         if loglog:
@@ -598,7 +570,7 @@ class SHCoeffs(object):
             ax.grid(True, which='both')
             ax.plot(ls[1:], power[1:], label='power per degree l')
         if show:
-            _plt.show()
+            plt.show()
         if fname is not None:
             fig.savefig(fname)
 
@@ -622,7 +594,7 @@ class SHCoeffs(object):
         power = self.get_powerperband(bandwidth)
         ls = self.get_degrees()
 
-        fig, ax = _plt.subplots(1, 1)
+        fig, ax = plt.subplots(1, 1)
         ax.set_xlabel('degree l')
         ax.set_ylabel('bandpower')
         ax.set_xscale('log', basex=bandwidth)
@@ -631,14 +603,14 @@ class SHCoeffs(object):
         ax.plot(ls[1:], power[1:], label='power per degree l')
         fig.tight_layout(pad=0.1)
         if show:
-            _plt.show()
+            plt.show()
         if fname is not None:
             fig.savefig(fname)
 
 
 # ================== REAL SPHERICAL HARMONICS ================
 
-class SHRealCoefficients(SHCoeffs):
+class SHRealCoeffs(SHCoeffs):
     """
     Real Spherical Harmonics Coefficient class.
     """
@@ -675,8 +647,8 @@ class SHRealCoefficients(SHCoeffs):
 
         SHComplexCoeffsInstance = x.make_complex()
         """
-        rcomplex_coeffs = _shtools.SHrtoc(self.coeffs,
-                                          convention=1, switchcs=0)
+        rcomplex_coeffs = shtools.SHrtoc(self.coeffs,
+                                         convention=1, switchcs=0)
 
         # These coefficients are using real floats, and need to be
         # converted to complex form.
@@ -696,14 +668,14 @@ class SHRealCoefficients(SHCoeffs):
     def _powerperdegree(self):
         """Return the power per degree l spectrum."""
         if self.normalization == '4pi':
-            return _shtools.SHPowerSpectrum(self.coeffs)
+            return shtools.SHPowerSpectrum(self.coeffs)
         elif self.normalization == 'schmidt':
-            power = _shtools.SHPowerSpectrum(self.coeffs)
+            power = shtools.SHPowerSpectrum(self.coeffs)
             l = self.get_degrees()
             power /= (2.0 * l + 1.0)
             return power
         elif self.normalization == 'ortho':
-            return _shtools.SHPowerSpectrum(self.coeffs) / (4.0 * np.pi)
+            return shtools.SHPowerSpectrum(self.coeffs) / (4.0 * np.pi)
         else:
             raise ValueError(
                 "Normalization must be '4pi', 'ortho', or 'schmidt'. " +
@@ -752,10 +724,10 @@ class SHRealCoefficients(SHCoeffs):
         harmonics coefficients by the Euler angles alpha, beta, gamma.
         """
         if dj_matrix is None:
-            dj_matrix = _shtools.djpi2(self.lmax + 1)
+            dj_matrix = shtools.djpi2(self.lmax + 1)
 
         # The coefficients need to be 4pi normalized with csphase = 1
-        coeffs = _shtools.SHRotateRealCoef(
+        coeffs = shtools.SHRotateRealCoef(
             self.get_coeffs(normalization='4pi', csphase=1), angles, dj_matrix)
 
         # Convert 4pi normalized coefficients to the same normalization
@@ -786,8 +758,8 @@ class SHRealCoefficients(SHCoeffs):
                 "Normalization must be '4pi', 'ortho', or 'schmidt'. " +
                 "Input value was {:s}".format(repr(self.normalization)))
 
-        data = _shtools.MakeGridDH(self.coeffs, sampling=sampling, norm=norm,
-                                   csphase=self.csphase, **kwargs)
+        data = shtools.MakeGridDH(self.coeffs, sampling=sampling, norm=norm,
+                                  csphase=self.csphase, **kwargs)
         gridout = SHGrid.from_array(data, grid='DH')
         return gridout
 
@@ -805,17 +777,17 @@ class SHRealCoefficients(SHCoeffs):
                 "Input value was {:s}".format(repr(self.normalization)))
 
         if zeros is None:
-            zeros, weights = _shtools.SHGLQ(self.lmax)
+            zeros, weights = shtools.SHGLQ(self.lmax)
 
-        data = _shtools.MakeGridGLQ(self.coeffs, zeros, norm=norm,
-                                    csphase=self.csphase, **kwargs)
+        data = shtools.MakeGridGLQ(self.coeffs, zeros, norm=norm,
+                                   csphase=self.csphase, **kwargs)
         gridout = SHGrid.from_array(data, grid='GLQ')
         return gridout
 
 
 # =============== COMPLEX SPHERICAL HARMONICS ================
 
-class SHComplexCoefficients(SHCoeffs):
+class SHComplexCoeffs(SHCoeffs):
     """
     Complex Spherical Harmonics Coefficients class.
     """
@@ -881,8 +853,8 @@ class SHComplexCoefficients(SHCoeffs):
         coeffs_rc = np.zeros((2, self.lmax + 1, self.lmax + 1))
         coeffs_rc[0, :, :] = self.coeffs[0, :, :].real
         coeffs_rc[1, :, :] = self.coeffs[0, :, :].imag
-        real_coeffs = _shtools.SHctor(coeffs_rc, convention=1,
-                                      switchcs=0)
+        real_coeffs = shtools.SHctor(coeffs_rc, convention=1,
+                                     switchcs=0)
         return SHCoeffs.from_array(real_coeffs,
                                    normalization=self.normalization,
                                    csphase=self.csphase)
@@ -890,14 +862,14 @@ class SHComplexCoefficients(SHCoeffs):
     def _powerperdegree(self):
         """Return the power per degree l spectrum."""
         if self.normalization == '4pi':
-            return _shtools.SHPowerSpectrumC(self.coeffs)
+            return shtools.SHPowerSpectrumC(self.coeffs)
         elif self.normalization == 'schmidt':
-            power = _shtools.SHPowerSpectrumC(self.coeffs)
+            power = shtools.SHPowerSpectrumC(self.coeffs)
             l = self.get_degrees()
             power /= (2.0 * l + 1.0)
             return power
         elif self.normalization == 'ortho':
-            return _shtools.SHPowerSpectrumC(self.coeffs) / (4.0 * np.pi)
+            return shtools.SHPowerSpectrumC(self.coeffs) / (4.0 * np.pi)
         else:
             raise ValueError(
                 "Normalization must be '4pi', 'ortho', or 'schmidt'. " +
@@ -952,22 +924,22 @@ class SHComplexCoefficients(SHCoeffs):
         # combined to make a complex grid, and the resultant is expanded
         # in complex spherical harmonics.
         if dj_matrix is None:
-            dj_matrix = _shtools.djpi2(self.lmax + 1)
+            dj_matrix = shtools.djpi2(self.lmax + 1)
 
         cgrid = self.expand(grid='DH')
         rgrid, igrid = cgrid.data.real, cgrid.data.imag
-        rgridcoeffs = _shtools.SHExpandDH(rgrid, norm=1, sampling=1, csphase=1)
-        igridcoeffs = _shtools.SHExpandDH(igrid, norm=1, sampling=1, csphase=1)
+        rgridcoeffs = shtools.SHExpandDH(rgrid, norm=1, sampling=1, csphase=1)
+        igridcoeffs = shtools.SHExpandDH(igrid, norm=1, sampling=1, csphase=1)
 
-        rgridcoeffs_rot = _shtools.SHRotateRealCoef(
+        rgridcoeffs_rot = shtools.SHRotateRealCoef(
             rgridcoeffs, angles, dj_matrix)
-        igridcoeffs_rot = _shtools.SHRotateRealCoef(
+        igridcoeffs_rot = shtools.SHRotateRealCoef(
             igridcoeffs, angles, dj_matrix)
 
-        rgrid_rot = _shtools.MakeGridDH(rgridcoeffs_rot, norm=1,
-                                        sampling=1, csphase=1)
-        igrid_rot = _shtools.MakeGridDH(igridcoeffs_rot, norm=1,
-                                        sampling=1, csphase=1)
+        rgrid_rot = shtools.MakeGridDH(rgridcoeffs_rot, norm=1,
+                                       sampling=1, csphase=1)
+        igrid_rot = shtools.MakeGridDH(igridcoeffs_rot, norm=1,
+                                       sampling=1, csphase=1)
         grid_rot = rgrid_rot + 1j * igrid_rot
 
         if self.normalization == '4pi':
@@ -980,8 +952,8 @@ class SHComplexCoefficients(SHCoeffs):
             raise ValueError(
                 "Normalization must be '4pi', 'ortho', or 'schmidt'")
 
-        coeffs_rot = _shtools.SHExpandDHC(grid_rot, norm=norm,
-                                          csphase=self.csphase)
+        coeffs_rot = shtools.SHExpandDHC(grid_rot, norm=norm,
+                                         csphase=self.csphase)
 
         return SHCoeffs.from_array(coeffs_rot,
                                    normalization=self.normalization,
@@ -1003,8 +975,8 @@ class SHComplexCoefficients(SHCoeffs):
                 "Normalization must be '4pi', 'ortho', or 'schmidt'. " +
                 "Input value was {:s}".format(repr(self.normalization)))
 
-        data = _shtools.MakeGridDHC(self.coeffs, sampling=sampling,
-                                    norm=norm, csphase=self.csphase, **kwargs)
+        data = shtools.MakeGridDHC(self.coeffs, sampling=sampling,
+                                   norm=norm, csphase=self.csphase, **kwargs)
         gridout = SHGrid.from_array(data, grid='DH')
         return gridout
 
@@ -1022,711 +994,9 @@ class SHComplexCoefficients(SHCoeffs):
                 "Input value was {:s}".format(repr(self.normalization)))
 
         if zeros is None:
-            zeros, weights = _shtools.SHGLQ(self.lmax)
+            zeros, weights = shtools.SHGLQ(self.lmax)
 
-        data = _shtools.MakeGridGLQC(self.coeffs, zeros, norm=norm,
-                                     csphase=self.csphase, **kwargs)
+        data = shtools.MakeGridGLQC(self.coeffs, zeros, norm=norm,
+                                    csphase=self.csphase, **kwargs)
         gridout = SHGrid.from_array(data, grid='GLQ')
         return gridout
-
-
-# ========================================================================
-# ======      GRID CLASSES      ==========================================
-# ========================================================================
-
-class SHGrid(object):
-    """
-    Grid Class for global gridded data on the sphere. Grids can be
-    initialized from:
-
-    >> x = SHGrid.from_array(array)
-    >> x = SHGrid.from_file('fname.dat')
-
-    The class instance defines the following class attributes:
-
-    data       : Gridded array of the data.
-    nlat, nlon : The number of latitude and longitude bands in the grid.
-    lmax       : The maximum spherical harmonic degree that can be resolved
-                 by the grid sampling.
-    sampling   : For Driscoll and Healy grids, the longitudinal sampling
-                 of the grid. Either nlong = nlat or nlong = 2 * nlat.
-    kind       : Either 'complex' or 'real' for the data type.
-    grid       : Either 'DH' or 'GLQ' for Driscoll and Healy grids or Gauss-
-                 Legendre Quadrature grids.
-    zeros      : The cos(colatitude) nodes used with Gauss-Legendre
-                 Quadrature grids. Default is None.
-    weights    : The latitudinal weights used with Gauss-Legendre
-                 Quadrature grids. Default is None.
-
-    Each class instance provides the following methods:
-
-    get_lats()     : Return a vector containing the latitudes of each row
-                     of the gridded data.
-    get_lons()     : Return a vector containing the longitudes of each column
-                     of the gridded data.
-    expand()       : Expand the grid into spherical harmonics.
-    plot_rawdata() : Plot the raw data using a simple cylindrical projection.
-    """
-
-    def __init__():
-        pass
-
-    # ---- factory methods
-    @classmethod
-    def from_array(self, array, grid='DH'):
-        """
-        Initialize the grid of the class instance from an input array.
-
-        Usage
-        -----
-
-        x = SHGrid.from_array(array, [grid])
-
-        Parameters
-        ----------
-
-        array : numpy array of size (nlat, nlon)
-        grid : 'DH' (default) or 'GLQ' for Driscoll and Healy grids or Gauss
-                Legendre Quadrature grids, respectively.
-        """
-        if np.iscomplexobj(array):
-            kind = 'complex'
-        else:
-            kind = 'real'
-
-        if type(grid) != str:
-            raise ValueError('grid must be a string. ' +
-                             'Input type was {:s}'
-                             .format(str(type(grid))))
-
-        if grid.upper() not in set(['DH', 'GLQ']):
-            raise ValueError(
-                "grid must be 'DH' or 'GLQ'. Input value was {:s}."
-                .format(repr(grid))
-                )
-
-        for cls in self.__subclasses__():
-            if cls.istype(kind) and cls.isgrid(grid):
-                return cls(array)
-
-    @classmethod
-    def from_file(self, fname, kind='real', grid='DH'):
-        """Initialize the grid of the object from a file."""
-        raise NotImplementedError('Not implemented yet')
-
-    # ---- Extract grid properties ----
-    def get_lats(self):
-        """
-        Return a vector containing the latitudes (in degrees) of each row
-        of the gridded data.
-
-        Usage
-        -----
-
-        lats = x.get_lats()
-
-        Returns
-        -------
-
-        lats : numpy array of size nlat containing the latitude (in degrees)
-               of each row of the gridded data.
-        """
-        return self._get_lats()
-
-    def get_lons(self):
-        """
-        Return a vector containing the longitudes (in degrees) of each
-        column of the gridded data.
-
-        Usage
-        -----
-
-        lons = x.get_lon()
-
-        Returns
-        -------
-
-        lons : numpy array of size nlon containing the longitude (in degrees)
-               of each column of the gridded data.
-        """
-        return self._get_lons()
-
-    # ---- Plotting routines ----
-    def plot_rawdata(self, show=True, fname=None):
-        """
-        Plot the raw data using a simple cylindrical projection.
-
-        Usage
-        -----
-
-        x.plot_rawdata([show, fname])
-
-        Parameters
-        ----------
-
-        show   : If True (default), plot the image to the screen.
-        fname  : If present, save the image to the file.
-        """
-        fig, ax = self._plot_rawdata()
-        if show:
-            _plt.show()
-        if fname is not None:
-            fig.savefig(fname)
-
-    def expand(self, normalization='4pi', csphase=1, **kwargs):
-        """
-        Expand the grid into spherical harmonics.
-
-        Usage
-        -----
-
-        SHCoeffsInstance = x.expand([normalization, csphase, lmax_calc])
-
-        Parameters
-        ----------
-
-        normalization : '4pi' (default), geodesy 4-pi normalized
-                      : 'ortho', orthonormalized
-                      : 'schmidt', Schmidt semi-normalized)
-        csphase       : 1  (default), exlcude the Condon-Shortley phase factor
-        lmax_calc     : maximum spherical harmonic degree to return.
-                        Default is x.lmax.
-        """
-        if type(normalization) != str:
-            raise ValueError('normalization must be a string. ' +
-                             'Input type was {:s}'
-                             .format(str(type(normalization))))
-
-        if normalization.lower() not in set(['4pi', 'ortho', 'schmidt']):
-            raise ValueError(
-                "The normalization must be '4pi', 'ortho' " +
-                "or 'schmidt'. Input value was {:s}."
-                .format(repr(normalization))
-                )
-
-        if csphase != 1 and csphase != -1:
-            raise ValueError(
-                "csphase must be either 1 or -1. Input value was {:s}."
-                .format(repr(csphase))
-                )
-
-        return self._expand(normalization=normalization, csphase=csphase,
-                            **kwargs)
-
-
-# ---- Real Driscoll and Healy grid class ----
-
-class DHRealGrid(SHGrid):
-    """
-    Class for real Driscoll and Healy (1994) grids.
-    """
-    @staticmethod
-    def istype(kind):
-        return kind == 'real'
-
-    @staticmethod
-    def isgrid(grid):
-        return grid == 'DH'
-
-    def __init__(self, array):
-        self.nlat, self.nlon = array.shape
-
-        if self.nlat % 2 != 0:
-            raise ValueError('Input arrays for DH grids must have an even ' +
-                             'number of latitudes: nlat = {:d}'
-                             .format(self.nlat)
-                             )
-        if self.nlon == 2 * self.nlat:
-            self.sampling = 2
-        elif self.nlat == self.nlon:
-            self.sampling = 1
-        else:
-            raise ValueError('Input array has shape (nlat={:d},nlon={:d})\n' +
-                             'but needs nlat=nlon or nlat=2*nlon'
-                             .format(self.nlat, self.nlon)
-                             )
-
-        self.lmax = int(self.nlat / 2 - 1)
-        self.data = array
-        self.grid = 'DH'
-        self.kind = 'real'
-
-    def _get_lats(self):
-        """
-        Return a vector containing the latitudes (in degrees) of each row
-        of the gridded data.
-        """
-        lats = np.linspace(90.0, -90.0 + 180.0 / self.nlat, num=self.nlat)
-        return lats
-
-    def _get_lons(self):
-        """
-        Return a vector containing the longitudes (in degrees) of each row
-        of the gridded data.
-        """
-        lons = np.linspace(0.0, 360.0 - 360.0 / self.nlon, num=self.nlon)
-        return lons
-
-    def _expand(self, normalization, csphase, **kwargs):
-        """Expand the grid into real spherical harmonics."""
-        if normalization.lower() == '4pi':
-            norm = 1
-        elif normalization.lower() == 'schmidt':
-            norm = 2
-        elif normalization.lower() == 'ortho':
-            norm = 4
-        else:
-            raise ValueError(
-                "The normalization must be '4pi', 'ortho' " +
-                "or 'schmidt'. Input value was {:s}."
-                .format(repr(normalization))
-                )
-
-        cilm = _shtools.SHExpandDH(self.data, norm=norm, csphase=csphase,
-                                   **kwargs)
-        coeffs = SHCoeffs.from_array(cilm,
-                                     normalization=normalization.lower(),
-                                     csphase=csphase)
-        return coeffs
-
-    def _plot_rawdata(self):
-        """Plot the raw data using a simply cylindrical projection."""
-        fig, ax = _plt.subplots(1, 1)
-        ax.imshow(self.data, origin='top', extent=(0., 360., -90., 90.))
-        ax.set_title('Driscoll and Healy Grid')
-        ax.set_xlabel('longitude')
-        ax.set_ylabel('latitude')
-        fig.tight_layout(pad=0.5)
-        return fig, ax
-
-
-# ---- Complex Driscoll and Healy grid class ----
-
-class DHComplexGrid(SHGrid):
-    """
-    Class for complex Driscoll and Healy (1994) grids.
-    """
-    @staticmethod
-    def istype(kind):
-        return kind == 'complex'
-
-    @staticmethod
-    def isgrid(grid):
-        return grid == 'DH'
-
-    def __init__(self, array):
-        self.nlat, self.nlon = array.shape
-
-        if self.nlat % 2 != 0:
-            raise ValueError('Input arrays for DH grids must have an even ' +
-                             'number of latitudes: nlat = {:d}'
-                             .format(self.nlat)
-                             )
-        if self.nlon == 2 * self.nlat:
-            self.sampling = 2
-        elif self.nlat == self.nlon:
-            self.sampling = 1
-        else:
-            raise ValueError('Input array has shape (nlat={:d},nlon={:d})\n' +
-                             'but needs nlat=nlon or nlat=2*nlon'
-                             .format(self.nlat, self.nlon)
-                             )
-
-        self.lmax = int(self.nlat / 2 - 1)
-        self.data = array
-        self.grid = 'DH'
-        self.kind = 'complex'
-
-    def _get_lats(self):
-        """
-        Return a vector containing the latitudes (in degrees) of each row
-        of the gridded data.
-        """
-        lats = np.linspace(90.0, -90.0 + 180.0 / self.nlat, num=self.nlat)
-        return lats
-
-    def _get_lons(self):
-        """
-        Return a vector containing the longitudes (in degrees) of each row
-        of the gridded data.
-        """
-        lons = np.linspace(0., 360.0 - 360.0 / self.nlon, num=self.nlon)
-        return lons
-
-    def _expand(self, normalization, csphase, **kwargs):
-        """Expand the grid into real spherical harmonics."""
-        if normalization.lower() == '4pi':
-            norm = 1
-        elif normalization.lower() == 'schmidt':
-            norm = 2
-        elif normalization.lower() == 'ortho':
-            norm = 4
-        else:
-            raise ValueError(
-                "The normalization must be '4pi', 'ortho' " +
-                "or 'schmidt'. Input value was {:s}."
-                .format(repr(normalization))
-                )
-
-        cilm = _shtools.SHExpandDHC(self.data, norm=norm, csphase=csphase,
-                                    **kwargs)
-        coeffs = SHCoeffs.from_array(cilm,
-                                     normalization=normalization.lower(),
-                                     csphase=csphase)
-        return coeffs
-
-    def _plot_rawdata(self):
-        """Plot the raw data using a simply cylindrical projection."""
-        fig, ax = _plt.subplots(2, 1)
-        ax.flat[0].imshow(self.data.real, origin='top',
-                          extent=(0., 360., -90., 90.))
-        ax.flat[0].set_title('Driscoll and Healy Grid (real component)')
-        ax.flat[0].set_xlabel('longitude')
-        ax.flat[0].set_ylabel('latitude')
-        ax.flat[1].imshow(self.data.imag, origin='top',
-                          extent=(0., 360., -90., 90.))
-        ax.flat[1].set_title('Driscoll and Healy Grid (imaginary component)')
-        ax.flat[1].set_xlabel('longitude')
-        ax.flat[1].set_ylabel('latitude')
-        fig.tight_layout(pad=0.5)
-        return fig, ax
-
-
-# ---- Real Gaus Legendre Quadrature grid class ----
-
-class GLQRealGrid(SHGrid):
-    """
-    Class for real Gauss-Legendre Quadrature grids.
-    """
-    @staticmethod
-    def istype(kind):
-        return kind == 'real'
-
-    @staticmethod
-    def isgrid(grid):
-        return grid == 'GLQ'
-
-    def __init__(self, array, zeros=None, weights=None):
-        self.nlat, self.nlon = array.shape
-        self.lmax = self.nlat - 1
-
-        if self.nlat != self.lmax + 1 or self.nlon != 2 * self.lmax + 1:
-            raise ValueError('Input array has shape (nlat={:d}, nlon={:d})\n' +
-                             'but needs (nlat={:d}, {:d})'
-                             .format(self.nlat, self.nlon, self.lmax+1,
-                                     2*self.lmax+1)
-                             )
-
-        if zeros is None or weights is None:
-            self.zeros, self.weights = _shtools.SHGLQ(self.lmax)
-        else:
-            self.zeros = zeros
-            self.weights = weights
-
-        self.data = array
-        self.grid = 'GLQ'
-        self.kind = 'real'
-
-    def _get_lats(self):
-        """
-        Return a vector containing the latitudes (in degrees) of each row
-        of the gridded data.
-        """
-        lats = 90. - np.arccos(self.zeros) * 180. / np.pi
-        return lats
-
-    def _get_lons(self):
-        """
-        Return a vector containing the longitudes (in degrees) of each column
-        of the gridded data.
-        """
-        lons = np.linspace(0.0, 360.0 - 360.0 / self.nlon, num=self.nlon)
-        return lons
-
-    def _expand(self, normalization, csphase, **kwargs):
-        """Expand the grid into real spherical harmonics."""
-        if normalization.lower() == '4pi':
-            norm = 1
-        elif normalization.lower() == 'schmidt':
-            norm = 2
-        elif normalization.lower() == 'ortho':
-            norm = 4
-        else:
-            raise ValueError(
-                "The normalization must be '4pi', 'ortho' " +
-                "or 'schmidt'. Input value was {:s}."
-                .format(repr(normalization))
-                )
-
-        cilm = _shtools.SHExpandGLQ(self.data, self.weights, self.zeros,
-                                    norm=norm, csphase=csphase, **kwargs)
-        coeffs = SHCoeffs.from_array(cilm,
-                                     normalization=normalization.lower(),
-                                     csphase=csphase)
-        return coeffs
-
-    def _plot_rawdata(self):
-        """Plot the raw data using a simply cylindrical projection."""
-
-        fig, ax = _plt.subplots(1, 1)
-        ax.imshow(self.data, origin='top')
-        ax.set_title('Gauss-Legendre Quadrature Grid')
-        ax.set_xlabel('longitude index')
-        ax.set_ylabel('latitude index')
-        fig.tight_layout(pad=0.5)
-        return fig, ax
-
-
-# ---- Complex Gaus Legendre Quadrature grid class ----
-
-class GLQComplexGrid(SHGrid):
-    """
-    Class for complex Gauss Legendre Quadrature grids.
-    """
-    @staticmethod
-    def istype(kind):
-        return kind == 'complex'
-
-    @staticmethod
-    def isgrid(grid):
-        return grid == 'GLQ'
-
-    def __init__(self, array, zeros=None, weights=None):
-        self.nlat, self.nlon = array.shape
-        self.lmax = self.nlat - 1
-
-        if self.nlat != self.lmax + 1 or self.nlon != 2 * self.lmax + 1:
-            raise ValueError('Input array has shape (nlat={:d}, nlon={:d})\n' +
-                             'but needs (nlat={:d}, {:d})'
-                             .format(self.nlat, self.nlon, self.lmax+1,
-                                     2*self.lmax+1)
-                             )
-
-        if zeros is None or weights is None:
-            self.zeros, self.weights = _shtools.SHGLQ(self.lmax)
-        else:
-            self.zeros = zeros
-            self.weights = weights
-
-        self.data = array
-        self.grid = 'GLQ'
-        self.kind = 'complex'
-
-    def _get_lats(self):
-        """
-        Return a vector containing the latitudes (in degrees) of each row
-        of the gridded data.
-        """
-        lats = 90. - np.arccos(self.zeros) * 180. / np.pi
-        return lats
-
-    def _get_lons(self):
-        """
-        Return a vector containing the longitudes (in degrees) of each column
-        of the gridded data.
-        """
-        lons = np.linspace(0., 360. - 360. / self.nlon, num=self.nlon)
-        return lons
-
-    def _expand(self, normalization, csphase, **kwargs):
-        """Expand the grid into real spherical harmonics."""
-        if normalization.lower() == '4pi':
-            norm = 1
-        elif normalization.lower() == 'schmidt':
-            norm = 2
-        elif normalization.lower() == 'ortho':
-            norm = 4
-        else:
-            raise ValueError(
-                "The normalization must be '4pi', 'ortho' " +
-                "or 'schmidt'. Input value was {:s}."
-                .format(repr(normalization))
-                )
-
-        cilm = _shtools.SHExpandGLQC(self.data, self.weights, self.zeros,
-                                     norm=norm, csphase=csphase, **kwargs)
-        coeffs = SHCoeffs.from_array(cilm,
-                                     normalization=normalization.lower(),
-                                     csphase=csphase)
-        return coeffs
-
-    def _plot_rawdata(self):
-        """Plot the raw data using a simply cylindrical projection."""
-
-        fig, ax = _plt.subplots(2, 1)
-        ax.flat[0].imshow(self.data.real, origin='top')
-        ax.flat[0].set_title('Gauss-Legendre Quadrature Grid (real component)')
-        ax.flat[0].set_xlabel('longitude index')
-        ax.flat[0].set_ylabel('latitude index')
-        ax.flat[1].imshow(self.data.imag, origin='top')
-        ax.flat[1].set_title('Gauss-Legendre Quadrature Grid ' +
-                             '(imaginary component)')
-        ax.flat[1].set_xlabel('longitude index')
-        ax.flat[1].set_ylabel('latitude index')
-        fig.tight_layout(pad=0.5)
-        return fig, ax
-
-
-# ==== SPHERICAL HARMONICS WINDOW FUNCTION CLASS ====
-class SHWindow(object):
-    """
-    EXPERIMENTAL:
-    This class contains collections of spherical harmonics windows that
-    provide spectral estimates about a specific region
-    """
-    def __init__(self):
-        print("use one of the following constructors: [...]")
-
-    @classmethod
-    def from_cap(self, lmax, nwins, theta, clat=0., clon=0., degrees=True):
-        """
-        constructs a spherical cap window
-        """
-        if degrees:
-            theta = np.radians(theta)
-
-        tapers, eigenvalues, taper_order = _shtools.SHReturnTapers(theta, lmax)
-        return SHSymmetricWindow(tapers, eigenvalues, taper_order,
-                                          clat=clat, clon=clon)
-
-    @classmethod
-    def from_mask(self, lmax, nwins, dh_mask, sampling=1):
-        """
-        constructs optimal window functions in a masked region (needs dh grid)
-        """
-        tapers, eigenvalues = _shtools.SHReturnTapersMap(
-            dh_mask, lmax, sampling=sampling, Ntapers=nwins)
-        return SHAsymmetricWindow(tapers, eigenvalues)
-
-    def plot(self, nwins, show=True, fname=None):
-        """
-        plots the best concentrated spherical harmonics taper functions
-        """
-        # ---- setup figure and axes
-        maxcolumns = 5
-        ncolumns = min(maxcolumns, nwins)
-        nrows = np.ceil(nwins / ncolumns).astype(int)
-        figsize = ncolumns * 1.2, nrows * 1.2 + 0.5
-        fig, axes = _plt.subplots(nrows, ncolumns, figsize=figsize)
-        for ax in axes[:-1, :].flatten():
-            for xlabel_i in ax.get_xticklabels():
-                xlabel_i.set_visible(False)
-        for ax in axes[:, 1:].flatten():
-            for ylabel_i in ax.get_yticklabels():
-                ylabel_i.set_visible(False)
-
-        # loop through tapers and plot them
-        for itaper in range(min(self.nwins, nwins)):
-            evalue = self.eigenvalues[itaper]
-            coeffs = self._coeffs(itaper)
-            ax = axes.flatten()[itaper]
-            grid = _shtools.MakeGridDH(coeffs)
-            ax.imshow(grid)
-            ax.set_title('concentration: {:2.2f}'.format(evalue))
-        fig.tight_layout(pad=0.5)
-
-        if show:
-            _plt.show()
-        if fname is not None:
-            fig.savefig(fname)
-
-    def get_spectrum(self, shcoeffs, nwins):
-        """Returns the regional spherical harmonics spectrum"""
-        for itaper in range(nwins):
-            tapercoeffs = self._coeffs(itaper)
-            modelcoeffs = shcoeffs.get_coeffs(normalization='4pi', kind='real')
-            coeffs = _shtools.SHMultiply(tapercoeffs, modelcoeffs)
-
-    def get_couplingmatrix(self, lmax, nwins):
-        """returns the coupling matrix of the first nwins tapers"""
-        # store sqrt of taper power in 'tapers' array:
-        if nwins > self.nwins:
-            nwins = self.nwins
-        tapers = np.zeros((self.nl, nwins))
-        for itaper in range(nwins):
-            tapers[:, itaper] = np.sqrt(_shtools.SHPowerSpectrum(
-                self._coeffs(itaper)))
-
-        # compute coupling matrix of the first nwins tapers:
-        coupling_matrix = _shtools.SHMTCouplingMatrix(lmax, tapers[:, :nwins])
-        return coupling_matrix
-
-    def plot_couplingmatrix(self, lmax, nwins, show=True, fname=None):
-        """plots the window's coupling strength"""
-        figsize = _mpl.rcParams['figure.figsize']
-        figsize[0] = figsize[1]
-        fig = _plt.figure(figsize=figsize)
-        ax = fig.add_subplot(111)
-        coupling_matrix = self.get_couplingmatrix(lmax, nwins)
-        ax.imshow(coupling_matrix)
-        ax.set_xlabel('output power')
-        ax.set_ylabel('input power')
-        fig.tight_layout(pad=0.1)
-
-        if show:
-            _plt.show()
-        if fname is not None:
-            fig.savefig(fname)
-
-    def info(self):
-        """print meta information about the tapers"""
-        self._info()
-
-
-class SHSymmetricWindow(SHWindow):
-    """
-    This class saves a symmetric spherical window function. It needs to
-    save only the m=0 coefficients
-    """
-    @staticmethod
-    def istype(kind):
-        return kind == 'Symmetric'
-
-    def __init__(self, tapers, eigenvalues, orders, clat=0., clon=0.):
-        # center of cap window
-        self.clat, self.clon = clat, clon
-        # nl: number of degrees, nwins: number of windows
-        self.nl, self.nwins = tapers.shape
-        # lmax: maximum degree
-        self.lmax = self.nl - 1
-        # tapers[nl,nwins]: ith window coefs with m=orders[iwin]
-        self.tapers = tapers
-        # concentration factor of the ith taper
-        self.eigenvalues = eigenvalues
-        # order m of the ith taper
-        self.orders = orders
-
-    def _coeffs(self, itaper):
-        taperm = self.orders[itaper]
-        coeffs = np.zeros((2, self.nl, self.nl))
-        if taperm < 0:
-            coeffs[1, :, abs(taperm)] = self.tapers[:, itaper]
-        else:
-            coeffs[0, :, abs(taperm)] = self.tapers[:, itaper]
-        return coeffs
-
-    def _info(self):
-        print('Cap window with {:d} tapers'.format(self.nwins))
-
-
-class SHAsymmetricWindow(SHWindow):
-    """
-    This class saves a asymmetric spherical window function and is much like a
-    set of real sherical harmonics. It could maybe be merged at some point...
-    """
-    @staticmethod
-    def istype(kind):
-        return kind == 'Asymmetric'
-
-    def __init__(self, tapers, eigenvalues):
-        ncoeffs, self.nwins = tapers.shape
-        self.nl = np.sqrt(ncoeffs).astype(int)
-        self.lmax = self.nl-1
-        self.tapers = tapers
-        self.eigenvalues = eigenvalues
-
-    def _coeffs(self, itaper):
-        return _shtools.SHVectorToCilm(self.tapers[:, itaper], self.lmax)
-
-    def _info(self):
-        print('Asymmetric window with {:d} tapers'.format(self.nwins))

--- a/pyshtools/shclasses/SHGrid.py
+++ b/pyshtools/shclasses/SHGrid.py
@@ -1,0 +1,544 @@
+# ========================================================================
+# ======      GRID CLASSES      ==========================================
+# ========================================================================
+
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+
+from .. import _SHTOOLS as shtools
+
+
+class SHGrid(object):
+    """
+    Grid Class for global gridded data on the sphere. Grids can be
+    initialized from:
+
+    >> x = SHGrid.from_array(array)
+    >> x = SHGrid.from_file('fname.dat')
+
+    The class instance defines the following class attributes:
+
+    data       : Gridded array of the data.
+    nlat, nlon : The number of latitude and longitude bands in the grid.
+    lmax       : The maximum spherical harmonic degree that can be resolved
+                 by the grid sampling.
+    sampling   : For Driscoll and Healy grids, the longitudinal sampling
+                 of the grid. Either nlong = nlat or nlong = 2 * nlat.
+    kind       : Either 'complex' or 'real' for the data type.
+    grid       : Either 'DH' or 'GLQ' for Driscoll and Healy grids or Gauss-
+                 Legendre Quadrature grids.
+    zeros      : The cos(colatitude) nodes used with Gauss-Legendre
+                 Quadrature grids. Default is None.
+    weights    : The latitudinal weights used with Gauss-Legendre
+                 Quadrature grids. Default is None.
+
+    Each class instance provides the following methods:
+
+    get_lats()     : Return a vector containing the latitudes of each row
+                     of the gridded data.
+    get_lons()     : Return a vector containing the longitudes of each column
+                     of the gridded data.
+    expand()       : Expand the grid into spherical harmonics.
+    plot_rawdata() : Plot the raw data using a simple cylindrical projection.
+    """
+
+    def __init__():
+        pass
+
+    # ---- factory methods
+    @classmethod
+    def from_array(self, array, grid='DH'):
+        """
+        Initialize the grid of the class instance from an input array.
+
+        Usage
+        -----
+
+        x = SHGrid.from_array(array, [grid])
+
+        Parameters
+        ----------
+
+        array : numpy array of size (nlat, nlon)
+        grid : 'DH' (default) or 'GLQ' for Driscoll and Healy grids or Gauss
+                Legendre Quadrature grids, respectively.
+        """
+        if np.iscomplexobj(array):
+            kind = 'complex'
+        else:
+            kind = 'real'
+
+        if type(grid) != str:
+            raise ValueError('grid must be a string. ' +
+                             'Input type was {:s}'
+                             .format(str(type(grid))))
+
+        if grid.upper() not in set(['DH', 'GLQ']):
+            raise ValueError(
+                "grid must be 'DH' or 'GLQ'. Input value was {:s}."
+                .format(repr(grid))
+                )
+
+        for cls in self.__subclasses__():
+            if cls.istype(kind) and cls.isgrid(grid):
+                return cls(array)
+
+    @classmethod
+    def from_file(self, fname, kind='real', grid='DH'):
+        """Initialize the grid of the object from a file."""
+        raise NotImplementedError('Not implemented yet')
+
+    # ---- Extract grid properties ----
+    def get_lats(self):
+        """
+        Return a vector containing the latitudes (in degrees) of each row
+        of the gridded data.
+
+        Usage
+        -----
+
+        lats = x.get_lats()
+
+        Returns
+        -------
+
+        lats : numpy array of size nlat containing the latitude (in degrees)
+               of each row of the gridded data.
+        """
+        return self._get_lats()
+
+    def get_lons(self):
+        """
+        Return a vector containing the longitudes (in degrees) of each
+        column of the gridded data.
+
+        Usage
+        -----
+
+        lons = x.get_lon()
+
+        Returns
+        -------
+
+        lons : numpy array of size nlon containing the longitude (in degrees)
+               of each column of the gridded data.
+        """
+        return self._get_lons()
+
+    # ---- Plotting routines ----
+    def plot_rawdata(self, show=True, fname=None):
+        """
+        Plot the raw data using a simple cylindrical projection.
+
+        Usage
+        -----
+
+        x.plot_rawdata([show, fname])
+
+        Parameters
+        ----------
+
+        show   : If True (default), plot the image to the screen.
+        fname  : If present, save the image to the file.
+        """
+        fig, ax = self._plot_rawdata()
+        if show:
+            plt.show()
+        if fname is not None:
+            fig.savefig(fname)
+
+    def expand(self, normalization='4pi', csphase=1, **kwargs):
+        """
+        Expand the grid into spherical harmonics.
+
+        Usage
+        -----
+
+        SHCoeffsInstance = x.expand([normalization, csphase, lmax_calc])
+
+        Parameters
+        ----------
+
+        normalization : '4pi' (default), geodesy 4-pi normalized
+                      : 'ortho', orthonormalized
+                      : 'schmidt', Schmidt semi-normalized)
+        csphase       : 1  (default), exlcude the Condon-Shortley phase factor
+        lmax_calc     : maximum spherical harmonic degree to return.
+                        Default is x.lmax.
+        """
+        if type(normalization) != str:
+            raise ValueError('normalization must be a string. ' +
+                             'Input type was {:s}'
+                             .format(str(type(normalization))))
+
+        if normalization.lower() not in set(['4pi', 'ortho', 'schmidt']):
+            raise ValueError(
+                "The normalization must be '4pi', 'ortho' " +
+                "or 'schmidt'. Input value was {:s}."
+                .format(repr(normalization))
+                )
+
+        if csphase != 1 and csphase != -1:
+            raise ValueError(
+                "csphase must be either 1 or -1. Input value was {:s}."
+                .format(repr(csphase))
+                )
+
+        return self._expand(normalization=normalization, csphase=csphase,
+                            **kwargs)
+
+
+# ---- Real Driscoll and Healy grid class ----
+
+class DHRealGrid(SHGrid):
+    """
+    Class for real Driscoll and Healy (1994) grids.
+    """
+    @staticmethod
+    def istype(kind):
+        return kind == 'real'
+
+    @staticmethod
+    def isgrid(grid):
+        return grid == 'DH'
+
+    def __init__(self, array):
+        self.nlat, self.nlon = array.shape
+
+        if self.nlat % 2 != 0:
+            raise ValueError('Input arrays for DH grids must have an even ' +
+                             'number of latitudes: nlat = {:d}'
+                             .format(self.nlat)
+                             )
+        if self.nlon == 2 * self.nlat:
+            self.sampling = 2
+        elif self.nlat == self.nlon:
+            self.sampling = 1
+        else:
+            raise ValueError('Input array has shape (nlat={:d},nlon={:d})\n' +
+                             'but needs nlat=nlon or nlat=2*nlon'
+                             .format(self.nlat, self.nlon)
+                             )
+
+        self.lmax = int(self.nlat / 2 - 1)
+        self.data = array
+        self.grid = 'DH'
+        self.kind = 'real'
+
+    def _get_lats(self):
+        """
+        Return a vector containing the latitudes (in degrees) of each row
+        of the gridded data.
+        """
+        lats = np.linspace(90.0, -90.0 + 180.0 / self.nlat, num=self.nlat)
+        return lats
+
+    def _get_lons(self):
+        """
+        Return a vector containing the longitudes (in degrees) of each row
+        of the gridded data.
+        """
+        lons = np.linspace(0.0, 360.0 - 360.0 / self.nlon, num=self.nlon)
+        return lons
+
+    def _expand(self, normalization, csphase, **kwargs):
+        """Expand the grid into real spherical harmonics."""
+        if normalization.lower() == '4pi':
+            norm = 1
+        elif normalization.lower() == 'schmidt':
+            norm = 2
+        elif normalization.lower() == 'ortho':
+            norm = 4
+        else:
+            raise ValueError(
+                "The normalization must be '4pi', 'ortho' " +
+                "or 'schmidt'. Input value was {:s}."
+                .format(repr(normalization))
+                )
+
+        cilm = shtools.SHExpandDH(self.data, norm=norm, csphase=csphase,
+                                  **kwargs)
+        coeffs = SHCoeffs.from_array(cilm,
+                                     normalization=normalization.lower(),
+                                     csphase=csphase)
+        return coeffs
+
+    def _plot_rawdata(self):
+        """Plot the raw data using a simply cylindrical projection."""
+        fig, ax = plt.subplots(1, 1)
+        ax.imshow(self.data, origin='top', extent=(0., 360., -90., 90.))
+        ax.set_title('Driscoll and Healy Grid')
+        ax.set_xlabel('longitude')
+        ax.set_ylabel('latitude')
+        fig.tight_layout(pad=0.5)
+        return fig, ax
+
+
+# ---- Complex Driscoll and Healy grid class ----
+
+class DHComplexGrid(SHGrid):
+    """
+    Class for complex Driscoll and Healy (1994) grids.
+    """
+    @staticmethod
+    def istype(kind):
+        return kind == 'complex'
+
+    @staticmethod
+    def isgrid(grid):
+        return grid == 'DH'
+
+    def __init__(self, array):
+        self.nlat, self.nlon = array.shape
+
+        if self.nlat % 2 != 0:
+            raise ValueError('Input arrays for DH grids must have an even ' +
+                             'number of latitudes: nlat = {:d}'
+                             .format(self.nlat)
+                             )
+        if self.nlon == 2 * self.nlat:
+            self.sampling = 2
+        elif self.nlat == self.nlon:
+            self.sampling = 1
+        else:
+            raise ValueError('Input array has shape (nlat={:d},nlon={:d})\n' +
+                             'but needs nlat=nlon or nlat=2*nlon'
+                             .format(self.nlat, self.nlon)
+                             )
+
+        self.lmax = int(self.nlat / 2 - 1)
+        self.data = array
+        self.grid = 'DH'
+        self.kind = 'complex'
+
+    def _get_lats(self):
+        """
+        Return a vector containing the latitudes (in degrees) of each row
+        of the gridded data.
+        """
+        lats = np.linspace(90.0, -90.0 + 180.0 / self.nlat, num=self.nlat)
+        return lats
+
+    def _get_lons(self):
+        """
+        Return a vector containing the longitudes (in degrees) of each row
+        of the gridded data.
+        """
+        lons = np.linspace(0., 360.0 - 360.0 / self.nlon, num=self.nlon)
+        return lons
+
+    def _expand(self, normalization, csphase, **kwargs):
+        """Expand the grid into real spherical harmonics."""
+        if normalization.lower() == '4pi':
+            norm = 1
+        elif normalization.lower() == 'schmidt':
+            norm = 2
+        elif normalization.lower() == 'ortho':
+            norm = 4
+        else:
+            raise ValueError(
+                "The normalization must be '4pi', 'ortho' " +
+                "or 'schmidt'. Input value was {:s}."
+                .format(repr(normalization))
+                )
+
+        cilm = shtools.SHExpandDHC(self.data, norm=norm, csphase=csphase,
+                                   **kwargs)
+        coeffs = SHCoeffs.from_array(cilm,
+                                     normalization=normalization.lower(),
+                                     csphase=csphase)
+        return coeffs
+
+    def _plot_rawdata(self):
+        """Plot the raw data using a simply cylindrical projection."""
+        fig, ax = plt.subplots(2, 1)
+        ax.flat[0].imshow(self.data.real, origin='top',
+                          extent=(0., 360., -90., 90.))
+        ax.flat[0].set_title('Driscoll and Healy Grid (real component)')
+        ax.flat[0].set_xlabel('longitude')
+        ax.flat[0].set_ylabel('latitude')
+        ax.flat[1].imshow(self.data.imag, origin='top',
+                          extent=(0., 360., -90., 90.))
+        ax.flat[1].set_title('Driscoll and Healy Grid (imaginary component)')
+        ax.flat[1].set_xlabel('longitude')
+        ax.flat[1].set_ylabel('latitude')
+        fig.tight_layout(pad=0.5)
+        return fig, ax
+
+
+# ---- Real Gaus Legendre Quadrature grid class ----
+
+class GLQRealGrid(SHGrid):
+    """
+    Class for real Gauss-Legendre Quadrature grids.
+    """
+    @staticmethod
+    def istype(kind):
+        return kind == 'real'
+
+    @staticmethod
+    def isgrid(grid):
+        return grid == 'GLQ'
+
+    def __init__(self, array, zeros=None, weights=None):
+        self.nlat, self.nlon = array.shape
+        self.lmax = self.nlat - 1
+
+        if self.nlat != self.lmax + 1 or self.nlon != 2 * self.lmax + 1:
+            raise ValueError('Input array has shape (nlat={:d}, nlon={:d})\n' +
+                             'but needs (nlat={:d}, {:d})'
+                             .format(self.nlat, self.nlon, self.lmax+1,
+                                     2*self.lmax+1)
+                             )
+
+        if zeros is None or weights is None:
+            self.zeros, self.weights = shtools.SHGLQ(self.lmax)
+        else:
+            self.zeros = zeros
+            self.weights = weights
+
+        self.data = array
+        self.grid = 'GLQ'
+        self.kind = 'real'
+
+    def _get_lats(self):
+        """
+        Return a vector containing the latitudes (in degrees) of each row
+        of the gridded data.
+        """
+        lats = 90. - np.arccos(self.zeros) * 180. / np.pi
+        return lats
+
+    def _get_lons(self):
+        """
+        Return a vector containing the longitudes (in degrees) of each column
+        of the gridded data.
+        """
+        lons = np.linspace(0.0, 360.0 - 360.0 / self.nlon, num=self.nlon)
+        return lons
+
+    def _expand(self, normalization, csphase, **kwargs):
+        """Expand the grid into real spherical harmonics."""
+        if normalization.lower() == '4pi':
+            norm = 1
+        elif normalization.lower() == 'schmidt':
+            norm = 2
+        elif normalization.lower() == 'ortho':
+            norm = 4
+        else:
+            raise ValueError(
+                "The normalization must be '4pi', 'ortho' " +
+                "or 'schmidt'. Input value was {:s}."
+                .format(repr(normalization))
+                )
+
+        cilm = shtools.SHExpandGLQ(self.data, self.weights, self.zeros,
+                                   norm=norm, csphase=csphase, **kwargs)
+        coeffs = SHCoeffs.from_array(cilm,
+                                     normalization=normalization.lower(),
+                                     csphase=csphase)
+        return coeffs
+
+    def _plot_rawdata(self):
+        """Plot the raw data using a simply cylindrical projection."""
+
+        fig, ax = plt.subplots(1, 1)
+        ax.imshow(self.data, origin='top')
+        ax.set_title('Gauss-Legendre Quadrature Grid')
+        ax.set_xlabel('longitude index')
+        ax.set_ylabel('latitude index')
+        fig.tight_layout(pad=0.5)
+        return fig, ax
+
+
+# ---- Complex Gaus Legendre Quadrature grid class ----
+
+class GLQComplexGrid(SHGrid):
+    """
+    Class for complex Gauss Legendre Quadrature grids.
+    """
+    @staticmethod
+    def istype(kind):
+        return kind == 'complex'
+
+    @staticmethod
+    def isgrid(grid):
+        return grid == 'GLQ'
+
+    def __init__(self, array, zeros=None, weights=None):
+        self.nlat, self.nlon = array.shape
+        self.lmax = self.nlat - 1
+
+        if self.nlat != self.lmax + 1 or self.nlon != 2 * self.lmax + 1:
+            raise ValueError('Input array has shape (nlat={:d}, nlon={:d})\n' +
+                             'but needs (nlat={:d}, {:d})'
+                             .format(self.nlat, self.nlon, self.lmax+1,
+                                     2*self.lmax+1)
+                             )
+
+        if zeros is None or weights is None:
+            self.zeros, self.weights = shtools.SHGLQ(self.lmax)
+        else:
+            self.zeros = zeros
+            self.weights = weights
+
+        self.data = array
+        self.grid = 'GLQ'
+        self.kind = 'complex'
+
+    def _get_lats(self):
+        """
+        Return a vector containing the latitudes (in degrees) of each row
+        of the gridded data.
+        """
+        lats = 90. - np.arccos(self.zeros) * 180. / np.pi
+        return lats
+
+    def _get_lons(self):
+        """
+        Return a vector containing the longitudes (in degrees) of each column
+        of the gridded data.
+        """
+        lons = np.linspace(0., 360. - 360. / self.nlon, num=self.nlon)
+        return lons
+
+    def _expand(self, normalization, csphase, **kwargs):
+        """Expand the grid into real spherical harmonics."""
+        if normalization.lower() == '4pi':
+            norm = 1
+        elif normalization.lower() == 'schmidt':
+            norm = 2
+        elif normalization.lower() == 'ortho':
+            norm = 4
+        else:
+            raise ValueError(
+                "The normalization must be '4pi', 'ortho' " +
+                "or 'schmidt'. Input value was {:s}."
+                .format(repr(normalization))
+                )
+
+        cilm = shtools.SHExpandGLQC(self.data, self.weights, self.zeros,
+                                    norm=norm, csphase=csphase, **kwargs)
+        coeffs = SHCoeffs.from_array(cilm,
+                                     normalization=normalization.lower(),
+                                     csphase=csphase)
+        return coeffs
+
+    def _plot_rawdata(self):
+        """Plot the raw data using a simply cylindrical projection."""
+
+        fig, ax = plt.subplots(2, 1)
+        ax.flat[0].imshow(self.data.real, origin='top')
+        ax.flat[0].set_title('Gauss-Legendre Quadrature Grid (real component)')
+        ax.flat[0].set_xlabel('longitude index')
+        ax.flat[0].set_ylabel('latitude index')
+        ax.flat[1].imshow(self.data.imag, origin='top')
+        ax.flat[1].set_title('Gauss-Legendre Quadrature Grid ' +
+                             '(imaginary component)')
+        ax.flat[1].set_xlabel('longitude index')
+        ax.flat[1].set_ylabel('latitude index')
+        fig.tight_layout(pad=0.5)
+        return fig, ax

--- a/pyshtools/shclasses/SHWindow.py
+++ b/pyshtools/shclasses/SHWindow.py
@@ -1,0 +1,173 @@
+# ==== SPHERICAL HARMONICS WINDOW FUNCTION CLASS ====
+
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+
+from .. import _SHTOOLS as shtools
+
+
+class SHWindow(object):
+    """
+    EXPERIMENTAL:
+    This class contains collections of spherical harmonics windows that
+    provide spectral estimates about a specific region
+    """
+    def __init__(self):
+        print("use one of the following constructors: [...]")
+
+    @classmethod
+    def from_cap(self, lmax, nwins, theta, clat=0., clon=0., degrees=True):
+        """
+        constructs a spherical cap window
+        """
+        if degrees:
+            theta = np.radians(theta)
+
+        tapers, eigenvalues, taper_order = shtools.SHReturnTapers(theta, lmax)
+        return SHSymmetricWindow(tapers, eigenvalues, taper_order,
+                                 clat=clat, clon=clon)
+
+    @classmethod
+    def from_mask(self, lmax, nwins, dh_mask, sampling=1):
+        """
+        constructs optimal window functions in a masked region (needs dh grid)
+        """
+        tapers, eigenvalues = shtools.SHReturnTapersMap(
+            dh_mask, lmax, sampling=sampling, Ntapers=nwins)
+        return SHAsymmetricWindow(tapers, eigenvalues)
+
+    def plot(self, nwins, show=True, fname=None):
+        """
+        plots the best concentrated spherical harmonics taper functions
+        """
+        # ---- setup figure and axes
+        maxcolumns = 5
+        ncolumns = min(maxcolumns, nwins)
+        nrows = np.ceil(nwins / ncolumns).astype(int)
+        figsize = ncolumns * 1.2, nrows * 1.2 + 0.5
+        fig, axes = plt.subplots(nrows, ncolumns, figsize=figsize)
+        for ax in axes[:-1, :].flatten():
+            for xlabel_i in ax.get_xticklabels():
+                xlabel_i.set_visible(False)
+        for ax in axes[:, 1:].flatten():
+            for ylabel_i in ax.get_yticklabels():
+                ylabel_i.set_visible(False)
+
+        # loop through tapers and plot them
+        for itaper in range(min(self.nwins, nwins)):
+            evalue = self.eigenvalues[itaper]
+            coeffs = self._coeffs(itaper)
+            ax = axes.flatten()[itaper]
+            grid = shtools.MakeGridDH(coeffs)
+            ax.imshow(grid)
+            ax.set_title('concentration: {:2.2f}'.format(evalue))
+        fig.tight_layout(pad=0.5)
+
+        if show:
+            plt.show()
+        if fname is not None:
+            fig.savefig(fname)
+
+    def get_spectrum(self, shcoeffs, nwins):
+        """Returns the regional spherical harmonics spectrum"""
+        for itaper in range(nwins):
+            tapercoeffs = self._coeffs(itaper)
+            modelcoeffs = shcoeffs.get_coeffs(normalization='4pi', kind='real')
+            coeffs = shtools.SHMultiply(tapercoeffs, modelcoeffs)
+
+    def get_couplingmatrix(self, lmax, nwins):
+        """returns the coupling matrix of the first nwins tapers"""
+        # store sqrt of taper power in 'tapers' array:
+        if nwins > self.nwins:
+            nwins = self.nwins
+        tapers = np.zeros((self.nl, nwins))
+        for itaper in range(nwins):
+            tapers[:, itaper] = np.sqrt(shtools.SHPowerSpectrum(
+                self._coeffs(itaper)))
+
+        # compute coupling matrix of the first nwins tapers:
+        coupling_matrix = shtools.SHMTCouplingMatrix(lmax, tapers[:, :nwins])
+        return coupling_matrix
+
+    def plot_couplingmatrix(self, lmax, nwins, show=True, fname=None):
+        """plots the window's coupling strength"""
+        figsize = mpl.rcParams['figure.figsize']
+        figsize[0] = figsize[1]
+        fig = plt.figure(figsize=figsize)
+        ax = fig.add_subplot(111)
+        coupling_matrix = self.get_couplingmatrix(lmax, nwins)
+        ax.imshow(coupling_matrix)
+        ax.set_xlabel('output power')
+        ax.set_ylabel('input power')
+        fig.tight_layout(pad=0.1)
+
+        if show:
+            plt.show()
+        if fname is not None:
+            fig.savefig(fname)
+
+    def info(self):
+        """print meta information about the tapers"""
+        self._info()
+
+
+class SHSymmetricWindow(SHWindow):
+    """
+    This class saves a symmetric spherical window function. It needs to
+    save only the m=0 coefficients
+    """
+    @staticmethod
+    def istype(kind):
+        return kind == 'Symmetric'
+
+    def __init__(self, tapers, eigenvalues, orders, clat=0., clon=0.):
+        # center of cap window
+        self.clat, self.clon = clat, clon
+        # nl: number of degrees, nwins: number of windows
+        self.nl, self.nwins = tapers.shape
+        # lmax: maximum degree
+        self.lmax = self.nl - 1
+        # tapers[nl,nwins]: ith window coefs with m=orders[iwin]
+        self.tapers = tapers
+        # concentration factor of the ith taper
+        self.eigenvalues = eigenvalues
+        # order m of the ith taper
+        self.orders = orders
+
+    def _coeffs(self, itaper):
+        taperm = self.orders[itaper]
+        coeffs = np.zeros((2, self.nl, self.nl))
+        if taperm < 0:
+            coeffs[1, :, abs(taperm)] = self.tapers[:, itaper]
+        else:
+            coeffs[0, :, abs(taperm)] = self.tapers[:, itaper]
+        return coeffs
+
+    def _info(self):
+        print('Cap window with {:d} tapers'.format(self.nwins))
+
+
+class SHAsymmetricWindow(SHWindow):
+    """
+    This class saves a asymmetric spherical window function and is much like a
+    set of real sherical harmonics. It could maybe be merged at some point...
+    """
+    @staticmethod
+    def istype(kind):
+        return kind == 'Asymmetric'
+
+    def __init__(self, tapers, eigenvalues):
+        ncoeffs, self.nwins = tapers.shape
+        self.nl = np.sqrt(ncoeffs).astype(int)
+        self.lmax = self.nl-1
+        self.tapers = tapers
+        self.eigenvalues = eigenvalues
+
+    def _coeffs(self, itaper):
+        return shtools.SHVectorToCilm(self.tapers[:, itaper], self.lmax)
+
+    def _info(self):
+        print('Asymmetric window with {:d} tapers'.format(self.nwins))

--- a/pyshtools/shclasses/__init__.py
+++ b/pyshtools/shclasses/__init__.py
@@ -1,0 +1,36 @@
+"""
+pyshtools defines several classes that facilitate the interactive
+examination of geographical gridded data and their associated
+spherical harmonic coefficients. Subclasses are used to handle different
+internal data types and superclasses are used to implement interface
+functions and documentation.
+
+pyshtools class structure:
+
+    SHCoeffs
+        SHRealCoeffs
+        SHComplexCoeffs
+
+    SHGrid
+        DHRealGrid
+        DHComplexGrid
+        GLQRealGrid
+        GLQComplexGrid
+
+    SHWindow
+        SHSymmetricWindow
+        SHAsymmetricWindow
+
+For more information, see the documentation for the top level classes.
+"""
+
+from __future__ import absolute_import as _absolute_import
+from __future__ import division as _division
+from __future__ import print_function as _print_function
+
+from .. import _SHTOOLS as _shtools
+
+from .SHCoeffs import SHCoeffs, SHRealCoeffs, SHComplexCoeffs
+from .SHGrid import (SHGrid, DHRealGrid, DHComplexGrid, GLQRealGrid,
+                     GLQComplexGrid)
+from .SHWindow import SHWindow, SHSymmetricWindow, SHAsymmetricWindow

--- a/src/SHRotateCoef.f95
+++ b/src/SHRotateCoef.f95
@@ -15,7 +15,8 @@ subroutine SHRotateCoef(x, cof, rcof, dj, lmax)
 !   Calling Parameters
 !
 !       IN
-!           x       Array of dimension 3 containing the three Euler angles.
+!           x       Array of dimension 3 containing the three Euler angles
+!                   in radians.
 !           dj      Roation matrix with dimension (lmax+1, lmax+1, lmax+1).
 !           cof     Indexed spherical harmonic coefficients with dimensions
 !                   (2, (lmax+1)*(lmax+2)/2).

--- a/src/SHRotateRealCoef.f95
+++ b/src/SHRotateRealCoef.f95
@@ -37,7 +37,7 @@ subroutine SHRotateRealCoef(cilmrot, cilm, lmax, x, dj)
 !       IN
 !           cilm        Real "geodesy" normalized spherical harmonic 
 !                       coefficients with dimension (2, lmax+1, lmax+1).
-!           x           Array or rotation angles.
+!           x           Array or rotation angles in radians.
 !           lmax        Maximum spherical harmonic degree.
 !           dj          Rotation matrix with dimension (lmax+1, lmax+1, lmax+1).
 !

--- a/src/fdoc/shrotatecoef.md
+++ b/src/fdoc/shrotatecoef.md
@@ -9,8 +9,8 @@ call SHRotateCoef (`x`, `coef`, `rcoef`, `dj`, `lmax`)
 # Parameters
 
 `x` : input, real\*8, dimension(3)
-:   The three Euler angles, alpha, beta, and gamma.
-	
+:   The three Euler angles, alpha, beta, and gamma, in radians.
+
 `coef` : input, real\*8, dimension (2, (`lmax`+1)\*(`lmax`+2)/2)
 :   The input complex spherical harmonic coefficients. This is an indexed array where the real and complex components are given by `coef(1,:)` and `coef(2,:)`, respectively. The functions `SHCilmToCindex` and `SHCindexToCilm` are used to convert to and from indexed and `cilm(2,:,:)` form. The coefficients must correspond to unit-normalized spherical harmonics that possess the Condon-Shortley phase convention.
 
@@ -35,7 +35,7 @@ The rotation of a coordinate system or body can be viewed in two complementary w
 (II) Rotation about the new y axis by beta.
 (III) Rotation about the new z axis by gamma.
 
-`Scheme B:`	
+`Scheme B:`
 
 (I) Rotation about the z axis by gamma.
 (II) Rotation about the initial y axis by beta.
@@ -43,7 +43,7 @@ The rotation of a coordinate system or body can be viewed in two complementary w
 
 The rotations can further be viewed either as a rotation of the coordinate system or the physical body. For a rotation of the coordinate system without rotation of the physical body, use 
 
-`x(alpha, beta, gamma)`. 
+`x(alpha, beta, gamma)`.
 
 For a rotation of the physical body without rotation of the coordinate system, use 
 

--- a/src/fdoc/shrotatecoef.md
+++ b/src/fdoc/shrotatecoef.md
@@ -53,7 +53,6 @@ To perform the inverse transform of `x(alpha, beta, gamma)`, use `x(-gamma, -bet
 
 Note that this routine uses the "y convention", where the second rotation is with respect to the new y axis. If alpha, beta, and gamma were orginally defined in terms of the "x convention", where the second rotation was with respect to the newx axis, the Euler angles according to the y convention would be `alpha_y=alpha_x-pi/2`, `beta_x=beta_y`, and `gamma_y=gamma_x+pi/2`.
 
-This routine is based upon code originally written by Guy Masters, which was then subsequently modified by Mark Simons and myself.
 
 # See also
 

--- a/src/fdoc/shrotaterealcoef.md
+++ b/src/fdoc/shrotaterealcoef.md
@@ -15,7 +15,7 @@ call SHRotateRealCoef (`cilmrot`, `cilm`, `lmax`, `x`, `dj`)
 :   The input real spherical harmonic coefficients. The coefficients must correspond to geodesy 4-pi normalized spherical harmonics that do not possess the Condon-Shortley phase convention.
 
 `x` : input, real\*8, dimension(3)
-:   The three Euler angles, alpha, beta, and gamma.
+:   The three Euler angles, alpha, beta, and gamma, in radians.
 
 `dj` : input, real\*8, dimension (`lmax`+1, `lmax`+1, `lmax`+1)
 :   The rotation matrix `dj(pi/2)`, obtained from a call to `djpi2`.

--- a/src/pydoc/pyshrotatecoef.md
+++ b/src/pydoc/pyshrotatecoef.md
@@ -55,8 +55,6 @@ To perform the inverse transform of `x(alpha, beta, gamma)`, use `x(-gamma, -bet
 
 Note that this routine uses the "y convention", where the second rotation is with respect to the new y axis. If alpha, beta, and gamma were orginally defined in terms of the "x convention", where the second rotation was with respect to the newx axis, the Euler angles according to the y convention would be `alpha_y=alpha_x-pi/2`, `beta_x=beta_y`, and `gamma_y=gamma_x+pi/2`.
 
-This routine is based upon code originally written by Guy Masters, which was then subsequently modified by Mark Simons and myself.
-
 # See also
 
 [djpi2](pydjpi2.html), [shrotaterealcoef](pyshrotaterealcoef.html), [shctor](pyshctor.html), [shrtoc](pyshrtoc.html), [shcilmtocindex](pyshcilmtocindex.html), [shcindextocilm](pyshcindextocilm.html)

--- a/src/pydoc/pyshrotatecoef.md
+++ b/src/pydoc/pyshrotatecoef.md
@@ -14,7 +14,7 @@ Determine the spherical harmonic coefficients of a complex function rotated by t
 # Parameters
 
 `x` : float, dimension(3)
-:   The three Euler angles, alpha, beta, and gamma.
+:   The three Euler angles, alpha, beta, and gamma, in radians.
 
 `coef` : float, dimension (2, (`lmaxin`+1)\*(`lmaxin`+2)/2)
 :   The input complex spherical harmonic coefficients. This is an indexed array where the real and complex components are given by `coef[0,:]` and `coef[1,:]`, respectively. The functions `SHCilmToCindex` and `SHCindexToCilm` are used to convert to and from indexed and `cilm[:,:,:]` form. The coefficients must correspond to unit-normalized spherical harmonics that possess the Condon-Shortley phase convention.

--- a/src/pydoc/pyshrotaterealcoef.md
+++ b/src/pydoc/pyshrotaterealcoef.md
@@ -17,7 +17,7 @@ Determine the spherical harmonic coefficients of a real function rotated by thre
 :   The input real spherical harmonic coefficients. The coefficients must correspond to geodesy 4-pi normalized spherical harmonics that do not possess the Condon-Shortley phase convention.
 
 `x` : float, dimension(3)
-:   The three Euler angles, alpha, beta, and gamma.
+:   The three Euler angles, alpha, beta, and gamma, in radians.
 
 `dj` : float, dimension (`lmaxin2`+1, `lmaxin2`+1, `lmaxin2`+1)
 :   The rotation matrix `dj(pi/2)`, obtained from a call to `djpi2`.

--- a/src/pyshtools.pyf
+++ b/src/pyshtools.pyf
@@ -317,8 +317,8 @@ python module _SHTOOLS
             integer, optional,intent(in) :: csphase = 1
             integer, optional,intent(in),depend(lmax) :: lmax_calc = lmax
             integer, optional,intent(in),intent(hide) :: cilm_d0 = 2
-            integer, optional,intent(in),depend(lmax),intent(hide) :: cilm_d1 = lmax+1
-            integer, optional,intent(in),depend(lmax),intent(hide) :: cilm_d2 = lmax+1
+            integer, optional,intent(in),depend(lmax_calc),intent(hide) :: cilm_d1 = lmax_calc+1
+            integer, optional,intent(in),depend(lmax_calc),intent(hide) :: cilm_d2 = lmax_calc+1
             integer, optional,intent(in),check(shape(gridglq,0)==gridglq_d0),depend(gridglq),intent(hide) :: gridglq_d0=shape(gridglq,0)
             integer, optional,intent(in),check(shape(gridglq,1)==gridglq_d1),depend(gridglq),intent(hide) :: gridglq_d1=shape(gridglq,1)
             integer, optional,intent(in),check(len(zero)>=zero_d0),depend(zero),intent(hide) :: zero_d0=len(zero)
@@ -641,8 +641,8 @@ python module _SHTOOLS
             integer, optional,intent(in) :: csphase=1
             integer, optional,intent(in),depend(n) :: lmax_calc=n/2-1
             integer, optional,intent(in),intent(hide) :: cilm_d0=2
-            integer, optional,intent(in),depend(n),intent(hide) :: cilm_d1=n/2
-            integer, optional,intent(in),depend(n),intent(hide) :: cilm_d2=n/2
+            integer, optional,intent(in),depend(lmax_calc),intent(hide) :: cilm_d1=lmax_calc+1
+            integer, optional,intent(in),depend(lmax_calc),intent(hide) :: cilm_d2=lmax_calc+1
             integer, optional,intent(in),check(shape(grid,0)==grid_d0),depend(grid),intent(hide) :: grid_d0=shape(grid,0)
             integer, optional,intent(in),check(shape(grid,1)==grid_d1),depend(grid),intent(hide) :: grid_d1=shape(grid,1)
         end subroutine SHExpandDH
@@ -1314,8 +1314,8 @@ python module _SHTOOLS
             integer, optional,intent(in) :: csphase = 1
             integer, optional,intent(in),depend(n) :: lmax_calc = n/2-1
             integer, optional,intent(in) :: cilm_d0=2
-            integer, optional,intent(in),depend(n),intent(hide) :: cilm_d1=n/2
-            integer, optional,intent(in),depend(n),intent(hide) :: cilm_d2=n/2
+            integer, optional,intent(in),depend(lmax_calc),intent(hide) :: cilm_d1=lmax_calc+1
+            integer, optional,intent(in),depend(lmax_calc),intent(hide) :: cilm_d2=lmax_calc+1
             integer, optional,intent(in),check(shape(grid,0)==grid_d0),depend(grid),intent(hide) :: grid_d0=shape(grid,0)
             integer, optional,intent(in),check(shape(grid,1)==grid_d1),depend(grid),intent(hide) :: grid_d1=shape(grid,1)
         end subroutine SHExpandDHC
@@ -1365,8 +1365,8 @@ python module _SHTOOLS
             integer, optional,intent(in) :: csphase = 1
             integer, optional,intent(in),depend(lmax) :: lmax_calc = lmax
             integer, optional,intent(in) :: cilm_d0 = 2
-            integer, optional,intent(in),depend(lmax),intent(hide) :: cilm_d1 = lmax+1
-            integer, optional,intent(in),depend(lmax),intent(hide) :: cilm_d2 = lmax+1
+            integer, optional,intent(in),depend(lmax_calc),intent(hide) :: cilm_d1 = lmax_calc+1
+            integer, optional,intent(in),depend(lmax_calc),intent(hide) :: cilm_d2 = lmax_calc+1
             integer, optional,intent(in),depend(gridglq),intent(hide) :: gridglq_d0=shape(gridglq,0)
             integer, optional,intent(in),depend(gridglq),intent(hide) :: gridglq_d1=shape(gridglq,1)
             integer, optional,intent(in),depend(zero),intent(hide) :: zero_d0=len(zero)

--- a/www/history.html
+++ b/www/history.html
@@ -43,6 +43,8 @@
 		<li>Minor modifications to the python example scripts.</li>
 		<li>Minor bug fix to the scripts that create the unix <tt>man</tt> documentation.</li>
 		<li>Added an <tt>info()</tt> method to shtools constants that prints an info string.</li>
+		<li>Add full support for the python classes <tt>SHCoeffs</tt> and <tt>SHGrid</tt>.</li>
+		<li>Change python wrapper so that the output arrays in the <tt>SHExpand</tt> routines correspond to the optional input variable <tt>lmax_calc</tt>.</li>
 		<li>Created an SHTOOLS development fund, funded by bitcoin donations.</li>
 		
 	</ul>

--- a/www/license.html
+++ b/www/license.html
@@ -34,8 +34,7 @@
 
 	<h1>License/Copyright</h1>
 
-	<p>Copyright &copy; 2005-2015, Mark A. Wieczorek<br>
-	Copyright &copy; 2014-2015, Matthias Meschede<br>
+	<p>Copyright &copy; 2005-2016, SHTOOLS<br>
 All rights reserved.</p>
 
 	<p>Redistribution and use in source and binary forms, with or without

--- a/www/pyclasses.html
+++ b/www/pyclasses.html
@@ -32,229 +32,29 @@
 <p class="dir">
 >  <a href="../index.html" class="dir">Home</a> > <a href="documentation.html" class="dir">Documentation</a> > <a href="python-routines.html" class="dir">Python</a></p>
 
-	<h1 class="nomarginbot">SHCoeffs</h1>
-	
-	<table class="pyclass">
+	<h1>Classes</h1>
+
+	<table class="main">
 		<tbody>
 		<tr>
-		<td class="head">Subclasses</td> 
-		</tr>
-	
-		<tr>
-		<td class="left"><tt>SHRealCoefficients</tt></td> 
-		<td class="right">Real spherical harmonic coefficient class.</td>
+		<td class="left"><a href="pyshcoeffs.html"><tt>SHCoeffs</tt></a></td> 
+		<td class="right">Class for working with spherical harmonic coefficients.</td>
 		</tr>
 		
 		<tr>
-		<td class="left"><tt>SHComplexCoefficients</tt></td> 
-		<td class="right">Complex spherical harmonic coefficient class.</td>
-		</tr>
-		
-		<tr>
-		<td class="head">Initialization</td> 
-		</tr>
-	
-		<tr>
-		<td class="left"><tt>x = SHCoeffs.from_array()</tt></td> 
-		<td class="right">Initialize using coefficients from an array.</td>
-		</tr>
-		
-		<tr>
-		<td class="left"><tt>x = SHCoeffs.from_random()</tt></td> 
-		<td class="right">Initialize using random coefficients with a prescribed power spectrum.</td>
-		</tr>
-		
-		<tr>
-		<td class="left"><tt>x = SHCoeffs.from_file()</tt></td> 
-		<td class="right">Initialize using coefficients from a file.</td>
-		</tr>
-		
-		<tr>
-		<td class="head">Class methods</td> 
-		</tr>
-	
-		<tr>
-		<td class="left"><tt>x.get_degrees()</tt></td> 
-		<td class="right">Return the array <tt>[0,...,lmax]</tt> that contains the ordered degrees <tt>l</tt>.</td>
-		</tr>
-		
-		<tr>
-		<td class="left"><tt>x.get_powerperdegree()</tt></td> 
-		<td class="right">Return the power per degree spectrum.</td>
+		<td class="left"><a href="pyshgrid.html"><tt>SHGrid</tt></a></td> 
+		<td class="right">Class for working with global gridded data.</td>
 		</tr>
 
 		<tr>
-		<td class="left"><tt>x.get_powerperband()</tt></td> 
-		<td class="right">Return the power per log<sub>bandwidth</sub> spectrum.</td>
+		<td class="left"><a href="pyshwindow.html"><tt>SHWindow</tt></a></td> 
+		<td class="right">Class for working with localization windows.</td>
 		</tr>
 
-		<tr>
-		<td class="left"><tt>x.get_coeffs()</tt></td> 
-		<td class="right">Return complex or real spherical harmonics coefficients in different normalizations.</td>
-		</tr>
-		
-		<tr>
-		<td class="left"><tt>x.rotate()</tt></td> 
-		<td class="right">Rotate the spherical harmonics coefficients by
-        <tt>[alpha, beta, gamma]</tt>.</td>
-		</tr>
-		
-		<tr>
-		<td class="left"><tt>x.expand()</tt></td> 
-		<td class="right">Evaluate the coefficients on a spherical grid. Available grid types: <br>
-		<tt>kind ='DH1'</tt>: equidistant lat/lon grid with <tt>nlat=nlon</tt><br>
-		<tt>kind ='DH2'</tt>: equidistant lat/lon grid with <tt>2*nlat=nlon</tt><br>
-		<tt>kind ='GLQ'</tt>: Gauss Legendre Grid</td>
-		</tr>
-
-		<tr>
-		<td class="left"><tt>x.plot_powerperdegree()</tt></td> 
-		<td class="right">Plot the power per degree spectrum.</td>
-		</tr>
-		
-		<tr>
-		<td class="left"><tt>x.plot_powerperband()</tt></td> 
-		<td class="right">Plot the power per log<sub>bandwidth</sub>(degree) spectrum.</td>
-		</tr>
-		
-		<tr>
-		<td class="left"><tt>x.make_complex()</tt></td> 
-		<td class="right">Convert the real coefficient class to the complex harmonic coefficient class.</td>
-		</tr>
-		
-		<tr>
-		<td class="left"><tt>x.make_real()</tt></td> 
-		<td class="right">Convert the complex coefficient class to the real harmonic coefficient class.</td>
-		</tr>
-		
 		</tbody>
 	</table>
-	
-	<h1 class="nomarginbot extramargintop">SHGrid</h1>
-	
-	<table class="pyclass">
-		<tbody>
 
-		<tr>
-		<td class="head">Subclasses</td> 
-		</tr>
-	
-		<tr>
-		<td class="left"><tt>DHGrid</tt></td> 
-		<td class="right">Class for <i>Driscoll and Healy</i> (1994) sampled grids.</td>
-		</tr>
-		
-		<tr>
-		<td class="left"><tt>GLQGrid</tt></td> 
-		<td class="right">Class for Gauss-Legendre quadrature sampled grids.</td>
-		</tr>
-		
-		<tr>
-		<td class="head">Initialization</td> 
-		</tr>
-	
-		<tr>
-		<td class="left"><tt>x = SHGrid.from_array()</tt></td> 
-		<td class="right">Initialize using an array.</td>
-		</tr>
-		
-		<tr>
-		<td class="left"><tt>x = SHGrid.from_file()</tt></td> 
-		<td class="right">Initialize using an array from a file.</td>
-		</tr>
-		
-		<tr>
-		<td class="head">Methods</td> 
-		</tr>
-	
-		<tr>
-		<td class="left"><tt>x.get_lats()</tt></td> 
-		<td class="right">Return a vector containing the latitude of each row in the grid.</td>
-		</tr>
-		
-		<tr>
-		<td class="left"><tt>x.get_lons()</tt></td> 
-		<td class="right">Return a vector containing the longitude of each column in the grid.</td>
-		</tr>
-		
-		<tr>
-		<td class="left"><tt>x.plot_rawdata()</tt></td> 
-		<td class="right">Plot the grid using a two dimensional cylindrical projection.</td>
-		</tr>
-		
-		<tr>
-		<td class="left"><tt>x.expand()</tt></td> 
-		<td class="right">Expand the gridded data into spherical harmonics.</td>
-		</tr>
-		
-		</tbody>
-	</table>
-	
-	<h1 class="nomarginbot extramargintop">SHWindow</h1>
-	
-	<table class="pyclass">
-		<tbody>
 
-		<tr>
-		<td class="head">Subclasses</td> 
-		</tr>
-	
-		<tr>
-		<td class="left"><tt>SymmetricWindow</tt></td> 
-		<td class="right">Class for windows concentrated within a spherical cap.</td>
-		</tr>
-		
-		<tr>
-		<td class="left"><tt>AsymmetricWindow</tt></td> 
-		<td class="right">Class for windows concentrated in an arbitrary domain.</td>
-		</tr>
-		
-		<tr>
-		<td class="head">Initialization</td> 
-		</tr>
-	
-		<tr>
-		<td class="left"><tt>x = SHWindow.from_cap()</tt></td> 
-		<td class="right">Construct windows concentrated with a spherical cap.</td>
-		</tr>
-		
-		<tr>
-		<td class="left"><tt>x = SHWindow.from_mask()</tt></td> 
-		<td class="right">Construct windows concentrated with an arbitrary region.</td>
-		</tr>
-		
-		<tr>
-		<td class="head">Methods</td> 
-		</tr>
-	
-		<tr>
-		<td class="left"><tt>x.plot()</tt></td> 
-		<td class="right">Plot the best concentrated windows.</td>
-		</tr>
-		
-		<tr>
-		<td class="left"><tt>x.get_spectrum()</tt></td> 
-		<td class="right">Return the power spectrum of the localization windows.</td>
-		</tr>
-		
-		<tr>
-		<td class="left"><tt>x.get_couplingmatrix()</tt></td> 
-		<td class="right">Return the coupling matrix of the first <tt>nwin</tt> tapers.</td>
-		</tr>
-		
-		<tr>
-		<td class="left"><tt>x.plot_couplingmatrix()</tt></td> 
-		<td class="right">Plot the coupling strength of the localization windows.</td>
-		</tr>
-		
-<tr>
-		<td class="left"><tt>x.info()</tt></td> 
-		<td class="right">Print meta information about the tapers.</td>
-		</tr>
-		
-		</tbody>
-	</table>
-	
 <br>
 
 <p class="dir">

--- a/www/pyshcoeffs.html
+++ b/www/pyshcoeffs.html
@@ -1,0 +1,186 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+        "http://www.w3.org/TR/html4/strict.dtd">
+
+<html>
+
+<head>
+	<title>SHTOOLS - Python SHCoeffs Class</title>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<link rel="stylesheet" type="text/css" href="css/sh.css">
+	<link rel="shortcut icon" type="image/vnd.microsoft.icon" href="images/favicon.ico">
+	<link rel="icon" type="image/vnd.microsoft.icon" href="images/favicon.ico">
+	<meta name="description" content="Python classes defined by SHTOOLS.">
+</head>
+
+<body>
+
+<div class="main">
+
+	<p class="centeredimage"><img src="images/logo.jpg" width=894 height=135 alt="SHTOOLS --- Tools for working with spherical harmonics"></p>
+    	
+	<table class="menu">
+		<tbody>
+			<tr>
+				<td><a href="http://shtools.ipgp.fr/">HOME</a></td>
+				<td><a href="https://github.com/SHTOOLS/SHTOOLS/releases">DOWNLOAD</a></td>
+				<td class="selected"><a href="documentation.html">DOCUMENTATION</a></td>
+				<td><a href="faq.html">FAQ</a> </td>
+			</tr>
+		</tbody>
+	</table>
+
+<p class="dir">
+>  <a href="../index.html" class="dir">Home</a> > <a href="documentation.html" class="dir">Documentation</a> > <a href="python-routines.html" class="dir">Python</a> > <a href="pyclasses.html" class="dir">Classes</a></p>
+
+	<h1 class="nomarginbot">SHCoeffs</h1>
+	
+	<table class="pyclass">
+		<tbody>
+		<tr>
+		<td class="head">Subclasses</td> 
+		</tr>
+	
+		<tr>
+		<td class="left"><tt>SHRealCoefficients</tt></td> 
+		<td class="right">Real spherical harmonic coefficient class.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>SHComplexCoefficients</tt></td> 
+		<td class="right">Complex spherical harmonic coefficient class.</td>
+		</tr>
+		
+		<tr>
+		<td class="head">Initialization</td> 
+		</tr>
+	
+		<tr>
+		<td class="left"><tt>x = SHCoeffs.from_array()</tt></td> 
+		<td class="right">Initialize using coefficients from an array.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>x = SHCoeffs.from_random()</tt></td> 
+		<td class="right">Initialize using random coefficients with a prescribed power spectrum.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>x = SHCoeffs.from_file()</tt></td> 
+		<td class="right">Initialize using coefficients from a file.</td>
+		</tr>
+		
+		<tr>
+		<td class="head">Class attributes</td> 
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>lmax</tt></td> 
+		<td class="right">The maximum spherical harmonic degree of the coefficients.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>coeffs</tt></td> 
+		<td class="right">The raw coefficients with the specified normalization and phase conventions.</td>
+		</tr>
+
+		<tr>
+		<td class="left"><tt>normalization</tt></td> 
+		<td class="right">The normalization of the coefficients: <tt>'4pi'</tt>, <tt>'ortho'</tt>, or <tt>'schmidt'</tt>.</td>
+		</tr>
+
+		<tr>
+		<td class="left"><tt>csphase</tt></td> 
+		<td class="right">Defines whether the Condon-Shortley phase is used (<tt>1</tt>) or not (<tt>-1<tt>).</td>
+		</tr>
+
+		<tr>
+		<td class="left"><tt>mask</tt></td> 
+		<td class="right">A boolean mask that is <tt>True</tt> for the permissible values of degree <tt>l</tt> and order <tt>m</tt>.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>kind</tt></td> 
+		<td class="right">The coefficient data type: either <tt>'complex'</tt> or <tt>'real'</tt>.</td>
+		</tr>
+
+		<tr>
+		<td class="head">Class methods</td> 
+		</tr>
+	
+		<tr>
+		<td class="left"><tt>get_degrees()</tt></td> 
+		<td class="right">Return an array listing the spherical harmonic degrees from <tt>0</tt> to <tt>lmax</tt>.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>get_powerperdegree()</tt></td> 
+		<td class="right">Return an array with the power per degree spectrum.</td>
+		</tr>
+
+		<tr>
+		<td class="left"><tt>get_powerperband()</tt></td> 
+		<td class="right">Return an array with the power per log<sub>bandwidth</sub> spectrum.</td>
+		</tr>
+
+		<tr>
+		<td class="left"><tt>get_coeffs()</tt></td> 
+		<td class="right">Return an array of spherical harmonics coefficients with a different normalization convention.</td>
+		</tr>
+
+		<tr>
+		<td class="left"><tt>rotate()</tt></td> 
+		<td class="right">Rotate the coordinate system used to express the spherical harmonics coefficients and return a new class instance.</td>
+		</tr>
+
+		<tr>
+		<td class="left"><tt>convert()</tt></td> 
+		<td class="right">Convert the spherical harmonic coefficients to a different normalization and return a new class instance.</td>
+		</tr>
+
+		<tr>
+		<td class="left"><tt>expand()</tt></td> 
+		<td class="right">Evaluate the coefficients on a spherical grid and return a new SHGrid class instance.</td>
+		</tr>
+
+		<tr>
+		<td class="left"><tt>make_complex()</tt></td> 
+		<td class="right">Convert a complex <tt>SHCoeffs</tt> class instance to a real class instance.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>make_real()</tt></td> 
+		<td class="right">Convert a real <tt>SHCoeffs</tt> class instance to a complex class instance.</td>
+		</tr>
+
+		<tr>
+		<td class="left"><tt>plot_powerperdegree()</tt></td> 
+		<td class="right">Plot the power per degree spectrum.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>plot_powerperband()</tt></td> 
+		<td class="right">Plot the power per log<sub>bandwidth</sub>(degree) spectrum.</td>
+		</tr>
+
+		</tbody>
+	</table>
+	
+<br>
+
+<p class="dir">
+>  <a href="../index.html" class="dir">Home</a> > <a href="documentation.html" class="dir">Documentation</a> > <a href="python-routines.html" class="dir">Python</a> > <a href="pyclasses.html" class="dir">Classes</a></p>
+
+	<table class="footer2" summary = "SHTOOLS; Fortran and Python spherical harmonic transform software package">
+	<tbody>
+		<tr>
+			<td class="c1"><a href="http://www.ipgp.fr/">Institut de Physique du Globe de Paris</a></td>
+			<td class="c2"><a href="http://www.sorbonne-paris-cite.fr/index.php/en">University of Sorbonne Paris Cité</a></td>
+			<td class="c3">&copy; 2016 <a href="https://github.com/SHTOOLS">SHTOOLS</a></td>
+		</tr>
+	</tbody>
+	</table>
+	
+</div>
+
+</body>
+</html>

--- a/www/pyshcoeffs.html
+++ b/www/pyshcoeffs.html
@@ -41,12 +41,12 @@
 		</tr>
 	
 		<tr>
-		<td class="left"><tt>SHRealCoefficients</tt></td> 
+		<td class="left"><tt>SHRealCoeffs</tt></td> 
 		<td class="right">Real spherical harmonic coefficient class.</td>
 		</tr>
 		
 		<tr>
-		<td class="left"><tt>SHComplexCoefficients</tt></td> 
+		<td class="left"><tt>SHComplexCoeffs</tt></td> 
 		<td class="right">Complex spherical harmonic coefficient class.</td>
 		</tr>
 		

--- a/www/pyshgrid.html
+++ b/www/pyshgrid.html
@@ -1,0 +1,168 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+        "http://www.w3.org/TR/html4/strict.dtd">
+
+<html>
+
+<head>
+	<title>SHTOOLS - Python SHGrid Class</title>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<link rel="stylesheet" type="text/css" href="css/sh.css">
+	<link rel="shortcut icon" type="image/vnd.microsoft.icon" href="images/favicon.ico">
+	<link rel="icon" type="image/vnd.microsoft.icon" href="images/favicon.ico">
+	<meta name="description" content="Python classes defined by SHTOOLS.">
+</head>
+
+<body>
+
+<div class="main">
+
+	<p class="centeredimage"><img src="images/logo.jpg" width=894 height=135 alt="SHTOOLS --- Tools for working with spherical harmonics"></p>
+    	
+	<table class="menu">
+		<tbody>
+			<tr>
+				<td><a href="http://shtools.ipgp.fr/">HOME</a></td>
+				<td><a href="https://github.com/SHTOOLS/SHTOOLS/releases">DOWNLOAD</a></td>
+				<td class="selected"><a href="documentation.html">DOCUMENTATION</a></td>
+				<td><a href="faq.html">FAQ</a> </td>
+			</tr>
+		</tbody>
+	</table>
+
+<p class="dir">
+>  <a href="../index.html" class="dir">Home</a> > <a href="documentation.html" class="dir">Documentation</a> > <a href="python-routines.html" class="dir">Python</a> > <a href="pyclasses.html" class="dir">Classes</a></p>
+	
+	<h1 class="nomarginbot extramargintop">SHGrid</h1>
+	
+	<table class="pyclass">
+		<tbody>
+
+		<tr>
+		<td class="head">Subclasses</td> 
+		</tr>
+	
+		<tr>
+		<td class="left"><tt>DHRealGrid</tt></td> 
+		<td class="right">Class for real <i>Driscoll and Healy</i> (1994) sampled grids.</td>
+		</tr>
+
+		<tr>
+		<td class="left"><tt>DHComplexGrid</tt></td> 
+		<td class="right">Class for complex <i>Driscoll and Healy</i> (1994) sampled grids.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>GLQRealGrid</tt></td> 
+		<td class="right">Class for real Gauss-Legendre quadrature sampled grids.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>GLQComplexGrid</tt></td> 
+		<td class="right">Class for complex Gauss-Legendre quadrature sampled grids.</td>
+		</tr>
+		
+		<tr>
+		<td class="head">Initialization</td> 
+		</tr>
+	
+		<tr>
+		<td class="left"><tt>x = SHGrid.from_array()</tt></td> 
+		<td class="right">Initialize using an array.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>x = SHGrid.from_file()</tt></td> 
+		<td class="right">Initialize using an array from a file.</td>
+		</tr>
+
+		<tr>
+		<td class="head">Class attributes</td> 
+		</tr>
+	
+		<tr>
+		<td class="left"><tt>data</tt></td> 
+		<td class="right">Gridded array of the data.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>nlat, nlon</tt></td> 
+		<td class="right">The number of latitude and longitude bands in the grid.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>lmax</tt></td> 
+		<td class="right">The maximum spherical harmonic degree that can be resolved by the grid sampling.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>sampling</tt></td> 
+		<td class="right">For Driscoll and Healy grids, the longitudinal sampling of the grid. Either <tt>nlong = nlat</tt> or <tt>nlong = 2 * nlat</tt>.</td>
+		</tr>
+
+		<tr>
+		<td class="left"><tt>kind</tt></td> 
+		<td class="right">Either <tt>'complex'</tt> or <tt>'real'</tt> for the data type.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>grid</tt></td> 
+		<td class="right">Either <tt>'DH'</tt> or <tt>'GLQ'</tt> for Driscoll and Healy grids or Gauss-Legendre Quadrature grids.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>zeros</tt></td> 
+		<td class="right">The cos(colatitude) nodes used with Gauss-Legendre Quadrature grids. Default is <tt>None</tt>.</td>
+		</tr>
+
+		<tr>
+		<td class="left"><tt>weights</tt></td> 
+		<td class="right">The latitudinal weights used with Gauss-Legendre Quadrature grids. Default is <tt>None</tt>.</td>
+		</tr>
+
+		<tr>
+		<td class="head">Class methods</td> 
+		</tr>
+	
+		<tr>
+		<td class="left"><tt>get_lats()</tt></td> 
+		<td class="right">Return a vector containing the latitudes of each row of the gridded data.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>get_lons()</tt></td> 
+		<td class="right">Return a vector containing the longitudes of each column of the gridded data.</td>
+		</tr>
+
+		<tr>
+		<td class="left"><tt>expand()</tt></td> 
+		<td class="right">Expand the grid into spherical harmonics.</td>
+		</tr>
+
+		<tr>
+		<td class="left"><tt>plot_rawdata()</tt></td> 
+		<td class="right">Plot the raw data using a simple cylindrical projection.</td>
+		</tr>
+		
+		
+		</tbody>
+	</table>
+
+<br>
+
+<p class="dir">
+>  <a href="../index.html" class="dir">Home</a> > <a href="documentation.html" class="dir">Documentation</a> > <a href="python-routines.html" class="dir">Python</a> > <a href="pyclasses.html" class="dir">Classes</a></p>
+
+	<table class="footer2" summary = "SHTOOLS; Fortran and Python spherical harmonic transform software package">
+	<tbody>
+		<tr>
+			<td class="c1"><a href="http://www.ipgp.fr/">Institut de Physique du Globe de Paris</a></td>
+			<td class="c2"><a href="http://www.sorbonne-paris-cite.fr/index.php/en">University of Sorbonne Paris Cité</a></td>
+			<td class="c3">&copy; 2016 <a href="https://github.com/SHTOOLS">SHTOOLS</a></td>
+		</tr>
+	</tbody>
+	</table>
+	
+</div>
+
+</body>
+</html>

--- a/www/pyshwindow.html
+++ b/www/pyshwindow.html
@@ -1,0 +1,118 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+        "http://www.w3.org/TR/html4/strict.dtd">
+
+<html>
+
+<head>
+	<title>SHTOOLS - Python SHWindow Class</title>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<link rel="stylesheet" type="text/css" href="css/sh.css">
+	<link rel="shortcut icon" type="image/vnd.microsoft.icon" href="images/favicon.ico">
+	<link rel="icon" type="image/vnd.microsoft.icon" href="images/favicon.ico">
+	<meta name="description" content="Python classes defined by SHTOOLS.">
+</head>
+
+<body>
+
+<div class="main">
+
+	<p class="centeredimage"><img src="images/logo.jpg" width=894 height=135 alt="SHTOOLS --- Tools for working with spherical harmonics"></p>
+    	
+	<table class="menu">
+		<tbody>
+			<tr>
+				<td><a href="http://shtools.ipgp.fr/">HOME</a></td>
+				<td><a href="https://github.com/SHTOOLS/SHTOOLS/releases">DOWNLOAD</a></td>
+				<td class="selected"><a href="documentation.html">DOCUMENTATION</a></td>
+				<td><a href="faq.html">FAQ</a> </td>
+			</tr>
+		</tbody>
+	</table>
+
+<p class="dir">
+>  <a href="../index.html" class="dir">Home</a> > <a href="documentation.html" class="dir">Documentation</a> > <a href="python-routines.html" class="dir">Python</a> > <a href="pyclasses.html" class="dir">Classes</a></p>
+
+	<h1 class="nomarginbot extramargintop">SHWindow</h1>
+	
+	<table class="pyclass">
+		<tbody>
+
+		<tr>
+		<td class="head">Subclasses</td> 
+		</tr>
+	
+		<tr>
+		<td class="left"><tt>SymmetricWindow</tt></td> 
+		<td class="right">Class for windows concentrated within a spherical cap.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>AsymmetricWindow</tt></td> 
+		<td class="right">Class for windows concentrated in an arbitrary domain.</td>
+		</tr>
+		
+		<tr>
+		<td class="head">Initialization</td> 
+		</tr>
+	
+		<tr>
+		<td class="left"><tt>x = SHWindow.from_cap()</tt></td> 
+		<td class="right">Construct windows concentrated with a spherical cap.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>x = SHWindow.from_mask()</tt></td> 
+		<td class="right">Construct windows concentrated with an arbitrary region.</td>
+		</tr>
+		
+		<tr>
+		<td class="head">Methods</td> 
+		</tr>
+	
+		<tr>
+		<td class="left"><tt>plot()</tt></td> 
+		<td class="right">Plot the best concentrated windows.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>get_spectrum()</tt></td> 
+		<td class="right">Return the power spectrum of the localization windows.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>get_couplingmatrix()</tt></td> 
+		<td class="right">Return the coupling matrix of the first <tt>nwin</tt> tapers.</td>
+		</tr>
+		
+		<tr>
+		<td class="left"><tt>plot_couplingmatrix()</tt></td> 
+		<td class="right">Plot the coupling strength of the localization windows.</td>
+		</tr>
+		
+<tr>
+		<td class="left"><tt>info()</tt></td> 
+		<td class="right">Print meta information about the tapers.</td>
+		</tr>
+		
+		</tbody>
+	</table>
+	
+<br>
+
+<p class="dir">
+>  <a href="../index.html" class="dir">Home</a> > <a href="documentation.html" class="dir">Documentation</a> > <a href="python-routines.html" class="dir">Python</a> > <a href="pyclasses.html" class="dir">Classes</a></p>
+
+	<table class="footer2" summary = "SHTOOLS; Fortran and Python spherical harmonic transform software package">
+	<tbody>
+		<tr>
+			<td class="c1"><a href="http://www.ipgp.fr/">Institut de Physique du Globe de Paris</a></td>
+			<td class="c2"><a href="http://www.sorbonne-paris-cite.fr/index.php/en">University of Sorbonne Paris Cité</a></td>
+			<td class="c3">&copy; 2016 <a href="https://github.com/SHTOOLS">SHTOOLS</a></td>
+		</tr>
+	</tbody>
+	</table>
+	
+</div>
+
+</body>
+</html>

--- a/www/pyshwindow.html
+++ b/www/pyshwindow.html
@@ -42,12 +42,12 @@
 		</tr>
 	
 		<tr>
-		<td class="left"><tt>SymmetricWindow</tt></td> 
+		<td class="left"><tt>SHSymmetricWindow</tt></td> 
 		<td class="right">Class for windows concentrated within a spherical cap.</td>
 		</tr>
 		
 		<tr>
-		<td class="left"><tt>AsymmetricWindow</tt></td> 
+		<td class="left"><tt>SHAsymmetricWindow</tt></td> 
 		<td class="right">Class for windows concentrated in an arbitrary domain.</td>
 		</tr>
 		


### PR DESCRIPTION
This pull request makes a lot of modifications. It would be great if someone could look this over and give me comments (especially if you think I screwed up the init file). Otherwise, I will merge this tomorrow.

Please note that the classes file is now huge (>1 kLOC), so I will probably end up cutting this into three files, and placing them in a subdirectory/submodule later.

Major changes:
---------------
* Added full functionality to the pyshtools classes SHCoeffs and SHGrid (I have not touched the SHWindow class yet). This includes allowing to specify the normalization and csphase for the raw coefficients and adds another method `convert()` that returns a new instance of SHCoeffs with a different normalization convention. There were a bunch of minor bugs in the previous code (the power spectrum used to initial from_random was off by a factor of 1/sqrt(2l+1), and get_lats/lons were not exactly how the grids were specified. There were also some runtime errors that were just never tested as well). 

* I re-organized the __init__ file to be (what I think is) more logical. I removed the load_documentation function as this is only called once by init itself, and placed the shtools imports at the top of the file.

Minor changes
---------------
* I changed the python wrapper functions for the SHExpand routines so that the output coefficients were dimensioned according to the option variable lmax_calc, instead of lmax.

* There are some minor modifications to other files, particularly the web documentation.

