### PR TITLE
Pypi fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,7 +9,6 @@ graft examples/ExampleDataFiles
 recursive-include examples/fortran *.f95 input* Makefile
 recursive-include examples/python *.py Makefile
 recursive-include examples/notebooks *.ipynb
-include examples/python/ClassInterface/topo.dat.gz
 
 graft src/pydoc
 graft src/fdoc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,7 +13,7 @@ include examples/python/ClassInterface/topo.dat.gz
 
 graft src/pydoc
 graft src/fdoc
-recursive-include src *.py
+recursive-include src *.py *.pyf
 
 graft man
 graft www

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ from subprocess import CalledProcessError, check_output, check_call
 
 
 # convert markdown README.md to restructured text .rst for pypi
+# pandoc can be installed with
+# conda install -c conda-forge pandoc pypandoc
 try:
     import pypandoc
     long_description = pypandoc.convert('README.md', 'rst')

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,9 @@ import os
 import re
 import sys
 import sysconfig
-import setuptools
+# the setuptools import dummy patches the distutil commands such that
+# python setup.py develop works
+import setuptools  # NOQA
 
 from numpy.distutils.core import setup
 from numpy.distutils.command.build import build as _build
@@ -212,10 +214,10 @@ def configuration(parent_package='', top_path=None):
 
 metadata = dict(
     name='pyshtools',
-    version=get_version(),
+    version='3.3.1',
     description='SHTOOLS - Tools for working with spherical harmonics',
     url='http://shtools.ipgp.fr',
-    download_url='https://github.com/SHTOOLS/SHTOOLS/zipball/master',
+    download_url='https://github.com/MMesch/SHTOOLS/zipball/pypi-fixes',
     author='The SHTOOLS developers',
     license='BSD',
     keywords=KEYWORDS,

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,14 @@ from numpy.distutils.misc_util import Configuration
 from subprocess import CalledProcessError, check_output, check_call
 
 
+# convert markdown README.md to restructured text .rst for pypi
+try:
+    import pypandoc
+    long_description = pypandoc.convert('README.md', 'rst')
+except(IOError, ImportError):
+    long_description = open('README.md').read()
+
+
 def get_version():
     """Get version from git and VERSION file.
 
@@ -214,8 +222,9 @@ def configuration(parent_package='', top_path=None):
 
 metadata = dict(
     name='pyshtools',
-    version='3.3.1',
+    version=get_version(),
     description='SHTOOLS - Tools for working with spherical harmonics',
+    long_description=long_description,
     url='http://shtools.ipgp.fr',
     download_url='https://github.com/MMesch/SHTOOLS/zipball/pypi-fixes',
     author='The SHTOOLS developers',

--- a/setup.py
+++ b/setup.py
@@ -224,12 +224,12 @@ def configuration(parent_package='', top_path=None):
 
 metadata = dict(
     name='pyshtools',
-    # version=get_version(),
-    version='3.3.2',
+    version=get_version(),
+    # version='3.3.2',  # this line is only for testing
     description='SHTOOLS - Tools for working with spherical harmonics',
     long_description=long_description,
     url='http://shtools.ipgp.fr',
-    download_url='https://github.com/MMesch/SHTOOLS/zipball/pypi-fixes',
+    download_url='https://github.com/SHTOOLS/SHTOOLS/zipball/master',
     author='The SHTOOLS developers',
     license='BSD',
     keywords=KEYWORDS,

--- a/setup.py
+++ b/setup.py
@@ -224,7 +224,8 @@ def configuration(parent_package='', top_path=None):
 
 metadata = dict(
     name='pyshtools',
-    version=get_version(),
+    # version=get_version(),
+    version='3.3.2',
     description='SHTOOLS - Tools for working with spherical harmonics',
     long_description=long_description,
     url='http://shtools.ipgp.fr',


### PR DESCRIPTION
This PR makes SHTOOLS pypi ready. It works on the testpypi server and can be installed with:

``` pip install -i https://testpypi.python.org/pypi pyshtools```

The version string needs to be improved because the direct git version fails for the pypi upload ...