### PR TITLE
Modify travis to run notebooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,14 +53,16 @@ install:
 
 script:
   - if [[ "${PYTHON_VERSION:0:1}" == '2' ]]; then
+      make remove-notebooks
       make notebooks2;
     else
+      make remove-notebooks
       make notebooks3;
     fi
   - mkdir empty
   - cd empty
   - python -c "import pyshtools"
-  - python ../examples/python/TimingAccuracy/TimingAccuracyDH.py
+  - make -C ../examples/notebooks -f Makefile JUPYTER=$(jupyter nbconvert)
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,16 +53,16 @@ install:
 
 script:
   - if [[ "${PYTHON_VERSION:0:1}" == '2' ]]; then
-      make remove-notebooks
+      make remove-notebooks;
       make notebooks2;
     else
-      make remove-notebooks
+      make remove-notebooks;
       make notebooks3;
     fi
   - mkdir empty
   - cd empty
   - python -c "import pyshtools"
-  - make -C ../examples/notebooks -f Makefile JUPYTER=$(jupyter nbconvert)
+  - make -C ../examples/notebooks -f Makefile JUPYTER="jupyter nbconvert"
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,17 +52,11 @@ install:
   - pip install --no-deps .  
 
 script:
-  - if [[ "${PYTHON_VERSION:0:1}" == '2' ]]; then
-      make remove-notebooks;
-      make notebooks2;
-    else
-      make remove-notebooks;
-      make notebooks3;
-    fi
+  - python examples/notebooks/test_notebooks.py
+  - make -C ../examples/python -f Makefile no-timing
   - mkdir empty
   - cd empty
   - python -c "import pyshtools"
-  - make -C ../examples/notebooks -f Makefile JUPYTER="jupyter nbconvert"
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ install:
 
 script:
   - python examples/notebooks/test_notebooks.py
+  - export MPLBACKEND=Agg
   - make -C examples/python -f Makefile no-timing
   - mkdir empty
   - cd empty

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
 
 script:
   - python examples/notebooks/test_notebooks.py
-  - make -C ../examples/python -f Makefile no-timing
+  - make -C examples/python -f Makefile no-timing
   - mkdir empty
   - cd empty
   - python -c "import pyshtools"

--- a/Makefile
+++ b/Makefile
@@ -94,14 +94,24 @@
 #	make python3-tests
 #		Run all python 3 tests.
 #
+#	make python-tests-no-timing
+#		Run all python tests (with exception of timing/accuracy tests), where
+#		the variable PYTHON_VERSION determines which versions to run.
+#
+#	make python2-tests
+#		Run all python tests (with exception of timing/accuracy tests).
+#
+#	make python3-tests
+#		Run all python tests (with exception of timing/accuracy tests).
+#
 #	make clean-python-tests
-#		Detele all compiled python tests
+#		Detele all compiled python tests.
 #
 #	make notebooks
-#		Detele all compiled python tests
+#		Run notebooks and convert to html for web documentation.
 #
-#	make clean-notebooks
-#		Detele all compiled python tests
+#	make remove-notebooks
+#		Remove html notebooks.
 #
 #	make doc
 #		Create the man and html-man pages from input Markdown files.
@@ -205,11 +215,12 @@ endif
 
 
 .PHONY: all fortran python python2 python3 install doc remove-doc\
-	fortran-tests run-fortran-tests run-python-tests\
-	run-python2-tests run-python3-tests install-fortran install-python\
+	fortran-tests run-fortran-tests python-tests\
+	python2-tests python3-tests python-tests-no-timing python2-tests-no-timing\
+	python3-tests-no-timing install-fortran install-python\
 	install-python2 install-python3 uninstall fortran-mp clean\
 	clean-fortran-tests clean-python-tests clean-python2 clean-python3\
-	clean-libs clean-notebooks notebooks notebooks2 notebooks3
+	clean-libs remove-notebooks notebooks notebooks2 notebooks3
 
 
 all: fortran python
@@ -249,16 +260,19 @@ ifeq ($(PYTHON_VERSION),all)
 python: python2 python3
 install-python: install-python2 install-python3
 python-tests: python2-tests python3-tests
