### PR TITLE
Fix some conversion warnings

### DIFF
--- a/src/MakeCircleCoord.f95
+++ b/src/MakeCircleCoord.f95
@@ -58,7 +58,7 @@ subroutine MakeCircleCoord(coord, lat, lon, theta0, cinterval, cnum)
         interval = 1.0d0
     end if
     
-    num = 360.0d0/interval
+    num = int(360.0d0/interval)
     
     if (present(cnum)) then
         cnum = num

--- a/src/MakeEllipseCoord.f95
+++ b/src/MakeEllipseCoord.f95
@@ -46,7 +46,7 @@ subroutine MakeEllipseCoord(coord, lat, lon, dec, A_theta, B_theta, &
         interval = 1.0d0
     end if
     
-    num = 360.0d0/interval
+    num = int(360.0d0/interval)
     
     if (present(cnum)) then
         cnum = num

--- a/src/MakeGeoidGrid.f95
+++ b/src/MakeGeoidGrid.f95
@@ -134,8 +134,8 @@ subroutine MakeGeoidGrid(geoid, cilm, lmax, r0pot, GM, PotRef, omega, r, &
         nlong = 2 * nlat
         
     else if (gridtype == 4) then
-        nlat = 180.0d0 / interval + 1
-        nlong = 360.0d0 / interval + 1
+        nlat = int(180.0d0 / interval + 1)
+        nlong = int(360.0d0 / interval + 1)
         
     end if
         

--- a/src/MakeGrid2D.f95
+++ b/src/MakeGrid2D.f95
@@ -123,8 +123,8 @@ subroutine MakeGrid2D(grid, cilm, lmax, interval, nlat, nlong, norm, csphase, &
         
     end if
     
-    nlat = (latmax - latmin) / interval + 1
-    nlong = (longmax - longmin) / interval + 1
+    nlat = int((latmax - latmin) / interval + 1)
+    nlong = int((longmax - longmin) / interval + 1)
     
     if (present(norm)) then
         if (norm > 4 .or. norm < 1) then

--- a/src/MakeGridDH.F95
+++ b/src/MakeGridDH.F95
@@ -87,7 +87,7 @@ subroutine MakeGridDH(griddh, n, cilm, lmax, norm, sampling, csphase, &
     real*8, save, allocatable :: ff1(:,:), ff2(:,:), sqr(:)
     integer*1, save, allocatable :: fsymsign(:,:)
     integer, save :: lmax_old = 0, norm_old = 0
-    integer*1 :: phase
+    integer :: phase
     external :: dfftw_plan_dft_c2r_1d, dfftw_execute, dfftw_destroy_plan
 !$OMP   threadprivate(ff1, ff2, sqr, fsymsign, lmax_old, norm_old)
     

--- a/src/MakeGridDHC.F95
+++ b/src/MakeGridDHC.F95
@@ -93,7 +93,7 @@ subroutine MakeGridDHC(griddh, n, cilm, lmax, norm, sampling, &
     real*8, save, allocatable :: ff1(:,:), ff2(:,:), sqr(:)
     integer*1, save, allocatable :: fsymsign(:,:)
     integer, save :: lmax_old = 0, norm_old = 0
-    integer*1 :: phase
+    integer :: phase
     external :: dfftw_plan_dft_1d, dfftw_execute, dfftw_destroy_plan
 !$OMP   threadprivate(ff1, ff2, sqr, fsymsign, lmax_old, norm_old)
     

--- a/src/MakeGridGLQ.F95
+++ b/src/MakeGridGLQ.F95
@@ -88,7 +88,7 @@ subroutine MakeGridGLQ(gridglq, cilm, lmax, plx, zero, norm, csphase, lmax_calc)
     real*8, save, allocatable :: ff1(:,:), ff2(:,:), sqr(:)
     integer*1, save, allocatable :: fsymsign(:,:)
     integer, save :: lmax_old = 0, norm_old = 0
-    integer*1 :: phase
+    integer :: phase
     external :: dfftw_plan_dft_c2r_1d, dfftw_execute, dfftw_destroy_plan
 !$OMP   threadprivate(ff1, ff2, sqr, fsymsign, lmax_old, norm_old)
 

--- a/src/MakeGridGLQC.F95
+++ b/src/MakeGridGLQC.F95
@@ -90,7 +90,7 @@ subroutine MakeGridGLQC(gridglq, cilm, lmax, plx, zero, norm, csphase, &
     real*8, save, allocatable :: ff1(:,:), ff2(:,:), sqr(:)
     integer*1, save, allocatable :: fsymsign(:,:)
     integer, save :: lmax_old = 0, norm_old = 0
-    integer*1 :: phase
+    integer :: phase
     external :: dfftw_plan_dft_1d, dfftw_execute, dfftw_destroy_plan
 !$OMP   threadprivate(ff1, ff2, sqr, fsymsign, lmax_old, norm_old)
 

--- a/src/PreGLQ.f95
+++ b/src/PreGLQ.f95
@@ -156,7 +156,7 @@ integer function NGLQSH(degree)
         stop
     endif
     
-    nglqsh = degree + 1.0d0
+    nglqsh = degree + 1
 
 end function NGLQSH
 

--- a/src/SHExpandDH.F95
+++ b/src/SHExpandDH.F95
@@ -100,7 +100,7 @@ subroutine SHExpandDH(grid, n, cilm, lmax, norm, sampling, csphase, lmax_calc)
     real*8, save, allocatable :: sqr(:), ff1(:,:), ff2(:,:)
     integer*1, save, allocatable :: fsymsign(:,:)
     integer, save :: lmax_old = 0, norm_old = 0
-    integer*1 :: phase
+    integer :: phase
     external :: dfftw_plan_dft_r2c_1d, dfftw_execute, dfftw_destroy_plan
 !$OMP   threadprivate(sqr, ff1, ff2, fsymsign, lmax_old, norm_old)
 

--- a/src/SHExpandDHC.F95
+++ b/src/SHExpandDHC.F95
@@ -104,7 +104,7 @@ subroutine SHExpandDHC(grid, n, cilm, lmax, norm, sampling, csphase, lmax_calc)
     real*8, save, allocatable :: ff1(:,:), ff2(:,:), sqr(:)
     integer*1, save, allocatable :: fsymsign(:,:)
     integer, save :: lmax_old = 0, norm_old = 0
-    integer*1 :: phase
+    integer :: phase
     external :: dfftw_plan_dft_1d, dfftw_execute, dfftw_destroy_plan
 !$OMP   threadprivate(sqr, ff1, ff2, fsymsign, lmax_old, norm_old)
     

--- a/src/SHExpandGLQ.F95
+++ b/src/SHExpandGLQ.F95
@@ -84,7 +84,7 @@ subroutine SHExpandGLQ(cilm, lmax, gridglq, w, plx, zero, norm, csphase, &
     real*8, save, allocatable :: ff1(:,:), ff2(:,:), sqr(:)
     integer*1, save, allocatable :: fsymsign(:,:)
     integer, save :: lmax_old = 0, norm_old = 0
-    integer*1 :: phase
+    integer :: phase
     external :: dfftw_plan_dft_r2c_1d, dfftw_execute, dfftw_destroy_plan
 !$OMP   threadprivate(sqr, ff1, ff2, fsymsign, lmax_old, norm_old)
 

--- a/src/SHExpandGLQC.F95
+++ b/src/SHExpandGLQC.F95
@@ -86,7 +86,7 @@ subroutine SHExpandGLQC(cilm, lmax, gridglq, w, plx, zero, norm, csphase, &
     real*8, save, allocatable :: ff1(:,:), ff2(:,:), sqr(:)
     integer*1, save, allocatable :: fsymsign(:,:)
     integer, save :: lmax_old = 0, norm_old = 0
-    integer*1 :: phase
+    integer :: phase
     external :: dfftw_plan_dft_1d, dfftw_execute, dfftw_destroy_plan
 !$OMP   threadprivate(sqr, ff1, ff2, fsymsign, lmax_old, norm_old)
 

--- a/src/SHExpandLSQ.F95
+++ b/src/SHExpandLSQ.F95
@@ -230,7 +230,7 @@ subroutine SHExpandLSQ(cilm, d, lat, lon, nmax, lmax, norm, chi2, csphase)
     end if
     
     if ( work(1) >  dble(lwork) ) then
-        opt1 = work(1) / min((lmax+1)**2, nmax) - 1
+        opt1 = int(work(1) / min((lmax+1)**2, nmax) - 1)
         print*, "Warning --- SHExpandLSQ"
         print*, "Consider changing parameter value of OPT to ", opt1, &
                 " and recompiling the SHTOOLS archive."


### PR DESCRIPTION
This mostly makes explicit things that are already done.
 * REAL->INTEGER are cast with `int`
 * INTEGER->INTEGER*1 are fixed by changing `phase` into a regular INTEGER. This is consistent with some other cases, though I don't know if it should be the other way. It would change the ABI though.

There are three lines with a COMPLEX->REAL conversion that are left, but I'm not sure what the correct fix is there.