### PR TITLE
Remove future imports from most pyshtools files.

### DIFF
--- a/pyshtools/__init__.py
+++ b/pyshtools/__init__.py
@@ -34,6 +34,8 @@ and the GitHub project page at
    https://github.com/SHTOOLS/SHTOOLS
 """
 
+from __future__ import absolute_import as _absolute_import
+from __future__ import division as _division
 from __future__ import print_function as _print_function
 
 __version__ = '3.3-beta'

--- a/pyshtools/__init__.py
+++ b/pyshtools/__init__.py
@@ -12,6 +12,7 @@ main namespace:
 
     SHCoeffs - A high level class for spherical harmonic coefficients.
     SHGrid - A high level classes for global grids.
+    SHWindow - A high level classes for localization windows.
     shclasses - All pyshtools classes and subclasses.
     shtools - All pyshtools routines.
     legendre - Legendre functions.
@@ -33,8 +34,6 @@ and the GitHub project page at
    https://github.com/SHTOOLS/SHTOOLS
 """
 
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
 from __future__ import print_function as _print_function
 
 __version__ = '3.3-beta'

--- a/pyshtools/__init__.py
+++ b/pyshtools/__init__.py
@@ -103,7 +103,13 @@ for _name in _constant.planetsconstants.__dict__.keys():
         print(msg)
 
 
+# ---- Rewrite shtools doc string ----
+shtools.__doc__ = (
+    'pyshtools submodule that includes all pyshtools routines, with the\n' +
+    'exception of shclasses.')
+
+
 # ---- Define __all__ for use with: from pyshtools import * ----
 __all__ = ['constant', 'shclasses', 'SHCoeffs', 'SHGrid', 'SHWindow',
-           'legendre', 'expand', 'io', 'spectralanalysis',
+           'legendre', 'expand', 'shio', 'spectralanalysis',
            'localizedspectralanalysis', 'rotate', 'gravmag', 'other']

--- a/pyshtools/constant.py
+++ b/pyshtools/constant.py
@@ -6,8 +6,6 @@ To view information about a pyshtools constant, use
     pyshtools.constant.constantname.info()
 """
 
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
 from __future__ import print_function as _print_function
 
 import numpy as np

--- a/pyshtools/constant.py
+++ b/pyshtools/constant.py
@@ -6,6 +6,8 @@ To view information about a pyshtools constant, use
     pyshtools.constant.constantname.info()
 """
 
+from __future__ import absolute_import as _absolute_import
+from __future__ import division as _division
 from __future__ import print_function as _print_function
 
 import numpy as np

--- a/pyshtools/expand.py
+++ b/pyshtools/expand.py
@@ -43,11 +43,17 @@ SHMultiply    Multiply two functions and determine the spherical harmonic
               coefficients of the resulting function.
 """
 
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
-from ._SHTOOLS import SHExpandDH, MakeGridDH, SHExpandDHC, MakeGridDHC
-from ._SHTOOLS import SHGLQ, SHExpandGLQ, MakeGridGLQ, SHExpandGLQC
-from ._SHTOOLS import MakeGridGLQC, GLQGridCoord, SHExpandLSQ, MakeGrid2D
-from ._SHTOOLS import MakeGridPoint, SHMultiply
+from ._SHTOOLS import SHExpandDH
+from ._SHTOOLS import MakeGridDH
+from ._SHTOOLS import SHExpandDHC
+from ._SHTOOLS import MakeGridDHC
+from ._SHTOOLS import SHGLQ
+from ._SHTOOLS import SHExpandGLQ
+from ._SHTOOLS import MakeGridGLQ
+from ._SHTOOLS import SHExpandGLQC
+from ._SHTOOLS import MakeGridGLQC
+from ._SHTOOLS import GLQGridCoord
+from ._SHTOOLS import SHExpandLSQ
+from ._SHTOOLS import MakeGrid2D
+from ._SHTOOLS import MakeGridPoint
+from ._SHTOOLS import SHMultiply

--- a/pyshtools/expand.py
+++ b/pyshtools/expand.py
@@ -43,6 +43,10 @@ SHMultiply    Multiply two functions and determine the spherical harmonic
               coefficients of the resulting function.
 """
 
+from __future__ import absolute_import as _absolute_import
+from __future__ import division as _division
+from __future__ import print_function as _print_function
+
 from ._SHTOOLS import SHExpandDH
 from ._SHTOOLS import MakeGridDH
 from ._SHTOOLS import SHExpandDHC

--- a/pyshtools/gravmag.py
+++ b/pyshtools/gravmag.py
@@ -56,6 +56,10 @@ SHMagPowerL         Compute the power of the magnetic field for a single
                     potential spherical harmonic coefficients.
 """
 
+from __future__ import absolute_import as _absolute_import
+from __future__ import division as _division
+from __future__ import print_function as _print_function
+
 from ._SHTOOLS import MakeGravGridDH
 from ._SHTOOLS import MakeGravGradGridDH
 from ._SHTOOLS import MakeGeoidGridDH

--- a/pyshtools/gravmag.py
+++ b/pyshtools/gravmag.py
@@ -56,12 +56,18 @@ SHMagPowerL         Compute the power of the magnetic field for a single
                     potential spherical harmonic coefficients.
 """
 
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
-from ._SHTOOLS import MakeGravGridDH, MakeGravGradGridDH, MakeGeoidGridDH
-from ._SHTOOLS import CilmPlusDH, CilmMinusDH, CilmPlusRhoHDH, CilmMinusRhoHDH
-from ._SHTOOLS import BAtoHilmDH, BAtoHilmRhoHDH, DownContFilterMA
-from ._SHTOOLS import DownContFilterMC, NormalGravity, MakeMagGridDH
-from ._SHTOOLS import SHMagPowerSpectrum, SHMagPowerL
+from ._SHTOOLS import MakeGravGridDH
+from ._SHTOOLS import MakeGravGradGridDH
+from ._SHTOOLS import MakeGeoidGridDH
+from ._SHTOOLS import CilmPlusDH
+from ._SHTOOLS import CilmMinusDH
+from ._SHTOOLS import CilmPlusRhoHDH
+from ._SHTOOLS import CilmMinusRhoHDH
+from ._SHTOOLS import BAtoHilmDH
+from ._SHTOOLS import BAtoHilmRhoHDH
+from ._SHTOOLS import DownContFilterMA
+from ._SHTOOLS import DownContFilterMC
+from ._SHTOOLS import NormalGravity
+from ._SHTOOLS import MakeMagGridDH
+from ._SHTOOLS import SHMagPowerSpectrum
+from ._SHTOOLS import SHMagPowerL

--- a/pyshtools/legendre.py
+++ b/pyshtools/legendre.py
@@ -72,4 +72,4 @@ from ._SHTOOLS import PLegendre_d1
 # --- equivalent that uses different indexing conventions.
 # ---------------------------------------------------------------------
 def PlmIndex(l, m):