+python-tests-no-timing: python2-tests-no-timing python3-tests-no-timing
 notebooks: notebooks3 notebooks2
 else ifeq ($(PYTHON_VERSION),2)
 python: python2
 install-python: install-python2
 python-tests: python2-tests
+python-tests-no-timing: python2-tests-no-timing
 notebooks: notebooks2
 else ifeq ($(PYTHON_VERSION),3)
 python: python3
 install-python: install-python3
 python-tests: python3-tests
+python-tests-no-timing: python3-tests-no-timing
 notebooks: notebooks3
 else
 $(error $(PYTHON_VERSION) is unsupported.)
@@ -452,7 +466,7 @@ clean-libs:
 	@echo \*\*\* If you installed pyshtools using \"pip install -e .\" you should
 	@echo \*\*\* also execute \"pip uninstall pyshtools\".
 
-clean-notebooks:
+remove-notebooks:
 	$(MAKE) -C $(NBDIR) -f Makefile clean
 	@echo
 	@echo REMOVED NOTEBOOK HTML FILES
@@ -487,5 +501,15 @@ python2-tests: python2
 
 python3-tests: python3
 	$(MAKE) -C $(PEXDIR) -f Makefile all PYTHON=$(PYTHON3)
+	@echo
+	@echo RAN ALL PYTHON 3 TESTS
+
+python2-tests-no-timing: python2
+	$(MAKE) -C $(PEXDIR) -f Makefile no-timing PYTHON=$(PYTHON)
+	@echo
+	@echo RAN ALL PYTHON TESTS
+
+python3-tests-no-timing: python3
+	$(MAKE) -C $(PEXDIR) -f Makefile no-timing PYTHON=$(PYTHON3)
 	@echo
 	@echo RAN ALL PYTHON 3 TESTS

--- a/examples/notebooks/test_notebooks.py
+++ b/examples/notebooks/test_notebooks.py
@@ -1,0 +1,38 @@
+"""
+This script will run all jupyter notebooks in order to test for errors.
+"""
+from __future__ import print_function
+
+import sys
+import os
+
+import nbformat
+from nbconvert.preprocessors import ExecutePreprocessor
+
+os.chdir(os.path.dirname(sys.argv[0]))
+
+notebooks = ('Introduction-1.ipynb',
+             'Introduction-2.ipynb',
+             'tutorial_1.ipynb',
+             'tutorial_2.ipynb',
+             'tutorial_3.ipynb',
+             'tutorial_4.ipynb',
+             'tutorial_5.ipynb',
+             'tutorial_6.ipynb')
+
+if sys.version_info.major == 2:
+    kname = 'python2'
+elif sys.version_info.major == 3:
+    kname = 'python3'
+else:
+    raise ('Python version {:d} not supported.'.format(sys.version_info.major))
+
+print('Python kernel name = {:s}'.format(kname))
+
+for i in range(len(notebooks)):
+    with open(notebooks[i]) as f:
+        nb = nbformat.read(f, as_version=4)
+        ep = ExecutePreprocessor(timeout=240, kernel_name=kname)
+
+        print('Processing file {:s}'.format(notebooks[i]))
+        ep.preprocess(nb, {'metadata': {'path': '.'}})

--- a/examples/python/Common/FigStyle.py
+++ b/examples/python/Common/FigStyle.py
@@ -22,5 +22,5 @@ style_shtools = {'font.size': 7,
                  'savefig.dpi': 160,
                  'font.family': 'sans-serif',
                  'font.serif': ['Computer Modern Roman'],
-                 'text.usetex': True,
+                # 'text.usetex': True,
                  'figure.figsize': (columnwidth_in, columnwidth_in / 2)}

--- a/examples/python/GravMag/TestGrav.py
+++ b/examples/python/GravMag/TestGrav.py
@@ -53,7 +53,7 @@ def TestMakeGravGrid():
         lmax_calc=85, omega=constant.omega_mars, normal_gravity=1)
     fig, axes = plt.subplots(2, 2)
 
-    for num, vv, s in ((0, rad, "$g_{r}$"), (1, theta, "$g_{\theta}$"),
+    for num, vv, s in ((0, rad, "$g_{r}$"), (1, theta, "$g_{\\theta}$"),
                        (2, phi, "$g_{\phi}$"),
                        (3, total, "Gravity disturbance")):
         if (num == 3):
@@ -146,7 +146,7 @@ def TestMakeMagGrid():
                                                    lmax_calc=90)
     fig, axes = plt.subplots(2, 2)
 
-    for num, vv, s in ((0, rad, "$B_{r}$"), (1, theta, "$B_{\theta}$"),
+    for num, vv, s in ((0, rad, "$B_{r}$"), (1, theta, "$B_{\\theta}$"),
                        (2, phi, "$B_{\phi}$"), (3, total, "$|B|$")):
         if (num == 3):
             axes.flat[num].imshow(vv, vmin=0, vmax=700)

--- a/examples/python/Makefile
+++ b/examples/python/Makefile
@@ -3,6 +3,10 @@
 #	make all
 #		Run all Python tests.
 #
+#	make no-timing
+#		Run all Python tests, with the exception of the timing/accuracy
+#		routines.
+#
 #	make clean
 #		Remove compiled Python files and output.
 #
@@ -34,6 +38,22 @@ EXAMPLES = \
 	TimingAccuracy/TimingAccuracyGLQC.py \
 	$(EMPTY)
 
+EXAMPLES-NO-TIMING = \
+	ClassInterface/ClassExample.py \
+	ClassInterface/WindowExample.py \
+	GlobalSpectralAnalysis/SHComplexSpectralAnalysis.py \
+	GlobalSpectralAnalysis/SHRealSpectralAnalysis.py \
+	IOStorageConversions/SHConversions.py \
+	IOStorageConversions/SHStorage.py \
+	LocalizedSpectralAnalysis/SHMultitaperSE.py \
+	LocalizedSpectralAnalysis/SHWindowsBiasOther.py \
+	SHRotations/SHRotations.py \
+	GravMag/TestGrav.py \
+	GravMag/TestCT.py \
+	Other/TestOther.py \
+	TestLegendre/TestLegendre.py \
+	$(EMPTY)
+
 define run-example
 # Create a phony rule to run each example.
 $(addsuffix .phony,$1):
@@ -45,6 +65,8 @@ endef
 $(foreach example,$(EXAMPLES),$(eval $(call run-example,$(example))))
 
 all: $(addsuffix .phony, $(EXAMPLES))
+
+no-timing: $(addsuffix .phony, $(EXAMPLES-NO-TIMING))
 
 clean:
 	-rm -rf Common/*.pyc Common/__pycache__/

--- a/pyshtools/shclasses.py
+++ b/pyshtools/shclasses.py
@@ -227,15 +227,16 @@ class SHCoeffs(object):
         """
         Initialize the coefficients as random variables.
 
-        This routine picks random coefficients from a Normal Distribution.
-        The variance of the Normal Distribution is set to the given input power
+        This routine picks random coefficients from a normal distribution.
+        The variance of the normal distribution is set to the given input power
         divided by the number of coefficients at degree l. The output
         coefficient power can be fixed exactly using the keyword exact_power.
 
         Usage
         -----
 
-        x = SHCoeffs.from_random(power, [kind, normalization, csphase, exact_power])
+        x = SHCoeffs.from_random(power, [kind, normalization, csphase,
+                                         exact_power])
 
         Parameters
         ----------


### PR DESCRIPTION
The following modifications have been made:
* The python notebooks are now run by a single python script `test_notebooks.py`, which reads the notebooks, and executes them. This file determines which version of python is being used, and executes the notebooks using that kernel. This is in contrast to the current situation that uses `make notebooks` and which tries to convert all notebooks to html.
* All python tests in `make python-tests-no-timing` are run. This does not run the timing/accuracy routines, which are computationally expensive.
The python tests are run using `Agg` by setting `export MPLBACKEND=Agg` in the travis script.
* In order to avoid installing `tex` on travis, I have commented out the line `'text.usetex': True` in the file `FigStyle.py.