-    return int((l * (l + 1)) // 2) + m
+    return (l * (l + 1)) // 2 + m

--- a/pyshtools/legendre.py
+++ b/pyshtools/legendre.py
@@ -45,6 +45,10 @@ PlmIndex      Compute the index of an array of Legendre function corresponding
               to degree L and angular order M.
 """
 
+from __future__ import absolute_import as _absolute_import
+from __future__ import division as _division
+from __future__ import print_function as _print_function
+
 from ._SHTOOLS import PlmBar
 from ._SHTOOLS import PlmBar_d1
 from ._SHTOOLS import PlBar

--- a/pyshtools/legendre.py
+++ b/pyshtools/legendre.py
@@ -45,14 +45,22 @@ PlmIndex      Compute the index of an array of Legendre function corresponding
               to degree L and angular order M.
 """
 
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
-from ._SHTOOLS import PlmBar, PlmBar_d1, PlBar, PlBar_d1
-from ._SHTOOLS import PlmON, PlmON_d1, PlON, PlON_d1
-from ._SHTOOLS import PlmSchmidt, PlmSchmidt_d1, PlSchmidt, PlSchmidt_d1
-from ._SHTOOLS import PLegendreA, PLegendreA_d1, PLegendre, PLegendre_d1
+from ._SHTOOLS import PlmBar
+from ._SHTOOLS import PlmBar_d1
+from ._SHTOOLS import PlBar
+from ._SHTOOLS import PlBar_d1
+from ._SHTOOLS import PlmON
+from ._SHTOOLS import PlmON_d1
+from ._SHTOOLS import PlON
+from ._SHTOOLS import PlON_d1
+from ._SHTOOLS import PlmSchmidt
+from ._SHTOOLS import PlmSchmidt_d1
+from ._SHTOOLS import PlSchmidt
+from ._SHTOOLS import PlSchmidt_d1
+from ._SHTOOLS import PLegendreA
+from ._SHTOOLS import PLegendreA_d1
+from ._SHTOOLS import PLegendre
+from ._SHTOOLS import PLegendre_d1
 
 
 # ---------------------------------------------------------------------
@@ -60,4 +68,4 @@ from ._SHTOOLS import PLegendreA, PLegendreA_d1, PLegendre, PLegendre_d1
 # --- equivalent that uses different indexing conventions.
 # ---------------------------------------------------------------------
 def PlmIndex(l, m):
-    return (l * (l + 1)) // 2 + m
+    return int((l * (l + 1)) // 2) + m

--- a/pyshtools/localizedspectralanalysis.py
+++ b/pyshtools/localizedspectralanalysis.py
@@ -56,13 +56,22 @@ SphericalCapCoef       Calculate the spherical harmonic coefficients of a
                        spherical cap.
 """
 
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
-from ._SHTOOLS import SHMultiTaperSE, SHMultiTaperCSE, SHLocalizedAdmitCorr
-from ._SHTOOLS import SHReturnTapers, SHReturnTapersM, ComputeDm, ComputeDG82
-from ._SHTOOLS import SHFindLWin, SHBiasK, SHMTCouplingMatrix, SHBiasAdmitCorr
-from ._SHTOOLS import SHMTDebias, SHMTVarOpt, SHSjkPG
-from ._SHTOOLS import SHReturnTapersMap, ComputeDMap, Curve2Mask, SHBias
+from ._SHTOOLS import SHMultiTaperSE
+from ._SHTOOLS import SHMultiTaperCSE
+from ._SHTOOLS import SHLocalizedAdmitCorr
+from ._SHTOOLS import SHReturnTapers
+from ._SHTOOLS import SHReturnTapersM
+from ._SHTOOLS import ComputeDm
+from ._SHTOOLS import ComputeDG82
+from ._SHTOOLS import SHFindLWin
+from ._SHTOOLS import SHBiasK
+from ._SHTOOLS import SHMTCouplingMatrix
+from ._SHTOOLS import SHBiasAdmitCorr
+from ._SHTOOLS import SHMTDebias
+from ._SHTOOLS import SHMTVarOpt
+from ._SHTOOLS import SHSjkPG
+from ._SHTOOLS import SHReturnTapersMap
+from ._SHTOOLS import ComputeDMap
+from ._SHTOOLS import Curve2Mask
+from ._SHTOOLS import SHBias
 from ._SHTOOLS import SphericalCapCoef

--- a/pyshtools/localizedspectralanalysis.py
+++ b/pyshtools/localizedspectralanalysis.py
@@ -56,6 +56,10 @@ SphericalCapCoef       Calculate the spherical harmonic coefficients of a
                        spherical cap.
 """
 
+from __future__ import absolute_import as _absolute_import
+from __future__ import division as _division
+from __future__ import print_function as _print_function
+
 from ._SHTOOLS import SHMultiTaperSE
 from ._SHTOOLS import SHMultiTaperCSE
 from ._SHTOOLS import SHLocalizedAdmitCorr

--- a/pyshtools/make_docs.py
+++ b/pyshtools/make_docs.py
@@ -4,7 +4,9 @@ customized markdown files. The processed documentation is saved as ascii text
 files which are loaded on runtime and replace the __doc__ string of the f2py
 wrapped functions.
 """
-from __future__ import print_function
+from __future__ import absolute_import as _absolute_import
+from __future__ import division as _division
+from __future__ import print_function as _print_function
 
 import sys
 import os

--- a/pyshtools/make_docs.py
+++ b/pyshtools/make_docs.py
@@ -4,7 +4,7 @@ customized markdown files. The processed documentation is saved as ascii text
 files which are loaded on runtime and replace the __doc__ string of the f2py
 wrapped functions.
 """
-from __future__ import absolute_import, division, print_function
+from __future__ import print_function
 
 import sys
 import os
@@ -27,28 +27,31 @@ def main():
     for name, func in _SHTOOLS.__dict__.items():
         if callable(func):
             try:
-                #---- process and load documentation
-                # read md file documentation:
-                fname_mddoc = os.path.join(mddocfolder, 'py' + name.lower() + '.md')
+                # ---- process and load documentation ----
+                # ---- read md file documentation: ----
+                fname_mddoc = os.path.join(mddocfolder, 'py' +
+                                           name.lower() + '.md')
                 if (os.path.isfile(fname_mddoc)):
                     docstring = process_mddoc(fname_mddoc)
-                    #---- save combined docstring in the pydoc folder--
-                    fname_pydoc = os.path.join(pydocfolder, name.lower() + '.doc')
+                    # ---- save combined docstring in the pydoc folder ----
+                    fname_pydoc = os.path.join(pydocfolder, name.lower() +
+                                               '.doc')
                     with open(fname_pydoc, 'w') as pydocfile:
                         pydocfile.write(docstring)
 
             except IOError as msg:
                 print(msg)
 
-    #---- loop through functions that are defined in python ----
-    pyfunctions = ['PlmIndex','YilmIndexVector']
+    # ---- loop through functions that are defined in python ----
+    pyfunctions = ['PlmIndex', 'YilmIndexVector']
     for name in pyfunctions:
         try:
-            #---- process and load documentation
+            # ---- process and load documentation
             # read md file documentation:
-            fname_mddoc = os.path.join(mddocfolder, 'py' + name.lower() + '.md')
+            fname_mddoc = os.path.join(mddocfolder, 'py' + name.lower() +
+                                       '.md')
             docstring = process_mddoc(fname_mddoc)
-            #---- save combined docstring in the pydoc folder--
+            # ---- save combined docstring in the pydoc folder--
             fname_pydoc = os.path.join(pydocfolder, name.lower() + '.doc')
             with open(fname_pydoc, 'w') as pydocfile:
                 pydocfile.write(docstring)
@@ -56,88 +59,95 @@ def main():
         except IOError as msg:
             print(msg)
 
-    #---- loop through the f2py constants and make docstrings ----
+    # ---- loop through the f2py constants and make docstrings ----
     for name, value in _constant.planetsconstants.__dict__.items():
         try:
-            #---- read md file documentation:
-            fname_mddoc = os.path.join(mddocfolder, 'constant_' + name.lower() + '.md')
+            # ---- read md file documentation:
+            fname_mddoc = os.path.join(mddocfolder, 'constant_' +
+                                       name.lower() + '.md')
             docstring = process_mddoc(fname_mddoc)
 
-            #-- save docstring in the pydoc folder--
-            fname_pydoc = os.path.join(pydocfolder, 'constant_' + name.lower() + '.doc')
+            # ---- save docstring in the pydoc folder----
+            fname_pydoc = os.path.join(pydocfolder, 'constant_' +
+                                       name.lower() + '.doc')
             with open(fname_pydoc, 'w') as pydocfile:
                 pydocfile.write(docstring)
 
         except IOError as msg:
             print(msg)
 
-#===== PROCESS MD DOCUMENTATION FILE ====
+
+# ===== PROCESS MD DOCUMENTATION FILE ====
 def process_mddoc(fname_mddoc):
-    #---- md file search patterns ----
+    # ---- md file search patterns ----
     retail = re.compile('# See (.*)', re.DOTALL)
     reh2 = re.compile('## (.*?)\n', re.DOTALL)
     reh1 = re.compile('\A# (.*?)\n', re.DOTALL)
     reh1b = re.compile('\n# (.*?)\n', re.DOTALL)
     recode = re.compile('`(.*?)`', re.DOTALL)
     restaresc = re.compile(r'(\\\*)', re.DOTALL)
-    #rebold = re.compile('(?![\])[*](.*?)(?![\])[*]',re.DOTALL)
+    # rebold = re.compile('(?![\])[*](.*?)(?![\])[*]',re.DOTALL)
 
-    #---- open md file and search for patterns ----
+    # ---- open md file and search for patterns ----
     with open(fname_mddoc, 'r') as mdfile:
         mdstring = mdfile.read()
 
     match = retail.search(mdstring)
-    if match != None:
-        #    mdstring = re.sub(match.group(0),'',mdstring) doesn't work. don't know why
+    if match is not None:
         mdstring = mdstring.replace(match.group(0), '')
 
     match = reh1.search(mdstring)
-    while match != None:
-        mdstring = re.sub(match.group(0), match.group(1) + '\n' + len(match.group(1)) * '-' + '\n', mdstring)
+    while match is not None:
+        mdstring = re.sub(match.group(0), match.group(1) + '\n' +
+                          len(match.group(1)) * '-' + '\n', mdstring)
         match = reh1.search(mdstring)
 
     match = reh1b.search(mdstring)
-    while match != None:
-        mdstring = re.sub(match.group(0), '\n' + match.group(1) + '\n' + len(match.group(1)) * '-' + '\n', mdstring)
+    while match is not None:
+        mdstring = re.sub(match.group(0), '\n' + match.group(1) + '\n' +
+                          len(match.group(1)) * '-' + '\n', mdstring)
         match = reh1b.search(mdstring)
 
     match = reh2.search(mdstring)
-    while match != None:
-        mdstring = re.sub(match.group(0), match.group(1) + '\n' + len(match.group(1)) * '-' + '\n', mdstring)
+    while match is not None:
+        mdstring = re.sub(match.group(0), match.group(1) + '\n' +
+                          len(match.group(1)) * '-' + '\n', mdstring)
         match = reh2.search(mdstring)
 
     match = recode.search(mdstring)
-    while match != None:
-        #    mdstring = re.sub(match.group(0),match.group(1),mdstring) doesn't work. don't know why
+    while match is not None:
         mdstring = mdstring.replace(match.group(0), match.group(1))
         match = recode.search(mdstring)
 
     match = restaresc.search(mdstring)
-    while match != None:
+    while match is not None:
         mdstring = mdstring.replace(match.group(0), '*')
         match = recode.search(mdstring)
 
-    #---- combine into docstring ----
+    # ---- combine into docstring ----
     docstring = ''
     tmp = mdstring.splitlines(True)
     for i in range(0, len(tmp)):
         if tmp[i][0:4] == ':   ':
             docstring += textwrap.fill(tmp[i][4:], width=80,
-                                       replace_whitespace=False, initial_indent='    ',
+                                       replace_whitespace=False,
+                                       initial_indent='    ',
                                        subsequent_indent='    ') + '\n'
         else:
-            docstring += textwrap.fill(tmp[i], width=80, replace_whitespace=False) + '\n'
+            docstring += textwrap.fill(tmp[i], width=80,
+                                       replace_whitespace=False) + '\n'
 
     return docstring
 
-#===== PROCESS F2PY DOCUMENTATION ====
+
+# ===== PROCESS F2PY DOCUMENTATION ====
 def process_f2pydoc(f2pydoc):
     """
     this function replace all optional _d0 arguments with their default values
     in the function signature. These arguments are not intended to be used and
     signify merely the array dimensions of the associated argument.
     """
-    #---- split f2py document in its parts
+    # ---- split f2py document in its parts
     # 0=Call Signature
     # 1=Parameters
     # 2=Other (optional) Parameters (only if present)
@@ -152,10 +162,11 @@ def process_f2pydoc(f2pydoc):
         print('-- uninterpretable f2py documentation --')
         return f2pydoc
 
-    #---- replace arguments with _d suffix with empty string in function signature (remove them):
+    # ---- replace arguments with _d suffix with empty string in ----
+    # ---- function signature (remove them): ----
     docparts[0] = re.sub('[\[(,]\w+_d\d', '', docparts[0])
 
-    #---- replace _d arguments of the return arrays with their default value:
+    # ---- replace _d arguments of the return arrays with their default value:
     if doc_has_optionals:
 
         returnarray_dims = re.findall('[\[(,](\w+_d\d)', docparts[3])
@@ -163,20 +174,21 @@ def process_f2pydoc(f2pydoc):
             searchpattern = arg + ' : input.*\n.*Default: (.*)\n'
             match = re.search(searchpattern, docparts[2])
             if match:
-                default = match.group(1)  # this returns the value in brackets in the search pattern
+                default = match.group(1)
                 docparts[3] = re.sub(arg, default, docparts[3])
                 docparts[2] = re.sub(searchpattern, '', docparts[2])
 
-    #---- remove all optional _d# from optional argument list:
+    # ---- remove all optional _d# from optional argument list:
     if doc_has_optionals:
         searchpattern = '\w+_d\d : input.*\n.*Default: (.*)\n'
         docparts[2] = re.sub(searchpattern, '', docparts[2])
 
-    #---- combine doc parts to a single string
+    # ---- combine doc parts to a single string
     processed_signature = '\n--'.join(docparts)
 
     return processed_signature
 
-#==== EXECUTE SCRIPT ====
+
+# ==== EXECUTE SCRIPT ====
 if __name__ == "__main__":
     main()

--- a/pyshtools/other.py
+++ b/pyshtools/other.py
@@ -22,10 +22,12 @@ EigValSym          Compute the eigenvalues of a real symmetric matrix.
 Wigner3j           Compute the Wigner-3j symbols for all allowable values of J.
 """
 
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
-from ._SHTOOLS import MakeCircleCoord, MakeEllipseCoord, RandomN
-from ._SHTOOLS import RandomGaussian, PreGLQ, EigValVecSym, EigValVecSymTri
-from ._SHTOOLS import EigValSym, Wigner3j
+from ._SHTOOLS import MakeCircleCoord
+from ._SHTOOLS import MakeEllipseCoord
+from ._SHTOOLS import RandomN
+from ._SHTOOLS import RandomGaussian
+from ._SHTOOLS import PreGLQ
+from ._SHTOOLS import EigValVecSym
+from ._SHTOOLS import EigValVecSymTri
+from ._SHTOOLS import EigValSym
+from ._SHTOOLS import Wigner3j

--- a/pyshtools/other.py
+++ b/pyshtools/other.py
@@ -22,6 +22,10 @@ EigValSym          Compute the eigenvalues of a real symmetric matrix.
 Wigner3j           Compute the Wigner-3j symbols for all allowable values of J.
 """
 
+from __future__ import absolute_import as _absolute_import
+from __future__ import division as _division
+from __future__ import print_function as _print_function
+
 from ._SHTOOLS import MakeCircleCoord
 from ._SHTOOLS import MakeEllipseCoord
 from ._SHTOOLS import RandomN

--- a/pyshtools/rotate.py
+++ b/pyshtools/rotate.py
@@ -11,8 +11,6 @@ SHRotateRealCoef  Determine the spherical harmonic coefficients of a real
                   function rotated by three Euler angles.
 """
 
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
-from ._SHTOOLS import djpi2, SHRotateCoef, SHRotateRealCoef
+from ._SHTOOLS import djpi2
+from ._SHTOOLS import SHRotateCoef
+from ._SHTOOLS import SHRotateRealCoef

--- a/pyshtools/rotate.py
+++ b/pyshtools/rotate.py
@@ -11,6 +11,10 @@ SHRotateRealCoef  Determine the spherical harmonic coefficients of a real
                   function rotated by three Euler angles.
 """
 
+from __future__ import absolute_import as _absolute_import
+from __future__ import division as _division
+from __future__ import print_function as _print_function
+
 from ._SHTOOLS import djpi2
 from ._SHTOOLS import SHRotateCoef
 from ._SHTOOLS import SHRotateRealCoef

--- a/pyshtools/shclasses.py
+++ b/pyshtools/shclasses.py
@@ -24,13 +24,15 @@ pyshtools class structure:
 For more information, see the documentation for the top level classes.
 """
 
+from __future__ import absolute_import as _absolute_import
+from __future__ import division as _division
 from __future__ import print_function as _print_function
 
-import numpy as np
+import numpy as _np
 import matplotlib as _mpl
 import matplotlib.pyplot as _plt
 
-from . import _SHTOOLS as shtools
+from . import _SHTOOLS as _shtools
 
 
 # =============================================================================
@@ -126,7 +128,7 @@ class SHCoeffs(object):
         csphase       : 1 (default) if the coefficients exclude the Condon-
                         Shortley phase factor, or -1 if they include it.
         """
-        if np.iscomplexobj(coeffs):
+        if _np.iscomplexobj(coeffs):
             kind = 'complex'
         else:
             kind = 'real'
@@ -200,23 +202,23 @@ class SHCoeffs(object):
                 "Input value was {:s}.".format(repr(kind)))
 
         nl = len(power)
-        l = np.arange(nl)
+        l = _np.arange(nl)
 
         if kind.lower() == 'real':
-            coeffs = np.random.normal(size=(2, nl, nl))
+            coeffs = _np.random.normal(size=(2, nl, nl))
         elif kind.lower() == 'complex':
-            coeffs = (np.random.normal(size=(2, nl, nl)) +
-                      1j * np.random.normal(size=(2, nl, nl)))
+            coeffs = (_np.random.normal(size=(2, nl, nl)) +
+                      1j * _np.random.normal(size=(2, nl, nl)))
 
         if normalization.lower() == '4pi':
-            coeffs *= np.sqrt(
-                power / (2.0 * l + 1.0))[np.newaxis, :, np.newaxis]
+            coeffs *= _np.sqrt(
+                power / (2.0 * l + 1.0))[_np.newaxis, :, _np.newaxis]
         elif normalization.lower() == 'ortho':
-            coeffs *= np.sqrt(
-                4.0 * np.pi * power / (2.0 * l + 1.0)
-                )[np.newaxis, :, np.newaxis]
+            coeffs *= _np.sqrt(
+                4.0 * _np.pi * power / (2.0 * l + 1.0)
+                )[_np.newaxis, :, _np.newaxis]
         elif normalization.lower() == 'schmidt':
-            coeffs *= np.sqrt(power)[np.newaxis, :, np.newaxis]
+            coeffs *= _np.sqrt(power)[_np.newaxis, :, _np.newaxis]
 
         for cls in self.__subclasses__():
             if cls.istype(kind):
@@ -289,7 +291,7 @@ class SHCoeffs(object):
 
         if format.lower() == 'shtools':
             if kind.lower() == 'real':
-                coeffs, lmax = shtools.SHRead(fname, lmax, **kwargs)
+                coeffs, lmax = _shtools.SHRead(fname, lmax, **kwargs)
             else:
                 raise NotImplementedError(
                     "kind={:s} not yet implemented".format(repr(kind)))
@@ -318,7 +320,7 @@ class SHCoeffs(object):
 
         degrees : numpy ndarray of size (lmax+1).
         """
-        return np.arange(self.lmax + 1)
+        return _np.arange(self.lmax + 1)
 
     def get_powerperdegree(self):
         """
@@ -352,7 +354,7 @@ class SHCoeffs(object):
         power : numpy ndarray of size (lmax+1).
         """
         ls = self.get_degrees()
-        return self._powerperdegree() * ls * np.log(bandwidth)
+        return self._powerperdegree() * ls * _np.log(bandwidth)
 
     # ---- Return coefficients with a different normalization convention ----
     def get_coeffs(self, normalization='4pi', csphase=1):
@@ -468,9 +470,9 @@ class SHCoeffs(object):
         alpha_y=alpha_x-pi/2, beta_x=beta_y, and gamma_y=gamma_x+pi/2.
         """
         if degrees:
-            angles = np.radians([alpha, beta, gamma])
+            angles = _np.radians([alpha, beta, gamma])
         else:
-            angles = np.array([alpha, beta, gamma])
+            angles = _np.array([alpha, beta, gamma])
 
         rot = self._rotate(angles, dj_matrix)
         return rot
@@ -648,16 +650,16 @@ class SHRealCoeffs(SHCoeffs):
     def __init__(self, coeffs, normalization='4pi', csphase=1):
         lmax = coeffs.shape[1] - 1
         # ---- create mask to filter out m<=l ----
-        mask = np.zeros((2, lmax + 1, lmax + 1), dtype=np.bool)
+        mask = _np.zeros((2, lmax + 1, lmax + 1), dtype=_np.bool)
         mask[0, 0, 0] = True
-        for l in np.arange(lmax + 1):
+        for l in _np.arange(lmax + 1):
             mask[:, l, :l + 1] = True
         mask[1, :, 0] = False
 
         self.mask = mask
         self.lmax = lmax
-        self.coeffs = np.copy(coeffs)
-        self.coeffs[np.invert(mask)] = 0.
+        self.coeffs = _np.copy(coeffs)
+        self.coeffs[_np.invert(mask)] = 0.
         self.kind = 'real'
         self.normalization = normalization
         self.csphase = csphase
@@ -673,13 +675,13 @@ class SHRealCoeffs(SHCoeffs):
 
         SHComplexCoeffsInstance = x.make_complex()
         """
-        rcomplex_coeffs = shtools.SHrtoc(self.coeffs,
-                                         convention=1, switchcs=0)
+        rcomplex_coeffs = _shtools.SHrtoc(self.coeffs,
+                                          convention=1, switchcs=0)
 
         # These coefficients are using real floats, and need to be
         # converted to complex form.
-        complex_coeffs = np.zeros((2, self.lmax+1, self.lmax+1),
-                                  dtype='complex')
+        complex_coeffs = _np.zeros((2, self.lmax+1, self.lmax+1),
+                                   dtype='complex')
         complex_coeffs[0, :, :] = (rcomplex_coeffs[0, :, :] + 1j *
                                    rcomplex_coeffs[1, :, :])
         complex_coeffs[1, :, :] = complex_coeffs[0, :, :].conjugate()
@@ -694,14 +696,14 @@ class SHRealCoeffs(SHCoeffs):
     def _powerperdegree(self):
         """Return the power per degree l spectrum."""
         if self.normalization == '4pi':
-            return shtools.SHPowerSpectrum(self.coeffs)
+            return _shtools.SHPowerSpectrum(self.coeffs)
         elif self.normalization == 'schmidt':
-            power = shtools.SHPowerSpectrum(self.coeffs)
+            power = _shtools.SHPowerSpectrum(self.coeffs)
             l = self.get_degrees()
             power /= (2.0 * l + 1.0)
             return power
         elif self.normalization == 'ortho':
-            return shtools.SHPowerSpectrum(self.coeffs) / (4.0 * np.pi)
+            return _shtools.SHPowerSpectrum(self.coeffs) / (4.0 * _np.pi)
         else:
             raise ValueError(
                 "Normalization must be '4pi', 'ortho', or 'schmidt'. " +
@@ -712,30 +714,31 @@ class SHRealCoeffs(SHCoeffs):
         Return real spherical harmonic coefficients with a
         different normalization convention.
         """
-        coeffs = np.copy(self.coeffs)
+        coeffs = _np.copy(self.coeffs)
 
         if self.normalization == output_normalization:
             pass
         elif (self.normalization == '4pi' and
               output_normalization == 'schmidt'):
             for l in self.get_degrees():
-                coeffs[:, l, :l+1] *= np.sqrt(2.0 * l + 1.0)
+                coeffs[:, l, :l+1] *= _np.sqrt(2.0 * l + 1.0)
         elif self.normalization == '4pi' and output_normalization == 'ortho':
-            coeffs *= np.sqrt(4.0 * np.pi)
+            coeffs *= _np.sqrt(4.0 * _np.pi)
         elif (self.normalization == 'schmidt' and
               output_normalization == '4pi'):
             for l in self.get_degrees():
-                coeffs[:, l, :l+1] /= np.sqrt(2.0 * l + 1.0)
+                coeffs[:, l, :l+1] /= _np.sqrt(2.0 * l + 1.0)
         elif (self.normalization == 'schmidt' and
               output_normalization == 'ortho'):
             for l in self.get_degrees():
-                coeffs[:, l, :l+1] *= np.sqrt(4.0 * np.pi / (2.0 * l + 1.0))
+                coeffs[:, l, :l+1] *= _np.sqrt(4.0 * _np.pi / (2.0 * l + 1.0))
         elif self.normalization == 'ortho' and output_normalization == '4pi':
-            coeffs /= np.sqrt(4.0 * np.pi)
+            coeffs /= _np.sqrt(4.0 * _np.pi)
         elif (self.normalization == 'ortho' and
               output_normalization == 'schmidt'):
             for l in self.get_degrees():
-                coeffs[:, l, :l+1] *= np.sqrt((2.0 * l + 1.0) / (4.0 * np.pi))
+                coeffs[:, l, :l+1] *= _np.sqrt((2.0 * l + 1.0) /
+                                               (4.0 * _np.pi))
 
         if output_csphase != self.csphase:
             for m in self.get_degrees():
@@ -750,10 +753,10 @@ class SHRealCoeffs(SHCoeffs):
         harmonics coefficients by the Euler angles alpha, beta, gamma.
         """
         if dj_matrix is None:
-            dj_matrix = shtools.djpi2(self.lmax + 1)
+            dj_matrix = _shtools.djpi2(self.lmax + 1)
 
         # The coefficients need to be 4pi normalized with csphase = 1
-        coeffs = shtools.SHRotateRealCoef(
+        coeffs = _shtools.SHRotateRealCoef(
             self.get_coeffs(normalization='4pi', csphase=1), angles, dj_matrix)
 
         # Convert 4pi normalized coefficients to the same normalization
@@ -784,8 +787,8 @@ class SHRealCoeffs(SHCoeffs):
                 "Normalization must be '4pi', 'ortho', or 'schmidt'. " +
                 "Input value was {:s}".format(repr(self.normalization)))
 
-        data = shtools.MakeGridDH(self.coeffs, sampling=sampling, norm=norm,
-                                  csphase=self.csphase, **kwargs)
+        data = _shtools.MakeGridDH(self.coeffs, sampling=sampling, norm=norm,
+                                   csphase=self.csphase, **kwargs)
         gridout = SHGrid.from_array(data, grid='DH')
         return gridout
 
@@ -803,10 +806,10 @@ class SHRealCoeffs(SHCoeffs):
                 "Input value was {:s}".format(repr(self.normalization)))
 
         if zeros is None:
-            zeros, weights = shtools.SHGLQ(self.lmax)
+            zeros, weights = _shtools.SHGLQ(self.lmax)
 
-        data = shtools.MakeGridGLQ(self.coeffs, zeros, norm=norm,
-                                   csphase=self.csphase, **kwargs)
+        data = _shtools.MakeGridGLQ(self.coeffs, zeros, norm=norm,
+                                    csphase=self.csphase, **kwargs)
         gridout = SHGrid.from_array(data, grid='GLQ')
         return gridout
 
@@ -825,16 +828,16 @@ class SHComplexCoeffs(SHCoeffs):
     def __init__(self, coeffs, normalization='4pi', csphase=1):
         lmax = coeffs.shape[1] - 1
         # ---- create mask to filter out m<=l ----
-        mask = np.zeros((2, lmax + 1, lmax + 1), dtype=np.bool)
+        mask = _np.zeros((2, lmax + 1, lmax + 1), dtype=_np.bool)
         mask[0, 0, 0] = True
-        for l in np.arange(lmax + 1):
+        for l in _np.arange(lmax + 1):
             mask[:, l, :l + 1] = True
         mask[1, :, 0] = False
 
         self.mask = mask
         self.lmax = lmax
-        self.coeffs = np.copy(coeffs)
-        self.coeffs[np.invert(mask)] = 0.
+        self.coeffs = _np.copy(coeffs)
+        self.coeffs[_np.invert(mask)] = 0.
         self.kind = 'complex'
         self.normalization = normalization
         self.csphase = csphase
@@ -858,7 +861,7 @@ class SHComplexCoeffs(SHCoeffs):
                                    'to a real field. l = {:d}, m = 0: {:e}'
                                    .format(l, self.coeffs[0, l, 0]))
 
-            for m in np.arange(1, l + 1):
+            for m in _np.arange(1, l + 1):
                 if m % 2 == 1:
                     if (self.coeffs[0, l, m] != -
                             self.coeffs[1, l, m].conjugate()):
@@ -876,11 +879,11 @@ class SHComplexCoeffs(SHCoeffs):
                                            .format(l, m, self.coeffs[0, l, 0],
                                                    self.coeffs[1, l, 0]))
 
-        coeffs_rc = np.zeros((2, self.lmax + 1, self.lmax + 1))
+        coeffs_rc = _np.zeros((2, self.lmax + 1, self.lmax + 1))
         coeffs_rc[0, :, :] = self.coeffs[0, :, :].real
         coeffs_rc[1, :, :] = self.coeffs[0, :, :].imag
-        real_coeffs = shtools.SHctor(coeffs_rc, convention=1,
-                                     switchcs=0)
+        real_coeffs = _shtools.SHctor(coeffs_rc, convention=1,
+                                      switchcs=0)
         return SHCoeffs.from_array(real_coeffs,
                                    normalization=self.normalization,
                                    csphase=self.csphase)
@@ -888,14 +891,14 @@ class SHComplexCoeffs(SHCoeffs):
     def _powerperdegree(self):
         """Return the power per degree l spectrum."""
         if self.normalization == '4pi':
-            return shtools.SHPowerSpectrumC(self.coeffs)
+            return _shtools.SHPowerSpectrumC(self.coeffs)
         elif self.normalization == 'schmidt':
-            power = shtools.SHPowerSpectrumC(self.coeffs)
+            power = _shtools.SHPowerSpectrumC(self.coeffs)
             l = self.get_degrees()
             power /= (2.0 * l + 1.0)
             return power
         elif self.normalization == 'ortho':
-            return shtools.SHPowerSpectrumC(self.coeffs) / (4.0 * np.pi)
+            return _shtools.SHPowerSpectrumC(self.coeffs) / (4.0 * _np.pi)
         else:
             raise ValueError(
                 "Normalization must be '4pi', 'ortho', or 'schmidt'. " +
@@ -906,30 +909,31 @@ class SHComplexCoeffs(SHCoeffs):
         Return complex spherical harmonics coefficients with a
         different normalization convention.
         """
-        coeffs = np.copy(self.coeffs)
+        coeffs = _np.copy(self.coeffs)
 
         if self.normalization == output_normalization:
             pass
         elif (self.normalization == '4pi' and
               output_normalization == 'schmidt'):
             for l in self.get_degrees():
-                coeffs[:, l, :l+1] *= np.sqrt(2.0 * l + 1.0)
+                coeffs[:, l, :l+1] *= _np.sqrt(2.0 * l + 1.0)
         elif self.normalization == '4pi' and output_normalization == 'ortho':
-            coeffs *= np.sqrt(4.0 * np.pi)
+            coeffs *= _np.sqrt(4.0 * _np.pi)
         elif (self.normalization == 'schmidt' and
               output_normalization == '4pi'):
             for l in self.get_degrees():
-                coeffs[:, l, :l+1] /= np.sqrt(2.0 * l + 1.0)
+                coeffs[:, l, :l+1] /= _np.sqrt(2.0 * l + 1.0)
         elif (self.normalization == 'schmidt' and
               output_normalization == 'ortho'):
             for l in self.get_degrees():
-                coeffs[:, l, :l+1] *= np.sqrt(4.0 * np.pi / (2.0 * l + 1.0))
+                coeffs[:, l, :l+1] *= _np.sqrt(4.0 * _np.pi / (2.0 * l + 1.0))
         elif self.normalization == 'ortho' and output_normalization == '4pi':
-            coeffs /= np.sqrt(4.0 * np.pi)
+            coeffs /= _np.sqrt(4.0 * _np.pi)
         elif (self.normalization == 'ortho' and
               output_normalization == 'schmidt'):
             for l in self.get_degrees():
-                coeffs[:, l, :l+1] *= np.sqrt((2.0 * l + 1.0) / (4.0 * np.pi))
+                coeffs[:, l, :l+1] *= _np.sqrt((2.0 * l + 1.0) /
+                                               (4.0 * _np.pi))
 
         if output_csphase != self.csphase:
             for m in self.get_degrees():
@@ -950,22 +954,22 @@ class SHComplexCoeffs(SHCoeffs):
         # combined to make a complex grid, and the resultant is expanded
         # in complex spherical harmonics.
         if dj_matrix is None:
-            dj_matrix = shtools.djpi2(self.lmax + 1)
+            dj_matrix = _shtools.djpi2(self.lmax + 1)
 
         cgrid = self.expand(grid='DH')
         rgrid, igrid = cgrid.data.real, cgrid.data.imag
-        rgridcoeffs = shtools.SHExpandDH(rgrid, norm=1, sampling=1, csphase=1)
-        igridcoeffs = shtools.SHExpandDH(igrid, norm=1, sampling=1, csphase=1)
+        rgridcoeffs = _shtools.SHExpandDH(rgrid, norm=1, sampling=1, csphase=1)
+        igridcoeffs = _shtools.SHExpandDH(igrid, norm=1, sampling=1, csphase=1)
 
-        rgridcoeffs_rot = shtools.SHRotateRealCoef(
+        rgridcoeffs_rot = _shtools.SHRotateRealCoef(
             rgridcoeffs, angles, dj_matrix)
-        igridcoeffs_rot = shtools.SHRotateRealCoef(
+        igridcoeffs_rot = _shtools.SHRotateRealCoef(
             igridcoeffs, angles, dj_matrix)
 
-        rgrid_rot = shtools.MakeGridDH(rgridcoeffs_rot, norm=1,
-                                       sampling=1, csphase=1)
-        igrid_rot = shtools.MakeGridDH(igridcoeffs_rot, norm=1,
-                                       sampling=1, csphase=1)
+        rgrid_rot = _shtools.MakeGridDH(rgridcoeffs_rot, norm=1,
+                                        sampling=1, csphase=1)
+        igrid_rot = _shtools.MakeGridDH(igridcoeffs_rot, norm=1,
+                                        sampling=1, csphase=1)
         grid_rot = rgrid_rot + 1j * igrid_rot
 
         if self.normalization == '4pi':
@@ -978,8 +982,8 @@ class SHComplexCoeffs(SHCoeffs):
             raise ValueError(
                 "Normalization must be '4pi', 'ortho', or 'schmidt'")
 
-        coeffs_rot = shtools.SHExpandDHC(grid_rot, norm=norm,
-                                         csphase=self.csphase)
+        coeffs_rot = _shtools.SHExpandDHC(grid_rot, norm=norm,
+                                          csphase=self.csphase)
 
         return SHCoeffs.from_array(coeffs_rot,
                                    normalization=self.normalization,
@@ -1001,8 +1005,8 @@ class SHComplexCoeffs(SHCoeffs):
                 "Normalization must be '4pi', 'ortho', or 'schmidt'. " +
                 "Input value was {:s}".format(repr(self.normalization)))
 
-        data = shtools.MakeGridDHC(self.coeffs, sampling=sampling,
-                                   norm=norm, csphase=self.csphase, **kwargs)
+        data = _shtools.MakeGridDHC(self.coeffs, sampling=sampling,
+                                    norm=norm, csphase=self.csphase, **kwargs)
         gridout = SHGrid.from_array(data, grid='DH')
         return gridout
 
@@ -1020,10 +1024,10 @@ class SHComplexCoeffs(SHCoeffs):
                 "Input value was {:s}".format(repr(self.normalization)))
 
         if zeros is None:
-            zeros, weights = shtools.SHGLQ(self.lmax)
+            zeros, weights = _shtools.SHGLQ(self.lmax)
 
-        data = shtools.MakeGridGLQC(self.coeffs, zeros, norm=norm,
-                                    csphase=self.csphase, **kwargs)
+        data = _shtools.MakeGridGLQC(self.coeffs, zeros, norm=norm,
+                                     csphase=self.csphase, **kwargs)
         gridout = SHGrid.from_array(data, grid='GLQ')
         return gridout
 
@@ -1087,7 +1091,7 @@ class SHGrid(object):
         grid : 'DH' (default) or 'GLQ' for Driscoll and Healy grids or Gauss
                 Legendre Quadrature grids, respectively.
         """
-        if np.iscomplexobj(array):
+        if _np.iscomplexobj(array):
             kind = 'complex'
         else:
             kind = 'real'
@@ -1254,7 +1258,7 @@ class DHRealGrid(SHGrid):
         Return a vector containing the latitudes (in degrees) of each row
         of the gridded data.
         """
-        lats = np.linspace(90.0, -90.0 + 180.0 / self.nlat, num=self.nlat)
+        lats = _np.linspace(90.0, -90.0 + 180.0 / self.nlat, num=self.nlat)
         return lats
 
     def _get_lons(self):
@@ -1262,7 +1266,7 @@ class DHRealGrid(SHGrid):
         Return a vector containing the longitudes (in degrees) of each row
         of the gridded data.
         """
-        lons = np.linspace(0.0, 360.0 - 360.0 / self.nlon, num=self.nlon)
+        lons = _np.linspace(0.0, 360.0 - 360.0 / self.nlon, num=self.nlon)
         return lons
 
     def _expand(self, normalization, csphase, **kwargs):
@@ -1280,8 +1284,8 @@ class DHRealGrid(SHGrid):
                 .format(repr(normalization))
                 )
 
-        cilm = shtools.SHExpandDH(self.data, norm=norm, csphase=csphase,
-                                  **kwargs)
+        cilm = _shtools.SHExpandDH(self.data, norm=norm, csphase=csphase,
+                                   **kwargs)
         coeffs = SHCoeffs.from_array(cilm,
                                      normalization=normalization.lower(),
                                      csphase=csphase)
@@ -1340,7 +1344,7 @@ class DHComplexGrid(SHGrid):
         Return a vector containing the latitudes (in degrees) of each row
         of the gridded data.
         """
-        lats = np.linspace(90.0, -90.0 + 180.0 / self.nlat, num=self.nlat)
+        lats = _np.linspace(90.0, -90.0 + 180.0 / self.nlat, num=self.nlat)
         return lats
 
     def _get_lons(self):
@@ -1348,7 +1352,7 @@ class DHComplexGrid(SHGrid):
         Return a vector containing the longitudes (in degrees) of each row
         of the gridded data.
         """
-        lons = np.linspace(0., 360.0 - 360.0 / self.nlon, num=self.nlon)
+        lons = _np.linspace(0., 360.0 - 360.0 / self.nlon, num=self.nlon)
         return lons
 
     def _expand(self, normalization, csphase, **kwargs):
@@ -1366,8 +1370,8 @@ class DHComplexGrid(SHGrid):
                 .format(repr(normalization))
                 )
 
-        cilm = shtools.SHExpandDHC(self.data, norm=norm, csphase=csphase,
-                                   **kwargs)
+        cilm = _shtools.SHExpandDHC(self.data, norm=norm, csphase=csphase,
+                                    **kwargs)
         coeffs = SHCoeffs.from_array(cilm,
                                      normalization=normalization.lower(),
                                      csphase=csphase)
@@ -1416,7 +1420,7 @@ class GLQRealGrid(SHGrid):
                              )
 
         if zeros is None or weights is None:
-            self.zeros, self.weights = shtools.SHGLQ(self.lmax)
+            self.zeros, self.weights = _shtools.SHGLQ(self.lmax)
         else:
             self.zeros = zeros
             self.weights = weights
@@ -1430,7 +1434,7 @@ class GLQRealGrid(SHGrid):
         Return a vector containing the latitudes (in degrees) of each row
         of the gridded data.
         """
-        lats = 90. - np.arccos(self.zeros) * 180. / np.pi
+        lats = 90. - _np.arccos(self.zeros) * 180. / _np.pi
         return lats
 
     def _get_lons(self):
@@ -1438,7 +1442,7 @@ class GLQRealGrid(SHGrid):
         Return a vector containing the longitudes (in degrees) of each column
         of the gridded data.
         """
-        lons = np.linspace(0.0, 360.0 - 360.0 / self.nlon, num=self.nlon)
+        lons = _np.linspace(0.0, 360.0 - 360.0 / self.nlon, num=self.nlon)
         return lons
 
     def _expand(self, normalization, csphase, **kwargs):
@@ -1456,8 +1460,8 @@ class GLQRealGrid(SHGrid):
                 .format(repr(normalization))
                 )
 
-        cilm = shtools.SHExpandGLQ(self.data, self.weights, self.zeros,
-                                   norm=norm, csphase=csphase, **kwargs)
+        cilm = _shtools.SHExpandGLQ(self.data, self.weights, self.zeros,
+                                    norm=norm, csphase=csphase, **kwargs)
         coeffs = SHCoeffs.from_array(cilm,
                                      normalization=normalization.lower(),
                                      csphase=csphase)
@@ -1501,7 +1505,7 @@ class GLQComplexGrid(SHGrid):
                              )
 
         if zeros is None or weights is None:
-            self.zeros, self.weights = shtools.SHGLQ(self.lmax)
+            self.zeros, self.weights = _shtools.SHGLQ(self.lmax)
         else:
             self.zeros = zeros
             self.weights = weights
@@ -1515,7 +1519,7 @@ class GLQComplexGrid(SHGrid):
         Return a vector containing the latitudes (in degrees) of each row
         of the gridded data.
         """
-        lats = 90. - np.arccos(self.zeros) * 180. / np.pi
+        lats = 90. - _np.arccos(self.zeros) * 180. / _np.pi
         return lats
 
     def _get_lons(self):
@@ -1523,7 +1527,7 @@ class GLQComplexGrid(SHGrid):
         Return a vector containing the longitudes (in degrees) of each column
         of the gridded data.
         """
-        lons = np.linspace(0., 360. - 360. / self.nlon, num=self.nlon)
+        lons = _np.linspace(0., 360. - 360. / self.nlon, num=self.nlon)
         return lons
 
     def _expand(self, normalization, csphase, **kwargs):
@@ -1541,8 +1545,8 @@ class GLQComplexGrid(SHGrid):
                 .format(repr(normalization))
                 )
 
-        cilm = shtools.SHExpandGLQC(self.data, self.weights, self.zeros,
-                                    norm=norm, csphase=csphase, **kwargs)
+        cilm = _shtools.SHExpandGLQC(self.data, self.weights, self.zeros,
+                                     norm=norm, csphase=csphase, **kwargs)
         coeffs = SHCoeffs.from_array(cilm,
                                      normalization=normalization.lower(),
                                      csphase=csphase)
@@ -1584,9 +1588,9 @@ class SHWindow(object):
         constructs a spherical cap window
         """
         if degrees:
-            theta = np.radians(theta)
+            theta = _np.radians(theta)
 
-        tapers, eigenvalues, taper_order = shtools.SHReturnTapers(theta, lmax)
+        tapers, eigenvalues, taper_order = _shtools.SHReturnTapers(theta, lmax)
         return SHSymmetricWindow(tapers, eigenvalues, taper_order,
                                  clat=clat, clon=clon)
 
@@ -1595,7 +1599,7 @@ class SHWindow(object):
         """
         constructs optimal window functions in a masked region (needs dh grid)
         """
-        tapers, eigenvalues = shtools.SHReturnTapersMap(
+        tapers, eigenvalues = _shtools.SHReturnTapersMap(
             dh_mask, lmax, sampling=sampling, Ntapers=nwins)
         return SHAsymmetricWindow(tapers, eigenvalues)
 
@@ -1606,7 +1610,7 @@ class SHWindow(object):
         # ---- setup figure and axes
         maxcolumns = 5
         ncolumns = min(maxcolumns, nwins)
-        nrows = np.ceil(nwins / ncolumns).astype(int)
+        nrows = _np.ceil(nwins / ncolumns).astype(int)
         figsize = ncolumns * 1.2, nrows * 1.2 + 0.5
         fig, axes = _plt.subplots(nrows, ncolumns, figsize=figsize)
         for ax in axes[:-1, :].flatten():
@@ -1621,7 +1625,7 @@ class SHWindow(object):
             evalue = self.eigenvalues[itaper]
             coeffs = self._coeffs(itaper)
             ax = axes.flatten()[itaper]
-            grid = shtools.MakeGridDH(coeffs)
+            grid = _shtools.MakeGridDH(coeffs)
             ax.imshow(grid)
             ax.set_title('concentration: {:2.2f}'.format(evalue))
         fig.tight_layout(pad=0.5)
@@ -1636,20 +1640,20 @@ class SHWindow(object):
         for itaper in range(nwins):
             tapercoeffs = self._coeffs(itaper)
             modelcoeffs = shcoeffs.get_coeffs(normalization='4pi', kind='real')
-            coeffs = shtools.SHMultiply(tapercoeffs, modelcoeffs)
+            coeffs = _shtools.SHMultiply(tapercoeffs, modelcoeffs)
 
     def get_couplingmatrix(self, lmax, nwins):
         """returns the coupling matrix of the first nwins tapers"""
         # store sqrt of taper power in 'tapers' array:
         if nwins > self.nwins:
             nwins = self.nwins
-        tapers = np.zeros((self.nl, nwins))
+        tapers = _np.zeros((self.nl, nwins))
         for itaper in range(nwins):
-            tapers[:, itaper] = np.sqrt(shtools.SHPowerSpectrum(
+            tapers[:, itaper] = _np.sqrt(_shtools.SHPowerSpectrum(
                 self._coeffs(itaper)))
 
         # compute coupling matrix of the first nwins tapers:
-        coupling_matrix = shtools.SHMTCouplingMatrix(lmax, tapers[:, :nwins])
+        coupling_matrix = _shtools.SHMTCouplingMatrix(lmax, tapers[:, :nwins])
         return coupling_matrix
 
     def plot_couplingmatrix(self, lmax, nwins, show=True, fname=None):
@@ -1699,7 +1703,7 @@ class SHSymmetricWindow(SHWindow):
 
     def _coeffs(self, itaper):
         taperm = self.orders[itaper]
-        coeffs = np.zeros((2, self.nl, self.nl))
+        coeffs = _np.zeros((2, self.nl, self.nl))
         if taperm < 0:
             coeffs[1, :, abs(taperm)] = self.tapers[:, itaper]
         else:
@@ -1721,13 +1725,13 @@ class SHAsymmetricWindow(SHWindow):
 
     def __init__(self, tapers, eigenvalues):
         ncoeffs, self.nwins = tapers.shape
-        self.nl = np.sqrt(ncoeffs).astype(int)
+        self.nl = _np.sqrt(ncoeffs).astype(int)
         self.lmax = self.nl-1
         self.tapers = tapers
         self.eigenvalues = eigenvalues
 
     def _coeffs(self, itaper):
-        return shtools.SHVectorToCilm(self.tapers[:, itaper], self.lmax)
+        return _shtools.SHVectorToCilm(self.tapers[:, itaper], self.lmax)
 
     def _info(self):
         print('Asymmetric window with {:d} tapers'.format(self.nwins))

--- a/pyshtools/shclasses.py
+++ b/pyshtools/shclasses.py
@@ -24,13 +24,11 @@ pyshtools class structure:
 For more information, see the documentation for the top level classes.
 """
 
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
 from __future__ import print_function as _print_function
 
 import numpy as np
-import matplotlib as mpl
-import matplotlib.pyplot as plt
+import matplotlib as _mpl
+import matplotlib.pyplot as _plt
 
 from . import _SHTOOLS as shtools
 
@@ -589,7 +587,7 @@ class SHCoeffs(object):
         power = self.get_powerperdegree()
         ls = self.get_degrees()
 
-        fig, ax = plt.subplots(1, 1)
+        fig, ax = _plt.subplots(1, 1)
         ax.set_xlabel('degree l')
         ax.set_ylabel('power per degree')
         if loglog:
@@ -598,7 +596,7 @@ class SHCoeffs(object):
             ax.grid(True, which='both')
             ax.plot(ls[1:], power[1:], label='power per degree l')
         if show:
-            plt.show()
+            _plt.show()
         if fname is not None:
             fig.savefig(fname)
 
@@ -622,7 +620,7 @@ class SHCoeffs(object):
         power = self.get_powerperband(bandwidth)
         ls = self.get_degrees()
 
-        fig, ax = plt.subplots(1, 1)
+        fig, ax = _plt.subplots(1, 1)
         ax.set_xlabel('degree l')
         ax.set_ylabel('bandpower')
         ax.set_xscale('log', basex=bandwidth)
@@ -631,7 +629,7 @@ class SHCoeffs(object):
         ax.plot(ls[1:], power[1:], label='power per degree l')
         fig.tight_layout(pad=0.1)
         if show:
-            plt.show()
+            _plt.show()
         if fname is not None:
             fig.savefig(fname)
 
@@ -1169,7 +1167,7 @@ class SHGrid(object):
         """
         fig, ax = self._plot_rawdata()
         if show:
-            plt.show()
+            _plt.show()
         if fname is not None:
             fig.savefig(fname)
 
@@ -1291,7 +1289,7 @@ class DHRealGrid(SHGrid):
 
     def _plot_rawdata(self):
         """Plot the raw data using a simply cylindrical projection."""
-        fig, ax = plt.subplots(1, 1)
+        fig, ax = _plt.subplots(1, 1)
         ax.imshow(self.data, origin='top', extent=(0., 360., -90., 90.))
         ax.set_title('Driscoll and Healy Grid')
         ax.set_xlabel('longitude')
@@ -1377,7 +1375,7 @@ class DHComplexGrid(SHGrid):
 
     def _plot_rawdata(self):
         """Plot the raw data using a simply cylindrical projection."""
-        fig, ax = plt.subplots(2, 1)
+        fig, ax = _plt.subplots(2, 1)
         ax.flat[0].imshow(self.data.real, origin='top',
                           extent=(0., 360., -90., 90.))
         ax.flat[0].set_title('Driscoll and Healy Grid (real component)')
@@ -1468,7 +1466,7 @@ class GLQRealGrid(SHGrid):
     def _plot_rawdata(self):
         """Plot the raw data using a simply cylindrical projection."""
 
-        fig, ax = plt.subplots(1, 1)
+        fig, ax = _plt.subplots(1, 1)
         ax.imshow(self.data, origin='top')
         ax.set_title('Gauss-Legendre Quadrature Grid')
         ax.set_xlabel('longitude index')
@@ -1553,7 +1551,7 @@ class GLQComplexGrid(SHGrid):
     def _plot_rawdata(self):
         """Plot the raw data using a simply cylindrical projection."""
 
-        fig, ax = plt.subplots(2, 1)
+        fig, ax = _plt.subplots(2, 1)
         ax.flat[0].imshow(self.data.real, origin='top')
         ax.flat[0].set_title('Gauss-Legendre Quadrature Grid (real component)')
         ax.flat[0].set_xlabel('longitude index')
@@ -1578,7 +1576,7 @@ class SHWindow(object):
     provide spectral estimates about a specific region
     """
     def __init__(self):
-        print("use one of the following constructors: [...]")
+        pass
 
     @classmethod
     def from_cap(self, lmax, nwins, theta, clat=0., clon=0., degrees=True):
@@ -1610,7 +1608,7 @@ class SHWindow(object):
         ncolumns = min(maxcolumns, nwins)
         nrows = np.ceil(nwins / ncolumns).astype(int)
         figsize = ncolumns * 1.2, nrows * 1.2 + 0.5
-        fig, axes = plt.subplots(nrows, ncolumns, figsize=figsize)
+        fig, axes = _plt.subplots(nrows, ncolumns, figsize=figsize)
         for ax in axes[:-1, :].flatten():
             for xlabel_i in ax.get_xticklabels():
                 xlabel_i.set_visible(False)
@@ -1629,7 +1627,7 @@ class SHWindow(object):
         fig.tight_layout(pad=0.5)
 
         if show:
-            plt.show()
+            _plt.show()
         if fname is not None:
             fig.savefig(fname)
 
@@ -1656,9 +1654,9 @@ class SHWindow(object):
 
     def plot_couplingmatrix(self, lmax, nwins, show=True, fname=None):
         """plots the window's coupling strength"""
-        figsize = mpl.rcParams['figure.figsize']
+        figsize = _mpl.rcParams['figure.figsize']
         figsize[0] = figsize[1]
-        fig = plt.figure(figsize=figsize)
+        fig = _plt.figure(figsize=figsize)
         ax = fig.add_subplot(111)
         coupling_matrix = self.get_couplingmatrix(lmax, nwins)
         ax.imshow(coupling_matrix)
@@ -1667,7 +1665,7 @@ class SHWindow(object):
         fig.tight_layout(pad=0.1)
 
         if show:
-            plt.show()
+            _plt.show()
         if fname is not None:
             fig.savefig(fname)
 

--- a/pyshtools/shio.py
+++ b/pyshtools/shio.py
@@ -41,6 +41,10 @@ SHrtoc           Convert real spherical harmonics to complex form.
 SHctor           Convert complex spherical harmonics to real form.
 """
 
+from __future__ import absolute_import as _absolute_import
+from __future__ import division as _division
+from __future__ import print_function as _print_function
+
 from ._SHTOOLS import SHRead
 from ._SHTOOLS import SHReadH
 from ._SHTOOLS import SHReadError

--- a/pyshtools/shio.py
+++ b/pyshtools/shio.py
@@ -41,14 +41,20 @@ SHrtoc           Convert real spherical harmonics to complex form.
 SHctor           Convert complex spherical harmonics to real form.
 """
 
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
-from ._SHTOOLS import SHRead, SHReadH, SHReadError, SHReadErrorH
-from ._SHTOOLS import SHRead2, SHRead2Error, SHReadJPL, SHReadJPLError
-from ._SHTOOLS import SHCilmToCindex, SHCindexToCilm, SHCilmToVector
-from ._SHTOOLS import SHVectorToCilm, SHrtoc, SHctor
+from ._SHTOOLS import SHRead
+from ._SHTOOLS import SHReadH
+from ._SHTOOLS import SHReadError
+from ._SHTOOLS import SHReadErrorH
+from ._SHTOOLS import SHRead2
+from ._SHTOOLS import SHRead2Error
+from ._SHTOOLS import SHReadJPL
+from ._SHTOOLS import SHReadJPLError
+from ._SHTOOLS import SHCilmToCindex
+from ._SHTOOLS import SHCindexToCilm
+from ._SHTOOLS import SHCilmToVector
+from ._SHTOOLS import SHVectorToCilm
+from ._SHTOOLS import SHrtoc
+from ._SHTOOLS import SHctor
 
 
 # ---------------------------------------------------------------------

--- a/pyshtools/spectralanalysis.py
+++ b/pyshtools/spectralanalysis.py
@@ -46,6 +46,10 @@ SHCrossPowerSpectrumDensityC  Compute the cross-power spectral density of two
                               complex functions.
 """
 
+from __future__ import absolute_import as _absolute_import
+from __future__ import division as _division
+from __future__ import print_function as _print_function
+
 from ._SHTOOLS import SHPowerL
 from ._SHTOOLS import SHPowerDensityL
 from ._SHTOOLS import SHCrossPowerL

--- a/pyshtools/spectralanalysis.py
+++ b/pyshtools/spectralanalysis.py
@@ -46,15 +46,21 @@ SHCrossPowerSpectrumDensityC  Compute the cross-power spectral density of two
                               complex functions.
 """
 
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
-from ._SHTOOLS import SHPowerL, SHPowerDensityL, SHCrossPowerL
-from ._SHTOOLS import SHCrossPowerDensityL, SHPowerSpectrum
-from ._SHTOOLS import SHPowerSpectrumDensity, SHCrossPowerSpectrum
-from ._SHTOOLS import SHCrossPowerSpectrumDensity, SHAdmitCorr, SHConfidence
-from ._SHTOOLS import SHPowerLC, SHPowerDensityLC, SHCrossPowerLC
-from ._SHTOOLS import SHCrossPowerDensityLC, SHPowerSpectrumC
-from ._SHTOOLS import SHPowerSpectrumDensityC, SHCrossPowerSpectrumC
+from ._SHTOOLS import SHPowerL
+from ._SHTOOLS import SHPowerDensityL
+from ._SHTOOLS import SHCrossPowerL
+from ._SHTOOLS import SHCrossPowerDensityL
+from ._SHTOOLS import SHPowerSpectrum
+from ._SHTOOLS import SHPowerSpectrumDensity
+from ._SHTOOLS import SHCrossPowerSpectrum
+from ._SHTOOLS import SHCrossPowerSpectrumDensity
+from ._SHTOOLS import SHAdmitCorr
+from ._SHTOOLS import SHConfidence
+from ._SHTOOLS import SHPowerLC
+from ._SHTOOLS import SHPowerDensityLC
+from ._SHTOOLS import SHCrossPowerLC
+from ._SHTOOLS import SHCrossPowerDensityLC
+from ._SHTOOLS import SHPowerSpectrumC
+from ._SHTOOLS import SHPowerSpectrumDensityC
+from ._SHTOOLS import SHCrossPowerSpectrumC
 from ._SHTOOLS import SHCrossPowerSpectrumDensityC

--- a/www/using-python.html
+++ b/www/using-python.html
@@ -52,6 +52,7 @@
 	<ul>
 		<li><tt>SHCoeffs</tt> - A high level class for spherical harmonic coefficients.</li>
 		<li><tt>SHGrid</tt> - A high level classes for global grids.</li>
+		<li><tt>SHWindow</tt> - A high level classes for localization windows.</li>
 		<li><tt>shclasses</tt> - All pyshtools classes and subclasses.</li>
 		<li><tt>shtools</tt> - All <tt>pyshtools</tt> routines.</li>
 		<li><tt>legendre</tt> - Legendre functions.</li>


### PR DESCRIPTION
I've removed most future imports that are not necessary. The only exceptions are a few import print_function when print is explicitly used.

One problem I would like to fix is the import _SHTOOLS statement in make_docs, as this is not a relative import. I tried the following but it doesn't work:

In the make file, I ran this as a module using "-m"
~~~~
$(PYTHON) -m ./pyshtools/make_docs.py . .
~~~~
and in make_docs.py I used
~~~~
from . import _SHTOOLS
~~~~
but then I get the error when building:
~~~~
python -m ./pyshtools/make_docs.py . . 
/usr/local/opt/python/bin/python2.7: Relative module names not supported
~~~~
