### PR TITLE
Fix docstrings

### DIFF
--- a/pyshtools/make_docs.py
+++ b/pyshtools/make_docs.py
@@ -101,19 +101,19 @@ def process_mddoc(fname_mddoc):
     match = reh1.search(mdstring)
     while match is not None:
         mdstring = re.sub(match.group(0), match.group(1) + '\n' +
-                          len(match.group(1)) * '-' + '\n', mdstring)
+                          len(match.group(1)) * '-', mdstring)
         match = reh1.search(mdstring)
 
     match = reh1b.search(mdstring)
     while match is not None:
         mdstring = re.sub(match.group(0), '\n' + match.group(1) + '\n' +
-                          len(match.group(1)) * '-' + '\n', mdstring)
+                          len(match.group(1)) * '-', mdstring)
         match = reh1b.search(mdstring)
 
     match = reh2.search(mdstring)
     while match is not None:
         mdstring = re.sub(match.group(0), match.group(1) + '\n' +
-                          len(match.group(1)) * '-' + '\n', mdstring)
+                          len(match.group(1)) * '-', mdstring)
         match = reh2.search(mdstring)
 
     match = recode.search(mdstring)

--- a/pyshtools/make_docs.py
+++ b/pyshtools/make_docs.py
@@ -129,12 +129,18 @@ def process_mddoc(fname_mddoc):
     # ---- combine into docstring ----
     docstring = ''
     tmp = mdstring.splitlines(True)
+    for i in range(0, len(tmp)-3):
+        if tmp[i][0:4] == ':   ' and tmp[i+3][0:4] == ':   ':
+            tmp[i+1] = ''
+
     for i in range(0, len(tmp)):
         if tmp[i][0:4] == ':   ':
             docstring += textwrap.fill(tmp[i][4:], width=80,
                                        replace_whitespace=False,
                                        initial_indent='    ',
                                        subsequent_indent='    ') + '\n'
+        elif tmp[i] == '':
+            pass
         else:
             docstring += textwrap.fill(tmp[i], width=80,
                                        replace_whitespace=False) + '\n'

--- a/pyshtools/make_docs.py
+++ b/pyshtools/make_docs.py
@@ -129,6 +129,8 @@ def process_mddoc(fname_mddoc):
     # ---- combine into docstring ----
     docstring = ''
     tmp = mdstring.splitlines(True)
+
+    # --- remove line breaks between parameters ---
     for i in range(0, len(tmp)-3):
         if tmp[i][0:4] == ':   ' and tmp[i+3][0:4] == ':   ':
             tmp[i+1] = ''

--- a/pyshtools/shclasses.py
+++ b/pyshtools/shclasses.py
@@ -128,12 +128,10 @@ class SHCoeffs(object):
 
         Usage
         -----
-
         x = SHCoeffs.from_zeros(lmax, [normalization, csphase])
 
         Parameters
         ----------
-
         lmax          : The highest harmonic degree l of the coefficients
         normalization : '4pi' (default), 'ortho' or 'schmidt' for geodesy 4pi
                         normalized, orthonormalized, or Schmidt semi-normalized
@@ -180,12 +178,10 @@ class SHCoeffs(object):
 
         Usage
         -----
-
         x = SHCoeffs.from_array(array, [normalization, csphase])
 
         Parameters
         ----------
-
         array         : numpy array of size (2, lmax+1, lmax+1).
         normalization : '4pi' (default), 'ortho' or 'schmidt' for geodesy 4pi
                         normalized, orthonormalized, or Schmidt semi-normalized
@@ -237,13 +233,11 @@ class SHCoeffs(object):
 
         Usage
         -----
-
         x = SHCoeffs.from_random(power, [kind, normalization, csphase,
                                          exact_power])
 
         Parameters
         ----------
-
         power         : numpy array of size (lmax+1) that specifies the power
                         per degree l of the random coefficients. This is
                         usually the expected power.
@@ -328,7 +322,6 @@ class SHCoeffs(object):
 
         Usage
         -----
-
         x = SHCoeffs.from_file(filename, lmax, [format='shtools', kind,
                                                 normalization, csphase, skip])
         x = SHCoeffs.from_file(filename, [format='npy', kind, normalization,
@@ -336,7 +329,6 @@ class SHCoeffs(object):
 
         Parameters
         ----------
-
         filename      : Name of the file, including path.
         lmax          : Maximum spherical harmonic degree to read from the
                         file when format is 'shtools'.
@@ -353,7 +345,6 @@ class SHCoeffs(object):
 
         Description
         -----------
-
         If format='shtools', spherical harmonic coefficients will be read from
         an ascii-formatted file. The maximum spherical harmonic degree that is
         read is determined by the input value lmax. If the optional value skip
@@ -417,12 +408,10 @@ class SHCoeffs(object):
 
         Usage
         -----
-
         x.tofile(filename, [format, **kwargs])
 
         Parameters
         ----------
-
         filename : Name of the output file.
         format   : 'shtools' (default) or 'npy'.
         **kwargs : Keyword arguments of numpy.save().
@@ -618,12 +607,10 @@ class SHCoeffs(object):
 
         Usage
         -----
-
         degrees = x.get_degrees()
 
         Returns
         -------
-
         degrees : numpy ndarray of size (lmax+1).
         """
         return _np.arange(self.lmax + 1)
@@ -634,12 +621,10 @@ class SHCoeffs(object):
 
         Usage
         -----
-
         power = x.get_powerperdegree()
 
         Returns
         -------
-
         power : numpy ndarray of size (lmax+1).
         """
         return self._powerperdegree()
@@ -650,12 +635,10 @@ class SHCoeffs(object):
 
         Usage
         -----
-
         power = x.get_powerperband()
 
         Returns
         -------
-
         power : numpy ndarray of size (lmax+1).
         """
         ls = self.get_degrees()
@@ -668,12 +651,10 @@ class SHCoeffs(object):
 
         Usage
         -----
-
         x.set_coeffs(values, ls, ms)
 
         Parameters
         ----------
-
         values : One or several coefficient values.
         ls     : The degree/s of the coefficients that should be set.
         ms     : The order/s of the coefficients that should be set. Positive
@@ -695,12 +676,10 @@ class SHCoeffs(object):
 
         Usage
         -----
-
         coeffs = x.get_coeffs([normalization, csphase, lmax])
 
         Returns
         -------
-
         coeffs : numpy ndarray of size (2, lmax + 1, lmax + 1).
 
         Parameters
@@ -752,12 +731,10 @@ class SHCoeffs(object):
 
         Usage
         -----
-
         SHCoeffsInstance = x.rotate(alpha, beta, gamma, [degrees, dj_matrix])
 
         Parameters
         ----------
-
         alpha, beta, gamma : The three Euler rotation angles in degrees.
         degrees            : True (default) if the Euler angles are in degrees,
                              False if they are in radians.
@@ -885,12 +862,10 @@ class SHCoeffs(object):
 
         Usage
         -----
-
         SHGridInstance = x.expand([grid, lmax, lmax_calc, zeros])
 
         Parameters
         ----------
-
         grid      : 'DH' or 'DH1' for an equisampled lat/lon grid with
                     nlat=nlon, 'DH2' for an equidistant lat/lon grid with
                     nlon=2*nlat, or 'GLQ' for a Gauss-Legendre quadrature grid.
@@ -903,7 +878,6 @@ class SHCoeffs(object):
 
         Description
         -----------
-
         For more information concerning the spherical harmonic expansions, and
         the properties of the output grids, see the documentation for
         SHExpandDH, SHExpandDHC, SHExpandGLQ and SHExpandGLQC.
@@ -933,12 +907,10 @@ class SHCoeffs(object):
 
         Usage
         -----
-
         x.plot_powerperdegree([loglog, show, fname])
 
         Parameters
         ----------
-
         loglog : If True (default), use log-log axis.
         show   : If True (default), plot to the screen.
         fname  : If present, save the image to the file.
@@ -966,12 +938,10 @@ class SHCoeffs(object):
 
         Usage
         -----
-
         x.plot_powerperband([loglog, show, fname])
 
         Parameters
         ----------
-
         bandwidth : The bandwidth, default = 2.
         loglog    : If True (default), use log-log axis.
         show      : If True (default), plot to the screen.
@@ -1000,7 +970,6 @@ class SHCoeffs(object):
 
         Usage
         -----
-
         x.info()
         """
         print('kind = {:s}\nnormalization = {:s}\n'
@@ -1048,7 +1017,6 @@ class SHRealCoeffs(SHCoeffs):
 
         Usage
         -----
-
         SHComplexCoeffsInstance = x.make_complex()
         """
         rcomplex_coeffs = _shtools.SHrtoc(self.coeffs,
@@ -1224,7 +1192,6 @@ class SHComplexCoeffs(SHCoeffs):
 
         Usage
         -----
-
         SHRealCoeffsInstance = x.make_real()
         """
         # First test if the coefficients correspond to a real grid.
@@ -1458,12 +1425,10 @@ class SHGrid(object):
 
         Usage
         -----
-
         x = SHGrid.from_array(array, [grid])
 
         Parameters
         ----------
-
         array : numpy array of size (nlat, nlon)
         grid  : 'DH' (default) or 'GLQ' for Driscoll and Healy grids or Gauss
                 Legendre Quadrature grids, respectively.
@@ -1498,12 +1463,10 @@ class SHGrid(object):
 
         Usage
         -----
-
         x = SHGrid.from_file(fname, [binary, **kwargs])
 
         Parameters
         ----------
-
         fname    : The filename containing the gridded data. For text files
                    (default) the file is read using the numpy routine
                    loadtxt(), whereas for binary files, the file is read using
@@ -1554,12 +1517,10 @@ class SHGrid(object):
 
         Usage
         -----
-
         x.tofile(filename, [binary, **kwargs])
 
         Parameters
         ----------
-
         filename : Name of output file. For text files (default), the file will
                    be saved automatically in gzip compressed format if the
                    filename ends in .gz.
@@ -1708,12 +1669,10 @@ class SHGrid(object):
 
         Usage
         -----
-
         lats = x.get_lats()
 
         Parameters
         -------
-
         lats    : numpy array of size nlat containing the latitude of each row
                   of the gridded data.
         degrees : If True (default), the output will be in degrees. If False,
@@ -1730,12 +1689,10 @@ class SHGrid(object):
 
         Usage
         -----
-
         lons = x.get_lon()
 
         Parameters
         -------
-
         lons    : numpy array of size nlon containing the longitude of each
                   column of the gridded data.
         degrees : If True (default), the output will be in degrees. If False,
@@ -1752,12 +1709,10 @@ class SHGrid(object):
 
         Usage
         -----
-
         grid = x.get_grid()
 
         Returns
         -------
-
         grid : numpy array of the gridded data of size (nlat, nlon).
         """
         return self.data
@@ -1771,12 +1726,10 @@ class SHGrid(object):
 
         Usage
         -----
-
         x.plot_3dsphere([show, fname])
 
         Parameters
         ----------
-
         show   : If True (default), plot the image to the screen.
         fname  : If present, save the image to the file.
         """
@@ -1873,12 +1826,10 @@ class SHGrid(object):
 
         Usage
         -----
-
         x.plot_rawdata([show, fname])
 
         Parameters
         ----------
-
         show   : If True (default), plot the image to the screen.
         fname  : If present, save the image to the file.
         """
@@ -1895,12 +1846,10 @@ class SHGrid(object):
 
         Usage
         -----
-
         SHCoeffsInstance = x.expand([normalization, csphase, lmax_calc])
 
         Parameters
         ----------
-
         normalization : '4pi' (default), geodesy 4-pi normalized
                       : 'ortho', orthonormalized
                       : 'schmidt', Schmidt semi-normalized)
@@ -1935,7 +1884,6 @@ class SHGrid(object):
 
         Usage
         -----
-
         x.info()
         """
         print('kind = {:s}\ngrid = {:s}\n'.format(repr(self.kind),
@@ -2401,13 +2349,11 @@ class SHWindow(object):
 
         Usage
         -----
-
         x = SHWindow.from_cap(theta, lwin, [clat, clon, nwin, theta_degrees,
                                             coord_degrees, dj_matrix, weights])
 
         Parameters
         ----------
-
         theta          : Angular radius of the spherical cap localization
                          domain (default in degrees).
         lwin           : Spherical harmonic bandwidth of the localization
@@ -2443,12 +2389,10 @@ class SHWindow(object):
 
         Usage
         -----
-
         x = SHWindow.from_mask(dh_mask, lwin, [nwin])
 
         Parameters
         ----------
-
         dh_mask  : A Driscoll and Healy (1994) sampled grid describing the
                    concentration region R. All elements should either be 1
                    (for inside the concentration region) or 0 (for outside the
@@ -2494,12 +2438,10 @@ class SHWindow(object):
 
         Usage
         -----
-
         degrees = x.get_degrees()
 
         Returns
         -------
-
         degrees : numpy ndarray of size (lwin+1).
         """
         return _np.arange(self.lwin + 1)
@@ -2511,18 +2453,15 @@ class SHWindow(object):
 
         Usage
         -----
-
         k = x.get_k(alpha)
 
         Returns
         -------
-
         k : The number of windows with concentration factors greater or equal
             to alpha.
 
         Parameters
         ----------
-
         alpha  : The concentration factor, which is the power of the window
                  within the concentration region divided by the total power.
         """
@@ -2535,17 +2474,14 @@ class SHWindow(object):
 
         Usage
         -----
-
         coeffs = x.get_coeffs(itaper, [normalization, csphase])
 
         Returns
         -------
-
         coeffs : numpy ndarray of size (2, lwin + 1, lwin + 1).
 
         Parameters
         ----------
-
         itaper        : Taper number, where itaper = 0 is the best
                         concentrated.
         normalization : Normalization of the output coefficients:
@@ -2582,12 +2518,10 @@ class SHWindow(object):
 
         Usage
         -----
-
         gridout = x.get_grid(itaper, [grid, zeros])
 
         Parameters
         ----------
-
         grid      : 'DH' or 'DH1' for an equisampled lat/lon grid with
                     nlat = nlon, 'DH2' for an equidistant lat/lon grid with
                     nlon = 2 * nlat, or 'GLQ' for a Gauss-Legendre quadrature
@@ -2597,7 +2531,6 @@ class SHWindow(object):
 
         Description
         -----------
-
         For more information concerning the spherical harmonic expansions and
         the properties of the output grids, see the documentation for
         SHExpandDH and SHExpandGLQ.
@@ -2635,12 +2568,10 @@ class SHWindow(object):
 
         Usage
         -----
-
         SHCoeffsInstance = x.return_coeffs(itaper, [normalization, csphase])
 
         Parameters
         ----------
-
         itaper        : Taper number, where itaper = 0 is the best
                         concentrated.
         normalization : Normalization of the output class: '4pi' (default),
@@ -2682,12 +2613,10 @@ class SHWindow(object):
 
         Usage
         -----
-
         SHGridInstance = x.return_grid(itaper, [grid, zeros])
 
         Parameters
         ----------
-
         grid      : 'DH' or 'DH1' for an equisampled lat/lon grid with
                     nlat = nlon, 'DH2' for an equidistant lat/lon grid with
                     nlon = 2 * nlat, or 'GLQ' for a Gauss-Legendre quadrature
@@ -2697,7 +2626,6 @@ class SHWindow(object):
 
         Description
         -----------
-
         For more information concerning the spherical harmonic expansions and
         the properties of the output grids, see the documentation for
         SHExpandDH and SHExpandGLQ.
@@ -2729,7 +2657,6 @@ class SHWindow(object):
 
         Usage
         -----
-
         mtse, sd = x.get_multitaperpowerspectrum(clm, k, [lmax, taper_wt, clat,
                                                           clon, coord_degrees])
 
@@ -2758,7 +2685,6 @@ class SHWindow(object):
 
         Usage
         -----
-
         mtse, sd = x.get_multitapercrosspowerspectrum(
                       clm, slm, k, [lmax, taper_wt, clat, clon, coord_degrees])
 
@@ -2792,7 +2718,6 @@ class SHWindow(object):
 
         Usage
         -----
-
         outspectrum = x.get_biasedpowerspectrum(power, k, [taper_wt, save_cg,
                                                            ldata])
 
@@ -2823,12 +2748,10 @@ class SHWindow(object):
 
         Usage
         -----
-
         power = x.get_powerperdegree([itaper, nwin])
 
         Parameters
         ----------
-
         power   : A matrix with each column containing the power spectrum
                   of a localization window, and where the windows are arranged
                   with increasing concentration factors. If itaper is set,
@@ -2863,12 +2786,10 @@ class SHWindow(object):
 
         Usage
         -----
-
         Mmt = x.get_couplingmatrix(lmax, [nwin, weights, mode])
 
         Parameters
         ----------
-
         lmax    : Spherical harmonic bandwidth of the global power spectrum.
         nwin    : Number of tapers used in the mutlitaper spectral analysis.
                   Default = x.nwin
@@ -2921,12 +2842,10 @@ class SHWindow(object):
 
         Usage
         -----
-
         x.plot_windows(nwin, [show, fname])
 
         Parameters
         ----------
-
         nwin   : The number of localization windows to plot.
         show   : If True (default), plot the image to the screen.
         fname  : If present, save the image to the file.
@@ -2969,12 +2888,10 @@ class SHWindow(object):
 
         Usage
         -----
-
         x.plot_powerspectra(nwin, [show, fname])
 
         Parameters
         ----------
-
         nwin   : The number of localization windows to plot.
         show   : If True (default), plot the image to the screen.
         fname  : If present, save the image to the file.
@@ -3025,12 +2942,10 @@ class SHWindow(object):
 
         Usage
         -----
-
         x.plot_couplingmatrix(lmax, [nwin, weights, mode, show, fname])
 
         Parameters
         ----------
-
         lmax    : Spherical harmonic bandwidth of the global power spectrum.
         nwin    : Number of tapers used in the mutlitaper spectral analysis.
                   Default = x.nwin
@@ -3073,7 +2988,6 @@ class SHWindow(object):
 
         Usage
         -----
-
         x.info()
         """
         self._info()
@@ -3177,12 +3091,10 @@ class SHWindowCap(SHWindow):
 
         Usage
         -----
-
         x.rotate(clat, clon [coord_degrees, dj_matrix])
 
         Parameters
         ----------
-
         clat, clon    : Latitude and longitude of the center of the rotated
                         spherical-cap localization windows (default in
                         degrees).
@@ -3194,7 +3106,6 @@ class SHWindowCap(SHWindow):
 
         Description
         -----------
-
         This function will take the spherical-cap localization windows
         centered at the north pole (and saved in the attributes tapers and
         orders), rotate each function to the coordinate (clat, clon), and save

--- a/pyshtools/shclasses.py
+++ b/pyshtools/shclasses.py
@@ -72,7 +72,7 @@ class SHCoeffs(object):
 
     lmax          : The maximum spherical harmonic degree of the coefficients.
     coeffs        : The raw coefficients with the specified normalization and
-                    phase conventions.
+                    csphase conventions.
     normalization : The normalization of the coefficients: '4pi', 'ortho', or
                     'schmidt'.
     csphase       : Defines whether the Condon-Shortley phase is used (1)
@@ -88,11 +88,11 @@ class SHCoeffs(object):
     get_powerperdegree()  : Return an array with the power per degree spectrum.
     get_powerperband()    : Return an array with the power per log_{bandwidth}
                             spectrum.
-    get_coeffs()          : Return an array of spherical harmonics coefficients
+    get_coeffs()          : Return an array of spherical harmonic coefficients
                             with a different normalization convention.
     set_coeffs()          : Set coefficients in-place to specified values.
     rotate()              : Rotate the coordinate system used to express the
-                            spherical harmonics coefficients and return a new
+                            spherical harmonic coefficients and return a new
                             class instance.
     return_coeffs()       : Return the current class instance as a new instance
                             using a different normalization convention.
@@ -123,22 +123,30 @@ class SHCoeffs(object):
     @classmethod
     def from_zeros(self, lmax, kind='real', normalization='4pi', csphase=1):
         """
-        Initialize class with spherical harmonics set to zero from degree
-        0 to lmax.
+        Initialize class with spherical harmonic coefficients set to zero from
+        degree 0 to lmax.
 
         Usage
         -----
         x = SHCoeffs.from_zeros(lmax, [normalization, csphase])
 
+        Returns
+        -------
+        x : SHCoeffs class instance.
+
         Parameters
         ----------
-        lmax          : The highest harmonic degree l of the coefficients
-        normalization : '4pi' (default), 'ortho' or 'schmidt' for geodesy 4pi
-                        normalized, orthonormalized, or Schmidt semi-normalized
-                        coefficients, respectively.
-        csphase       : 1 (default) if the coefficients exclude the Condon-
-                        Shortley phase factor, or -1 if they include it.
-        kind          : 'real' (default) or 'complex' output coefficients.
+        lmax : int
+            The highest spherical harmonic degree l of the coefficients.
+        normalization : str, optional, default = '4pi'
+            '4pi', 'ortho' or 'schmidt' for geodesy 4pi normalized,
+            orthonormalized, or Schmidt semi-normalized coefficients,
+            respectively.
+        csphase : int, optional, defalt = 1
+            1 if the coefficients exclude the Condon-Shortley phase factor, or
+            -1 if they include it.
+        kind : str, optional, default = 'real'
+            'real' or 'complex' spherical harmonic coefficients.
         """
         if kind.lower() not in set(['real', 'complex']):
             raise ValueError(
@@ -174,23 +182,31 @@ class SHCoeffs(object):
     @classmethod
     def from_array(self, coeffs, normalization='4pi', csphase=1, copy=True):
         """
-        Initialize the coefficients from an input numpy array.
+        Initialize the class with spherical harmonic coefficients from an input
+        array.
 
         Usage
         -----
-        x = SHCoeffs.from_array(array, [normalization, csphase])
+        x = SHCoeffs.from_array(array, [normalization, csphase, copy])
+
+        Returns
+        -------
+        x : SHCoeffs class instance.
 
         Parameters
         ----------
-        array         : numpy array of size (2, lmax+1, lmax+1).
-        normalization : '4pi' (default), 'ortho' or 'schmidt' for geodesy 4pi
-                        normalized, orthonormalized, or Schmidt semi-normalized
-                        coefficients, respectively.
-        csphase       : 1 (default) if the coefficients exclude the Condon-
-                        Shortley phase factor, or -1 if they include it.
-        copy          : If True (default), make a copy of array when
-                        initializing the class instance. If False, initialize
-                        the class instance with a reference to array.
+        array : ndarray, size (2, lmax+1, lmax+1).
+            The input spherical harmonic coefficients.
+        normalization : str, optional, default = '4pi'
+            '4pi', 'ortho' or 'schmidt' for geodesy 4pi normalized,
+            orthonormalized, or Schmidt semi-normalized coefficients,
+            respectively.
+        csphase : int, optional, default = 1
+            1 if the coefficients exclude the Condon-Shortley phase factor, or
+            -1 if they include it.
+        copy : bool, optional, default = True
+            If True, make a copy of array when initializing the class instance.
+            If False, initialize the class instance with a reference to array.
         """
         if _np.iscomplexobj(coeffs):
             kind = 'complex'
@@ -224,7 +240,8 @@ class SHCoeffs(object):
     def from_random(self, power, kind='real', normalization='4pi', csphase=1,
                     exact_power=False):
         """
-        Initialize the coefficients as random variables.
+        Initialize the class with spherical harmonic coefficients as random
+        variables.
 
         This routine picks random coefficients from a normal distribution.
         The variance of the normal distribution is set to the given input power
@@ -236,22 +253,28 @@ class SHCoeffs(object):
         x = SHCoeffs.from_random(power, [kind, normalization, csphase,
                                          exact_power])
 
+        Returns
+        -------
+        x : SHCoeffs class instance.
+
         Parameters
         ----------
-        power         : numpy array of size (lmax+1) that specifies the power
-                        per degree l of the random coefficients. This is
-                        usually the expected power.
-        kind          : 'real' (default) or 'complex' output coefficients.
-        normalization : '4pi' (default), 'ortho' or 'schmidt' for geodesy 4pi
-                        normalized, orthonormalized, or Schmidt semi-normalized
-                        coefficients, respectively.
-        csphase       : 1 (default) if the coefficients exclude the Condon-
-                        Shortley phase factor, or -1 if they include it.
-        exact_power   : The total variance of the coefficients is set exactly
-                        to the input power. This means that only the
-                        distribution of power at degree l amongst coefficients
-                        with different m is random but their total power is
-                        fixed.
+        power : ndarray, size (lmax+1)
+            numpy array of size (lmax+1) that specifies the expected power per
+            degree l of the random coefficients.
+        kind : str, optional, default = 'real'
+            'real' or 'complex' spherical harmonic coefficients.
+        normalization : str, optional, defaul = '4pi'
+            '4pi', 'ortho' or 'schmidt' for geodesy 4pi normalized,
+            orthonormalized, or Schmidt semi-normalized coefficients,
+            respectively.
+        csphase : int, optional, default = 1
+            1 if the coefficients exclude the Condon-Shortley phase factor, or
+            -1 if they include it.
+        exact_power : bool, optional, default = False
+            The total variance of the coefficients is set exactly to the input
+            power. This means that the distribution of power at degree l
+            amongst the angular orders is random, but the total power is fixed.
         """
         # check if all arguments are correct
         if type(normalization) != str:
@@ -318,30 +341,42 @@ class SHCoeffs(object):
     def from_file(self, fname, lmax=None, format='shtools', kind='real',
                   normalization='4pi', csphase=1, **kwargs):
         """
-        Initialize the coefficients from a file.
+        Initialize the class with spherical harmonic coefficients from a file.
 
         Usage
         -----
         x = SHCoeffs.from_file(filename, lmax, [format='shtools', kind,
                                                 normalization, csphase, skip])
         x = SHCoeffs.from_file(filename, [format='npy', kind, normalization,
-                                          csphase])
+                                          csphase, **kwargs])
+
+        Returns
+        -------
+        x : SHCoeffs class instance.
 
         Parameters
         ----------
-        filename      : Name of the file, including path.
-        lmax          : Maximum spherical harmonic degree to read from the
-                        file when format is 'shtools'.
-        format        : 'shtools' (default) or 'npy'.
-        kind          : Output 'real' (default) or 'complex' coefficients.
-        normalization : '4pi' (default), 'ortho' or 'schmidt' for geodesy 4pi
-                        normalized, orthonormalized, or Schmidt semi-normalized
-                        coefficients, respectively.
-        csphase       : 1 (default) if the coefficients exclude the Condon-
-                        Shortley phase factor, or -1 if they include it.
-        skip          : Number of lines to skip at the beginning of the file
-                        when format is 'shtools'.
-        **kwargs      : Keyword arguments of numpy.load() when format is 'npy'.
+        filename : str
+            Name of the file, including path.
+        lmax : int, required when format = 'shtools'
+            Maximum spherical harmonic degree to read from the file when format
+            is 'shtools'.
+        format : str, optional, default = 'shtools'
+            'shtools' format or binary numpy 'npy' format.
+        kind : str, optional, default = 'real'
+            'real' or 'complex' spherical harmonic coefficients.
+        normalization : str, optional, default = '4pi'
+            '4pi', 'ortho' or 'schmidt' for geodesy 4pi normalized,
+            orthonormalized, or Schmidt semi-normalized coefficients,
+            respectively.
+        csphase : int, optional, default = 1
+            1 if the coefficients exclude the Condon-Shortley phase factor, or
+            -1 if they include it.
+        skip : int, required when format = 'shtools'
+            Number of lines to skip at the beginning of the file when format is
+            'shtools'.
+        **kwargs : keyword argument list, optional for format = 'npy'
+            Keyword arguments of numpy.load() when format is 'npy'.
 
         Description
         -----------
@@ -412,9 +447,12 @@ class SHCoeffs(object):
 
         Parameters
         ----------
-        filename : Name of the output file.
-        format   : 'shtools' (default) or 'npy'.
-        **kwargs : Keyword arguments of numpy.save().
+        filename : str
+            Name of the output file.
+        format : str, optional, default = 'shtools'
+            'shtools' or 'npy'. See method from_file for more information.
+        **kwargs : keyword argument list, optional for format = 'npy'
+            Keyword arguments of numpy.save().
         """
         if format is 'shtools':
             with open(filename, mode='w') as file:
@@ -466,7 +504,7 @@ class SHCoeffs(object):
     def __sub__(self, other):
         """
         Subtract two similar sets of coefficients or coefficients and a scalar:
-        self-other.
+        self - other.
         """
         if isinstance(other, SHCoeffs):
             if (self.normalization == other.normalization and self.csphase ==
@@ -492,7 +530,7 @@ class SHCoeffs(object):
     def __rsub__(self, other):
         """
         Subtract two similar sets of coefficients or coefficients and a scalar:
-        other-self.
+        other - self.
         """
         if isinstance(other, SHCoeffs):
             if (self.normalization == other.normalization and self.csphase ==
@@ -603,7 +641,8 @@ class SHCoeffs(object):
     # ---- Extract data ----
     def get_degrees(self):
         """
-        Return a numpy array with the harmonic degrees from 0 to lmax.
+        Return a numpy array with the spherical harmonic degrees from 0 to
+        lmax.
 
         Usage
         -----
@@ -611,7 +650,9 @@ class SHCoeffs(object):
 
         Returns
         -------
-        degrees : numpy ndarray of size (lmax+1).
+        degrees : ndarray, size (lmax+1)
+            1-D numpy ndarray listing the spherical harmonic degrees, where
+            lmax is the maximum spherical harmonic degree.
         """
         return _np.arange(self.lmax + 1)
 
@@ -625,7 +666,9 @@ class SHCoeffs(object):
 
         Returns
         -------
-        power : numpy ndarray of size (lmax+1).
+        power : ndarray, size (lmax+1)
+            1-D numpy ndarray of the power per degree l spectrum, where lmax
+            is the maximum spherical harmonic degree.
         """
         return self._powerperdegree()
 
@@ -639,7 +682,9 @@ class SHCoeffs(object):
 
         Returns
         -------
-        power : numpy ndarray of size (lmax+1).
+        power : ndarray, size (lmax+1)
+            1-D numpy ndarray of the power spectrum, where lmax is the maximum
+            spherical harmonic degree.
         """
         ls = self.get_degrees()
         return self._powerperdegree() * ls * _np.log(bandwidth)
@@ -647,7 +692,7 @@ class SHCoeffs(object):
     # ---- Set individual coefficient
     def set_coeffs(self, values, ls, ms):
         """
-        Set coefficients in-place to specified values.
+        Set spherical harmonic coefficients in-place to specified values.
 
         Usage
         -----
@@ -655,11 +700,20 @@ class SHCoeffs(object):
 
         Parameters
         ----------
-        values : One or several coefficient values.
-        ls     : The degree/s of the coefficients that should be set.
-        ms     : The order/s of the coefficients that should be set. Positive
-                 and negative values correspond to the cosine and sine
-                 components, respectively.
+        values : float or complex (list)
+            The value(s) of the spherical harmonic coefficient(s).
+        ls : int (list)
+            The degree(s) of the coefficient(s) that should be set.
+        ms : int (list)
+            The order(s) of the coefficient(s) that should be set. Positive
+            and negative values correspond to the cosine and sine
+            components, respectively.
+
+        Examples
+        --------
+        x.set_coeffs(10.,1,1)               # x.coeffs[0,1,1] = 10.
+        x.set_coeffs([1.,2], [1,2], [0,-2]) # x.coeffs[0,1,0] = 1.
+                                            # x.coeffs[1,2,2] = 2.
         """
         # make sure that the type is correct
         values = _np.array(values)
@@ -670,7 +724,7 @@ class SHCoeffs(object):
         self.coeffs[mneg_mask, ls, _np.abs(ms)] = values
 
     # ---- Return coefficients with a different normalization convention ----
-    def get_coeffs(self, normalization='4pi', csphase=1, lmax=None):
+    def get_coeffs(self, normalization=None, csphase=None, lmax=None):
         """
         Return spherical harmonics coefficients as a numpy array.
 
@@ -680,20 +734,27 @@ class SHCoeffs(object):
 
         Returns
         -------
-        coeffs : numpy ndarray of size (2, lmax + 1, lmax + 1).
+        coeffs : ndarry, size (2, lmax+1, lmax+1)
+            numpy ndarray of the spherical harmonic coefficients.
 
         Parameters
         ----------
-
-        normalization : Normalization of the output coefficients:
-                        '4pi' (default), 'ortho' or 'schmidt' for geodesy 4pi
-                        normalized, orthonormalized, or Schmidt semi-normalized
-                        coefficients, respectively.
-        csphase       : Output Condon-Shortley phase convention: 1 (default)
-                        to exlcude the phase factor, or -1 to include it.
-        lmax          : Maximum spherical harmonic degree to output.
-                        Default is x.lmax.
+        normalization : str, optional, default = x.normalization
+            Normalization of the output coefficients. '4pi', 'ortho' or
+            'schmidt' for geodesy 4pi normalized, orthonormalized, or Schmidt
+            semi-normalized coefficients, respectively.
+        csphase : int, optional, default = x.csphase
+            Output Condon-Shortley phase convention. 1 to exlcude the phase
+            factor, or -1 to include it.
+        lmax : int, optional, default = x.lmax
+            Maximum spherical harmonic degree to output.
         """
+        if normalization is None:
+            normalization = self.normalization
+
+        if csphase is None:
+            csphase = self.csphase
+
         if type(normalization) != str:
             raise ValueError('normalization must be a string. ' +
                              'Input type was {:s}'
@@ -727,19 +788,26 @@ class SHCoeffs(object):
     # ---- Rotate the coordinate system ----
     def rotate(self, alpha, beta, gamma, degrees=True, dj_matrix=None):
         """
-        Rotate the coordinate return rotated Coefficient class.
+        Rotate the coordinate system used to express the spherical harmonic
+        coeffcients and return a new class instance.
 
         Usage
         -----
-        SHCoeffsInstance = x.rotate(alpha, beta, gamma, [degrees, dj_matrix])
+        x_rotated = x.rotate(alpha, beta, gamma, [degrees, dj_matrix])
+
+        Returns
+        -------
+        x_rotated : SHCoeffs class instance
 
         Parameters
         ----------
-        alpha, beta, gamma : The three Euler rotation angles in degrees.
-        degrees            : True (default) if the Euler angles are in degrees,
-                             False if they are in radians.
-        dj_matrix          : The djpi2 rotation matrix (default=None), computed
-                             by a call to djpi2.
+        alpha, beta, gamma : float
+            The three Euler rotation angles in degrees.
+        degrees : bool, optional, default = True
+            True if the Euler angles are in degrees, False if they are in
+            radians.
+        dj_matrix : ndarray, optional, default = None
+            The djpi2 rotation matrix computed by a call to djpi2.
 
         Description
         -----------
@@ -805,19 +873,23 @@ class SHCoeffs(object):
 
         Usage
         -----
-        SHCoeffsInstance = x.return_coeffs([normalization, csphase, lmax])
+        clm = x.return_coeffs([normalization, csphase, lmax])
+
+        Returns
+        -------
+        clm : SHCoeffs class instance
 
         Parameters
         ----------
-        normalization : Normalization of the output class:
-                        None (x.normalization), '4pi', 'ortho' or 'schmidt'
-                        or geodesy 4pi normalized, orthonormalized, or
-                        Schmidt semi-normalized coefficients, respectively.
-        csphase       : Output Condon-Shortley phase convention:
-                        None (x.csphase), 1 to exlcude the phase factor, or
-                        -1 to include it.
-        lmax          : Maximum spherical harmonic degree to output.
-                        Default is x.lmax.
+        normalization : str, optional, default = x.normalization
+            Normalization of the output class: '4pi', 'ortho' or 'schmidt'
+            for geodesy 4pi normalized, orthonormalized, or Schmidt semi-
+            normalized coefficients, respectively.
+        csphase : int, optional, default = x.csphase
+            Output Condon-Shortley phase convention: 1 to exlcude the phase
+            factor, or -1 to include it.
+        lmax : int, optional, default = x.lmax
+            Maximum spherical harmonic degree to output.
         """
         # copy calling instance normalization and csphase if None is given
         if normalization is None:
@@ -858,23 +930,31 @@ class SHCoeffs(object):
     # ---- Expand the coefficients onto a grid ----
     def expand(self, grid='DH', **kwargs):
         """
-        Evaluate the coefficients on a spherical grid.
+        Evaluate the spherical harmonic coefficients on a spherical grid.
 
         Usage
         -----
-        SHGridInstance = x.expand([grid, lmax, lmax_calc, zeros])
+        f = x.expand([grid, lmax, lmax_calc, zeros])
+
+        Returns
+        -------
+        f : SHGrid class instance
 
         Parameters
         ----------
-        grid      : 'DH' or 'DH1' for an equisampled lat/lon grid with
-                    nlat=nlon, 'DH2' for an equidistant lat/lon grid with
-                    nlon=2*nlat, or 'GLQ' for a Gauss-Legendre quadrature grid.
-        lmax      : The maximum spherical harmonic degree, which determines the
-                    grid spacing of the output grid. Default is x.lmax.
-        lmax_calc : The maximum spherical harmonic degree to use when
-                    evaluating the function. Default is x.lmax.
-        zeros     : The cos(colatitude) nodes used in the Gauss-Legendre
-                    Quadrature grids. Default is None.
+        grid : str, optional, default = 'DH'
+            'DH' or 'DH1' for an equisampled lat/lon grid with nlat=nlon,
+            'DH2' for an equidistant lat/lon grid with nlon=2*nlat, or 'GLQ'
+            for a Gauss-Legendre quadrature grid.
+        lmax : int, optional, default = x.lmax
+            The maximum spherical harmonic degree, which determines the grid
+            spacing of the output grid.
+        lmax_calc : int, optional, default = x.lmax
+            The maximum spherical harmonic degree to use when evaluating the
+            function.
+        zeros : ndarray, optional, default = None
+            The cos(colatitude) nodes used in the Gauss-Legendre Quadrature
+            grids.
 
         Description
         -----------
@@ -911,9 +991,12 @@ class SHCoeffs(object):
 
         Parameters
         ----------
-        loglog : If True (default), use log-log axis.
-        show   : If True (default), plot to the screen.
-        fname  : If present, save the image to the file.
+        loglog : bool, optional, default = True
+            If True, use log-log axis.
+        show : bool, optional, default = True
+            If True, plot to the screen.
+        fname : str, optional, default = None
+            If present, save the image to the file.
         """
         power = self.get_powerperdegree()
         ls = self.get_degrees()
@@ -942,10 +1025,14 @@ class SHCoeffs(object):
 
         Parameters
         ----------
-        bandwidth : The bandwidth, default = 2.
-        loglog    : If True (default), use log-log axis.
-        show      : If True (default), plot to the screen.
-        fname     : If present, save the image to the file
+        bandwidth : int, optional, default = 2
+            The bandwidth.
+        loglog : bool, optional, default = True
+            If True, use log-log axis.
+        show : bool, optional, default = True
+            If True, plot to the screen.
+        fname : str, optional, default = None
+            If present, save the image to the file.
         """
         power = self.get_powerperband(bandwidth)
         ls = self.get_degrees()
@@ -1011,13 +1098,17 @@ class SHRealCoeffs(SHCoeffs):
 
     def make_complex(self):
         """
-        Convert real to the complex coefficient class.
+        Convert the real SHCoeffs class to the complex class.
 
         Normalization and phase conventions are kept unchanged.
 
         Usage
         -----
-        SHComplexCoeffsInstance = x.make_complex()
+        x_complex = x.make_complex()
+
+        Returns
+        -------
+        x_complex : complex SHCoeffs class instance
         """
         rcomplex_coeffs = _shtools.SHrtoc(self.coeffs,
                                           convention=1, switchcs=0)
@@ -1188,11 +1279,17 @@ class SHComplexCoeffs(SHCoeffs):
 
     def make_real(self):
         """
-        Convert the complex to the real harmonic coefficient class.
+        Convert the complex SHCoeffs class to the real class.
+
+        Normalization and phase conventions are kept unchanged.
 
         Usage
         -----
-        SHRealCoeffsInstance = x.make_real()
+        x_real = x.make_real()
+
+        Returns
+        -------
+        x_real : real SHCoeffs class instance
         """
         # First test if the coefficients correspond to a real grid.
         # This is not very elegant. Also, the equality condition
@@ -1386,7 +1483,7 @@ class SHGrid(object):
     lmax       : The maximum spherical harmonic degree that can be resolved
                  by the grid sampling.
     sampling   : For Driscoll and Healy grids, the longitudinal sampling
-                 of the grid. Either nlong = nlat or nlong = 2 * nlat.
+                 of the grid. Either nlong=nlat or nlong=2*nlat.
     kind       : Either 'complex' or 'real' for the data type.
     grid       : Either 'DH' or 'GLQ' for Driscoll and Healy grids or Gauss-
                  Legendre Quadrature grids.
@@ -1425,16 +1522,24 @@ class SHGrid(object):
 
         Usage
         -----
-        x = SHGrid.from_array(array, [grid])
+        x = SHGrid.from_array(array, [grid, copy])
+
+        Returns
+        -------
+        x : SHGrid class instance
 
         Parameters
         ----------
-        array : numpy array of size (nlat, nlon)
-        grid  : 'DH' (default) or 'GLQ' for Driscoll and Healy grids or Gauss
-                Legendre Quadrature grids, respectively.
-        copy  : If True (default), make a copy of array when
-                initializing the class instance. If False, initialize
-                the class instance with a reference to array.
+        array : ndarray, size (nlat, nlon)
+            2-D numpy array of the gridded data, where nlat and nlon are the
+            number of latitudinal and longitudinal bands, respectively.
+        grid : str, optional, default = 'DH'
+            'DH' or 'GLQ' for Driscoll and Healy grids or Gauss Legendre
+            Quadrature grids, respectively.
+        copy : bool, optional, default = True
+            If True (default), make a copy of array when initializing the class
+            instance. If False, initialize the class instance with a reference
+            to array.
         """
         if _np.iscomplexobj(array):
             kind = 'complex'
@@ -1465,17 +1570,22 @@ class SHGrid(object):
         -----
         x = SHGrid.from_file(fname, [binary, **kwargs])
 
+        Returns
+        -------
+        x : SHGrid class instance
+
         Parameters
         ----------
-        fname    : The filename containing the gridded data. For text files
-                   (default) the file is read using the numpy routine
-                   loadtxt(), whereas for binary files, the file is read using
-                   numpy.load(). The dimensions of the array must be
-                   nlon = nlat or nlon = 2 * nlat for Driscoll and Healy grids,
-                   or nlon = 2 * nlat -1 for Gauss-Legendre Quadrature grids.
-        binary   : If False (default), read a text file. If True, read a
-                   binary 'npy' file.
-        **kwargs : Keyword arguments of numpy.loadtxt() or numpy.load().
+        fname : str
+            The filename containing the gridded data. For text files (default)
+            the file is read using the numpy routine loadtxt(), whereas for
+            binary files, the file is read using numpy.load(). The dimensions
+            of the array must be nlon=nlat or nlon=2*nlat for Driscoll and
+            Healy grids, or nlon=2*nlat-1 for Gauss-Legendre Quadrature grids.
+        binary : bool, optional, default = False
+            If False, read a text file. If True, read a binary 'npy' file.
+        **kwargs : keyword arguments, optional
+            Keyword arguments of numpy.loadtxt() or numpy.load().
         """
         if binary is False:
             data = _np.loadtxt(fname, **kwargs)
@@ -1521,12 +1631,15 @@ class SHGrid(object):
 
         Parameters
         ----------
-        filename : Name of output file. For text files (default), the file will
-                   be saved automatically in gzip compressed format if the
-                   filename ends in .gz.
-        binary   : If False (default), save as text using numpy.savetxt(). If
-                   True, save as a 'npy' binary file using numpy.save().
-        **kwargs : Keyword arguments of numpy.savetxt() and numpy.save().
+        filename : str
+            Name of output file. For text files (default), the file will be
+            saved automatically in gzip compressed format if the filename ends
+            in .gz.
+        binary : bool, optional, default = False
+            If False, save as text using numpy.savetxt(). If True, save as a
+            'npy' binary file using numpy.save().
+        **kwargs : keyword arguments, optional
+            Keyword arguments of numpy.savetxt() and numpy.save().
         """
         if binary is False:
             _np.savetxt(filename, self.data, **kwargs)
@@ -1669,14 +1782,19 @@ class SHGrid(object):
 
         Usage
         -----
-        lats = x.get_lats()
+        lats = x.get_lats([degrees])
+
+        Returns
+        -------
+        lats : ndarray, size (nlat)
+            1-D numpy array of size nlat containing the latitude of each row
+            of the gridded data.
 
         Parameters
         -------
-        lats    : numpy array of size nlat containing the latitude of each row
-                  of the gridded data.
-        degrees : If True (default), the output will be in degrees. If False,
-                  the output will be in radians.
+        degrees : bool, optional, default = True
+            If True, the output will be in degrees. If False, the output will
+            be in radians.
         """
         if degrees is False:
             return _np.radians(self._get_lats())
@@ -1689,14 +1807,19 @@ class SHGrid(object):
 
         Usage
         -----
-        lons = x.get_lon()
+        lons = x.get_lon([degrees])
+
+        Returns
+        -------
+        lons : ndarray, size (nlon)
+            1-D numpy array of size nlon containing the longitude of each row
+            of the gridded data.
 
         Parameters
         -------
-        lons    : numpy array of size nlon containing the longitude of each
-                  column of the gridded data.
-        degrees : If True (default), the output will be in degrees. If False,
-                  the output will be in radians.
+        degrees : bool, optional, default = True
+            If True, the output will be in degrees. If False, the output will
+            be in radians.
         """
         if degrees is False:
             return _np.radians(self._get_lons())
@@ -1713,7 +1836,8 @@ class SHGrid(object):
 
         Returns
         -------
-        grid : numpy array of the gridded data of size (nlat, nlon).
+        grid : ndarray, size (nlat, nlon)
+            2-D numpy array of the gridded data.
         """
         return self.data
 
@@ -1730,8 +1854,10 @@ class SHGrid(object):
 
         Parameters
         ----------
-        show   : If True (default), plot the image to the screen.
-        fname  : If present, save the image to the file.
+        show : bool, optional, default = True
+            If True, plot the image to the screen.
+        fname : str, optional, default = None
+            If present, save the image to the file.
         """
         from mpl_toolkits.mplot3d import Axes3D  # NOQA
 
@@ -1830,8 +1956,10 @@ class SHGrid(object):
 
         Parameters
         ----------
-        show   : If True (default), plot the image to the screen.
-        fname  : If present, save the image to the file.
+        show : bool, optional, default = True
+            If True, plot the image to the screen.
+        fname : str, optional, default = None
+            If present, save the image to the file.
         """
         fig, ax = self._plot_rawdata()
         if show:
@@ -1846,16 +1974,22 @@ class SHGrid(object):
 
         Usage
         -----
-        SHCoeffsInstance = x.expand([normalization, csphase, lmax_calc])
+        clm = x.expand([normalization, csphase, lmax_calc])
+
+        Returns
+        -------
+        clm : SHCoeffs class instance
 
         Parameters
         ----------
-        normalization : '4pi' (default), geodesy 4-pi normalized
-                      : 'ortho', orthonormalized
-                      : 'schmidt', Schmidt semi-normalized)
-        csphase       : 1  (default), exlcude the Condon-Shortley phase factor
-        lmax_calc     : maximum spherical harmonic degree to return.
-                        Default is x.lmax.
+        normalization : str, optional, default = '4pi'
+            Normalization of the spherical harmonic coefficients: '4pi' for
+            geodesy 4-pi normalized, 'ortho' for orthonormalized, or 'schmidt'
+            for Schmidt semi-normalized.
+        csphase : int, optional, default = 1
+            Exlcude (1) or use (-1) the Condon-Shortley phase factor.
+        lmax_calc : int, optional, default = x.lmax
+            Maximum spherical harmonic degree to return.
         """
         if type(normalization) != str:
             raise ValueError('normalization must be a string. ' +
@@ -2283,7 +2417,7 @@ class SHWindow(object):
     theta           : Angular radius of the spherical cap localization domain
                       (default in degrees).
     theta_degrees   : True (default) if theta is in degrees.
-    nwin            : Number of localization windows. Default is (lwin + 1)**2.
+    nwin            : Number of localization windows. Default is (lwin+1)**2.
     nwinrot         : The number of best concentrated windows that were rotated
                       and whose coefficients are stored in coeffs.
     clat, clon      : Latitude and longitude of the center of the rotated
@@ -2293,14 +2427,14 @@ class SHWindow(object):
     Each class instance provides the following methods:
 
     get_coeffs()          : Return an array of the spherical harmonic
-                            coefficients for taper i, where i = 0 is the best
+                            coefficients for taper i, where i=0 is the best
                             concentrated, optionally using a different
                             normalization convention.
     get_degrees()         : Return an array containing the spherical harmonic
                             degrees of the localization windows, from 0 to
                             lwin.
     get_k()               : Return the number of windows that have
-                            concentration factors are greater or equal to a
+                            concentration factors greater or equal to a
                             specified value.
     get_powerperdegree()  : Return the power per degree spectra for one or more
                             of the localization windows.
@@ -2308,7 +2442,7 @@ class SHWindow(object):
                             localization windows.
     get_biasedpowerspectrum : Calculate the multitaper (cross-)power spectrum
                               expectation of a localized function.
-    get_grid()            : Return as an array a grid of taper i, where i = 0
+    get_grid()            : Return as an array a grid of taper i, where i=0
                             is the best concentrated window.
     get_multitaperpowerspectrum()      : Return the multitaper power spectrum
                                          estimate and uncertainty for the input
@@ -2317,14 +2451,15 @@ class SHWindow(object):
                                          spectrum estimate and uncertainty for
                                          two input SHCoeffs class instances.
     return_coeffs()       : Return the spherical harmonic coefficients of taper
-                            i, where i = 0 is the best concentrated, as a new
+                            i, where i=0 is the best concentrated, as a new
                             SHCoeffs class instance, optionally using a
                             different normalization convention.
     return_grid()         : Return as a new SHGrid instance a grid of taper i,
-                            where i = 0 is the best concentrated window.
+                            where i=0 is the best concentrated window.
     rotate()              : Rotate the spherical cap tapers, originally located
                             at the north pole, to clat and clon and save the
-                            spherical harmonic coefficients in coeffs.
+                            spherical harmonic coefficients in the attribute
+                            coeffs.
     plot_windows()        : Plot the best concentrated localization windows
                             using a simple cylindrical projection.
     plot_powerperdegree() : Plot the power spectra of the best concentrated
@@ -2332,8 +2467,8 @@ class SHWindow(object):
     plot_couplingmatrix() : Plot the multitaper coupling matrix.
     info()                : Print a summary of the data stored in the SHWindow
                             instance.
-    copy()         : Return a copy of the class instance.
-    """
+    copy()          : Return a copy of the class instance.
+"""
 
     def __init__(self):
         """Initialize with a factory method."""
@@ -2352,24 +2487,31 @@ class SHWindow(object):
         x = SHWindow.from_cap(theta, lwin, [clat, clon, nwin, theta_degrees,
                                             coord_degrees, dj_matrix, weights])
 
+        Returns
+        -------
+        x : SHWindow class instance
+
         Parameters
         ----------
-        theta          : Angular radius of the spherical cap localization
-                         domain (default in degrees).
-        lwin           : Spherical harmonic bandwidth of the localization
-                         windows.
-        clat, clon     : Latitude and longitude of the center of the rotated
-                         spherical cap localization windows (default in
-                         degrees).
-        nwin           : Number of localization windows. Default = (lwin+1)**2
-        theta_degrees  : True (default) if theta is in degrees.
-        coord_degrees  : True (default) if clat and clon are in degrees.
-        dj_matrix      : The djpi2 rotation matrix (default=None), computed
-                         by a call to djpi2.
-        weights        : Taper weights used with the multitaper spectral
-                         analyses. Default is None.
+        theta : float
+            Angular radius of the spherical cap localization domain (default
+            in degrees).
+        lwin : int
+            Spherical harmonic bandwidth of the localization windows.
+        clat, clon : float, optional, default = None
+            Latitude and longitude of the center of the rotated spherical cap
+            localization windows (default in degrees).
+        nwin : int, optional, default (lwin+1)**2
+            Number of localization windows.
+        theta_degrees : bool, optional, default = True
+            True if theta is in degrees.
+        coord_degrees : bool, optional, default = True
+            True if clat and clon are in degrees.
+        dj_matrix : ndarray, optional, default = None
+            The djpi2 rotation matrix computed by a call to djpi2.
+        weights : ndarray, optional, default = None
+            Taper weights used with the multitaper spectral analyses.
         """
-
         if theta_degrees:
             tapers, eigenvalues, taper_order = _shtools.SHReturnTapers(
                 _np.radians(theta), lwin)
@@ -2389,21 +2531,27 @@ class SHWindow(object):
 
         Usage
         -----
-        x = SHWindow.from_mask(dh_mask, lwin, [nwin])
+        x = SHWindow.from_mask(dh_mask, lwin, [nwin, weights])
+
+        Returns
+        -------
+        x : SHWindow class instance
 
         Parameters
         ----------
-        dh_mask  : A Driscoll and Healy (1994) sampled grid describing the
-                   concentration region R. All elements should either be 1
-                   (for inside the concentration region) or 0 (for outside the
-                   concentration region). The grid must have dimensions
-                   nlon = nlat or nlon = 2 * nlat, where nlat is even.
-        lwin     : The spherical harmonic bandwidth of the localization
-                   windows.
-        nwin     : The number of best concentrated eigenvalues and
-                   eigenfunctions to return. Default is (lwin + 1)**2.
-        weights  : Taper weights used with the multitaper spectral analyses.
-                   Default is None.
+        dh_mask :ndarray, size (nlat, nlon)
+            A Driscoll and Healy (1994) sampled grid describing the
+            concentration region R. All elements should either be 1 (for inside
+            the concentration region) or 0 (for outside the concentration
+            region). The grid must have dimensions nlon=nlat or nlon=2*nlat,
+            where nlat is even.
+        lwin : int
+            The spherical harmonic bandwidth of the localization windows.
+        nwin : int, optional, default = (lwin+1)**2
+            The number of best concentrated eigenvalues and eigenfunctions to
+            return.
+        weights ndarray, optional, default = None
+            Taper weights used with the multitaper spectral analyses.
         """
         if nwin is None:
             nwin = (lwin + 1)**2
@@ -2442,7 +2590,8 @@ class SHWindow(object):
 
         Returns
         -------
-        degrees : numpy ndarray of size (lwin+1).
+        degrees : ndarray, size (lwin+1)
+            numpy ndarray containing a list of the spherical harmonic degrees.
         """
         return _np.arange(self.lwin + 1)
 
@@ -2457,20 +2606,22 @@ class SHWindow(object):
 
         Returns
         -------
-        k : The number of windows with concentration factors greater or equal
+        k : int
+            The number of windows with concentration factors greater or equal
             to alpha.
 
         Parameters
         ----------
-        alpha  : The concentration factor, which is the power of the window
-                 within the concentration region divided by the total power.
+        alpha : float
+            The concentration factor, which is the power of the window within
+            the concentration region divided by the total power.
         """
         return len(self.eigenvalues[self.eigenvalues >= alpha])
 
     def get_coeffs(self, itaper, normalization='4pi', csphase=1):
         """
-        Return the spherical harmonics coefficients of taper i as a numpy
-        array, where itaper = 0 is the best concentrated.
+        Return the spherical harmonic coefficients of taper i as a numpy
+        array.
 
         Usage
         -----
@@ -2478,18 +2629,21 @@ class SHWindow(object):
 
         Returns
         -------
-        coeffs : numpy ndarray of size (2, lwin + 1, lwin + 1).
+        coeffs : ndarray, size (2, lwin+1, lwin+11)
+            3-D numpy ndarray of size of the spherical harmonic coefficients
+            of the window.
 
         Parameters
         ----------
-        itaper        : Taper number, where itaper = 0 is the best
-                        concentrated.
-        normalization : Normalization of the output coefficients:
-                        '4pi' (default), 'ortho' or 'schmidt' for geodesy 4pi
-                        normalized, orthonormalized, or Schmidt semi-normalized
-                        coefficients, respectively.
-        csphase       : Output Condon-Shortley phase convention: 1 (default)
-                        to exlcude the phase factor, or -1 to include it.
+        itaper : int
+            Taper number, where itaper=0 is the best concentrated.
+        normalization : str, optional, default = '4pi'
+            Normalization of the output coefficients: '4pi', 'ortho' or
+            'schmidt' for geodesy 4pi normalized, orthonormalized, or Schmidt
+            semi-normalized coefficients, respectively.
+        csphase : int, optional, default = 1
+            1 if the coefficients exclude the Condon-Shortley phase factor, or
+            -1 if they include it.
         """
         if type(normalization) != str:
             raise ValueError('normalization must be a string. ' +
@@ -2513,21 +2667,29 @@ class SHWindow(object):
 
     def get_grid(self, itaper, grid='DH2', zeros=None):
         """
-        Evaluate the coefficients of taper i on a spherical grid, where i = 0
-        is the best concentrated.
+        Evaluate the coefficients of taper i on a spherical grid and return a
+        numpy array.
 
         Usage
         -----
         gridout = x.get_grid(itaper, [grid, zeros])
 
+        Returns
+        -------
+        gridout : ndarray, size (nlat, nlon)
+            2-D numpy array of localization window.
+
         Parameters
         ----------
-        grid      : 'DH' or 'DH1' for an equisampled lat/lon grid with
-                    nlat = nlon, 'DH2' for an equidistant lat/lon grid with
-                    nlon = 2 * nlat, or 'GLQ' for a Gauss-Legendre quadrature
-                    grid.
-        zeros     : The cos(colatitude) nodes used in the Gauss-Legendre
-                    Quadrature grids. Default is None.
+        itaper : int
+            Taper number, where itaper=0 is the best concentrated.
+        grid : str, optional, default = 'DH'
+            'DH' or 'DH1' for an equisampled lat/lon grid with nlat=nlon,
+            'DH2' for an equidistant lat/lon grid with nlon=2*nlat, or 'GLQ'
+            for a Gauss-Legendre quadrature grid.
+        zeros : ndarray, optional, default = None
+            The cos(colatitude) nodes used in the Gauss-Legendre Quadrature
+            grids.
 
         Description
         -----------
@@ -2561,25 +2723,28 @@ class SHWindow(object):
 
     def return_coeffs(self, itaper, normalization='4pi', csphase=1):
         """
-        Return the spherical harmonic coefficients of taper i.
-
-        itaper = 0 is the best concentrated, as new SHCoeffs instance and with
-        in optionally different normalization convention.
+        Return the spherical harmonic coefficients of taper i as a SHCoeffs
+        class instance.
 
         Usage
         -----
-        SHCoeffsInstance = x.return_coeffs(itaper, [normalization, csphase])
+        clm = x.return_coeffs(itaper, [normalization, csphase])
+
+        Returns
+        -------
+        clm : SHCoeffs class instance
 
         Parameters
         ----------
-        itaper        : Taper number, where itaper = 0 is the best
-                        concentrated.
-        normalization : Normalization of the output class: '4pi' (default),
-                        'ortho' or 'schmidt' for geodesy 4pi-normalized,
-                        orthonormalized, or Schmidt semi-normalized
-                        coefficients, respectively.
-        csphase       : Output Condon-Shortley phase convention: 1 (default)
-                        to exlcude the phase factor, or -1 to include it.
+        itaper : int
+            Taper number, where itaper=0 is the best concentrated.
+        normalization : str, optional, default = '4pi'
+            Normalization of the output class: '4pi', 'ortho' or 'schmidt' for
+            geodesy 4pi-normalized, orthonormalized, or Schmidt semi-normalized
+            coefficients, respectively.
+        csphase : int, optional, default = 1
+            Output Condon-Shortley phase convention: 1 to exlcude the phase
+            factor, or -1 to include it.
         """
         if type(normalization) != str:
             raise ValueError('normalization must be a string. ' +
@@ -2606,23 +2771,28 @@ class SHWindow(object):
 
     def return_grid(self, itaper, grid='DH2', zeros=None):
         """
-        Evaluate the coefficients of taper i on a spherical grid.
-
-        i = 0 is the best concentrated, and return a new class instance of
-        SHGrid.
+        Evaluate the coefficients of taper i on a spherical grid and return
+        a SHGrid class instance.
 
         Usage
         -----
-        SHGridInstance = x.return_grid(itaper, [grid, zeros])
+        f = x.return_grid(itaper, [grid, zeros])
+
+        Returns
+        -------
+        f : SHGrid class instance
 
         Parameters
         ----------
-        grid      : 'DH' or 'DH1' for an equisampled lat/lon grid with
-                    nlat = nlon, 'DH2' for an equidistant lat/lon grid with
-                    nlon = 2 * nlat, or 'GLQ' for a Gauss-Legendre quadrature
-                    grid.
-        zeros     : The cos(colatitude) nodes used in the Gauss-Legendre
-                    Quadrature grids. Default is None.
+        itaper : int
+            Taper number, where itaper=0 is the best concentrated.
+        grid : str, optional, default = 'DH2'
+            'DH' or 'DH1' for an equisampled lat/lon grid with nlat=nlon, 'DH2'
+            for an equidistant lat/lon grid with nlon=2*nlat, or 'GLQ' for a
+            Gauss-Legendre quadrature grid.
+        zeros : ndarray, optional, default = None
+            The cos(colatitude) nodes used in the Gauss-Legendre Quadrature
+            grids.
 
         Description
         -----------
@@ -2660,22 +2830,33 @@ class SHWindow(object):
         mtse, sd = x.get_multitaperpowerspectrum(clm, k, [lmax, taper_wt, clat,
                                                           clon, coord_degrees])
 
+        Returns
+        -------
+        mtse : ndarray, size (lmax-lwin+1)
+            The localized multitaper power spectrum estimate, where lwin is the
+            spherical harmonic bandwidth of the localization windows.
+        sd : ndarray, size (lmax-lwin+1)
+            The standard error of the localized multitaper power spectral
+            estimates.
+
         Parameters
         ----------
-        mtse          : The localized multitaper power spectrum estimate.
-        sd            : The standard error of the localized multitaper power
-                        spectral estimates.
-        clm           : Input SHCoeffs class instance containing the spherical
-                        harmonic coefficients of the global field to analyze.
-        k             : The number of tapers to be utilized in performing the
-                        multitaper spectral analysis.
-        lmax          : The maximum spherical harmonic degree of clm to use.
-                        Default is clm.lmax.
-        taper_wt      : The weights used in calculating the multitaper spectral
-                        estimates and standard error. Default is None.
-        clat, clon    : Latitude and longitude of the center of the spherical-
-                        cap localization windows. Default is the north pole.
-        coord_degrees : True (default) if clat and clon are in degrees.
+        clm : SHCoeffs class instance
+            SHCoeffs class instance containing the spherical harmonic
+            coefficients of the global field to analyze.
+        k : int
+            The number of tapers to be utilized in performing the multitaper
+            spectral analysis.
+        lmax : int, optional, default = clm.lmax
+            The maximum spherical harmonic degree of clm to use.
+        taper_wt : ndarray, optional, default = None
+            1-D numpy arrar of the weights used in calculating the multitaper
+            spectral estimates and standard error.
+        clat, clon : float, optional, default = 90., 0.
+            Latitude and longitude of the center of the spherical-cap
+            localization windows.
+        coord_degrees : bool, optional, default = True
+            True if clat and clon are in degrees.
         """
         return self._get_multitaperpowerspectrum(clm, k, **kwargs)
 
@@ -2688,26 +2869,37 @@ class SHWindow(object):
         mtse, sd = x.get_multitapercrosspowerspectrum(
                       clm, slm, k, [lmax, taper_wt, clat, clon, coord_degrees])
 
+        Returns
+        -------
+        mtse : ndarray, size (lmax-lwin+1)
+            The localized multitaper cross-power spectrum estimate, where lwin
+            is the spherical harmonic bandwidth of the localization windows.
+        sd : ndarray, size (lmax-lwin+1)
+            The standard error of the localized multitaper cross-power spectral
+            estimates.
+
         Parameters
         ----------
-        mtse          : The localized multitaper power spectrum estimate.
-        sd            : The standard error of the localized multitaper power
-                        spectral estimates.
-        clm           : Input SHCoeffs class instance containing the spherical
-                        harmonic coefficients of the first global field to
-                        analyze.
-        slm           : Input SHCoeffs class instance containing the spherical
-                        harmonic coefficients of the second global field to
-                        analyze.
-        k             : The number of tapers to be utilized in performing the
-                        multitaper spectral analysis.
-        lmax          : The maximum spherical harmonic degree of clm to use.
-                        Default is clm.lmax.
-        taper_wt      : The weights used in calculating the multitaper spectral
-                        estimates and standard error. Default is None.
-        clat, clon    : Latitude and longitude of the center of the spherical-
-                        cap localization windows. Default is the north pole.
-        coord_degrees : True (default) if clat and clon are in degrees.
+        clm : SHCoeffs class instance
+            SHCoeffs class instance containing the spherical harmonic
+            coefficients of the first global field to analyze.
+        slm : SHCoeffs class instance
+            SHCoeffs class instance containing the spherical harmonic
+            coefficients of the second global field to analyze.
+        k : int
+            The number of tapers to be utilized in performing the multitaper
+            spectral analysis.
+        lmax : int, optional, default = min(clm.lmax, slm.lmax)
+            The maximum spherical harmonic degree of the input coefficients
+            to use.
+        taper_wt : ndarray, optional, default = None
+            The weights used in calculating the multitaper spectral estimates
+            and standard error.
+        clat, clon : float, optional, default = 90., 0.
+            Latitude and longitude of the center of the spherical-cap
+            localization windows.
+        coord_degrees : bool, optional, default = True
+            True if clat and clon are in degrees.
         """
         return self._get_multitapercrosspowerspectrum(clm, slm, k, **kwargs)
 
@@ -2721,23 +2913,29 @@ class SHWindow(object):
         outspectrum = x.get_biasedpowerspectrum(power, k, [taper_wt, save_cg,
                                                            ldata])
 
+        Returns
+        -------
+        outspectrum : ndarray, size (ldata+lwin+1)
+            The expectation of the windowed power spectrum, where lwin is the
+            spherical harmonic bandwidth of the localization windows.
+
         Parameters
         ----------
-
-        outspectrum  : The expectation of the windowed power spectrum.
-        power        : The global power spectrum.
-        k            : The number of best concentrated localization windows to
-                       use in constructing the windowed power spectrum.
-        taper_wt     : The weights used in calculating the multitaper spectral
-                       estimates and standard error. Default is None.
-        save_cg      : If set equal to 1, the Clebsch-Gordon coefficients will
-                       be precomputed and saved for future use. If set equal to
-                       0 (default), the Clebsch-Gordon coefficients will be
-                       recomputed for each call.
-        ldata        : The maximum degree of the global unwindowed power
-                       spectrum. Default is len(power) -1.
+        power : ndarray, size (ldata+1)
+            The global power spectrum.
+        k : int
+            The number of best concentrated localization windows to use in
+            constructing the windowed power spectrum.
+        taper_wt : ndarray, optional, default = None
+            The weights used in calculating the multitaper spectral estimates
+            and standard error.
+        save_cg : int, optional, default = 0
+            If 1, the Clebsch-Gordon coefficients will be precomputed and saved
+            for future use. If 0, the Clebsch-Gordon coefficients will be
+            recomputed for each call.
+        ldata : int, optional, default = len(power)-1
+            The maximum degree of the global unwindowed power spectrum.
         """
-
         outspectrum = self._get_biasedpowerspectrum(power, k, **kwargs)
         return outspectrum
 
@@ -2750,19 +2948,24 @@ class SHWindow(object):
         -----
         power = x.get_powerperdegree([itaper, nwin])
 
+        Returns
+        -------
+        power : ndarray, size (lwin+1, nwin)
+             A matrix with each column containing the power spectrum of a
+             localization window, and where the windows are arranged with
+             increasing concentration factors. If itaper is set, only a single
+             vector is returned, whereas if nwin is set, the first nwin spectra
+             are returned.
+
         Parameters
         ----------
-        power   : A matrix with each column containing the power spectrum
-                  of a localization window, and where the windows are arranged
-                  with increasing concentration factors. If itaper is set,
-                  only a single vector is returned, whereas if nwin is set, the
-                  first nwin spectra are returned.
-        itaper  : The taper number of the output power spectrum, where i = 0
-                  corresponds to the best concentrated taper.
-        nwin    : The number of best concentrated localization window power
-                  spectra to return.
+        itaper : int, optional, default = None
+            The taper number of the output power spectrum, where itaper=0
+            corresponds to the best concentrated taper.
+        nwin : int, optional, default = 1
+            The number of best concentrated localization window power spectra
+            to return.
         """
-
         if itaper is None:
             if nwin is None:
                 nwin = self.nwin
@@ -2788,25 +2991,29 @@ class SHWindow(object):
         -----
         Mmt = x.get_couplingmatrix(lmax, [nwin, weights, mode])
 
+        Returns
+        -------
+        Mmt : ndarray, size (lmax+lwin+1, lmax+1) or (lmax+1, lmax+1) or
+              (lmax-lwin+1, lmax+1)
+
         Parameters
         ----------
-        lmax    : Spherical harmonic bandwidth of the global power spectrum.
-        nwin    : Number of tapers used in the mutlitaper spectral analysis.
-                  Default = x.nwin
-        weights : Taper weights used with the multitaper spectral analyses.
-                  Defaut is x.weights.
-        mode    : Can be one of the following:
-                  'full' (default): couples over the data bandlimit. Returns a
-                  biased output spectrum with size lmax + lwin + 1. This
-                  assumes implicitly that the input spectrum is zero for
-                  degrees l > lmax.
-                  'same': couples exactly to the data bandlimit. Returns a
-                  biased output spectrum with size lmax + 1. This assumes
-                  implicitly that the spectrum is zero for degrees l > lmax.
-                  'valid': couples exactly to the data bandlimit. Returns a
-                  biased spectrum with size lmax - lwin + 1. This returns only
-                  the part of the biased spectrum that is not influenced by
-                  degrees with l > lmax.
+        lmax : int
+            Spherical harmonic bandwidth of the global power spectrum.
+        nwin : int, optional, default = x.nwin
+            Number of tapers used in the mutlitaper spectral analysis.
+        weights : ndarray, optional, default = x.weights
+            Taper weights used with the multitaper spectral analyses.
+        mode : str, opitonal, default = 'full'
+            Can be one of the following: 'full' couples over the data bandlimit
+            and returns a biased output spectrum with size lmax+lwin+1. This
+            assumes implicitly that the input spectrum is zero for degrees
+            l>lmax. 'same' couples exactly to the data bandlimit and returns a
+            biased output spectrum with size lmax+1. This assumes implicitly
+            that the spectrum is zero for degrees l>lmax. 'valid' couples
+            exactly to the data bandlimit and returns a biased spectrum with
+            size lmax-lwin+1. This returns only the part of the biased spectrum
+            that is not influenced by degrees with l>lmax.
         """
         if weights is not None:
             if nwin is not None:
@@ -2846,9 +3053,12 @@ class SHWindow(object):
 
         Parameters
         ----------
-        nwin   : The number of localization windows to plot.
-        show   : If True (default), plot the image to the screen.
-        fname  : If present, save the image to the file.
+        nwin : int
+            The number of localization windows to plot.
+        show : bool, optional, default = True
+            If True, plot the image to the screen.
+        fname : str, optional, default = None
+            If present, save the image to the file.
         """
         if self.kind == 'cap':
             if self.nwinrot is not None and self.nwinrot <= nwin:
@@ -2892,11 +3102,13 @@ class SHWindow(object):
 
         Parameters
         ----------
-        nwin   : The number of localization windows to plot.
-        show   : If True (default), plot the image to the screen.
-        fname  : If present, save the image to the file.
+        nwin : int
+            The number of localization windows to plot.
+        show : bool, optional, default = True
+            If True, plot the image to the screen.
+        fname : str, optional, default = None
+            If present, save the image to the file.
         """
-
         degrees = self.get_degrees()
         power = self.get_powerperdegree(nwin=nwin)
 
@@ -2946,25 +3158,26 @@ class SHWindow(object):
 
         Parameters
         ----------
-        lmax    : Spherical harmonic bandwidth of the global power spectrum.
-        nwin    : Number of tapers used in the mutlitaper spectral analysis.
-                  Default = x.nwin
-        weights : Taper weights used with the multitaper spectral analyses.
-                  Defaut is x.weights.
-        show    : If True (default), plot the image to the screen.
-        fname   : If present, save the image to the file.
-        mode    : Can be one of the following:
-                  'full' (default): couples over the data bandlimit. Returns a
-                  biased output spectrum with size lmax + lwin + 1. This
-                  assumes implicitly that the input spectrum is zero for
-                  degrees l > lmax.
-                  'same': couples exactly to the data bandlimit. Returns a
-                  biased output spectrum with size lmax + 1. This assumes
-                  implicitly that the spectrum is zero for degrees l > lmax.
-                  'valid': couples exactly to the data bandlimit. Returns a
-                  biased spectrum with size lmax - lwin + 1. This returns only
-                  the part of the biased spectrum that is not influenced by
-                  degrees with l > lmax.
+        lmax : int
+            Spherical harmonic bandwidth of the global power spectrum.
+        nwin : int, optional, default = x.nwin
+            Number of tapers used in the mutlitaper spectral analysis.
+        weights : ndarray, optional, default = x.weights
+            Taper weights used with the multitaper spectral analyses.
+        mode : str, opitonal, default = 'full'
+            Can be one of the following: 'full' couples over the data bandlimit
+            and returns a biased output spectrum with size lmax+lwin+1. This
+            assumes implicitly that the input spectrum is zero for degrees
+            l>lmax. 'same' couples exactly to the data bandlimit and returns a
+            biased output spectrum with size lmax+1. This assumes implicitly
+            that the spectrum is zero for degrees l>lmax. 'valid' couples
+            exactly to the data bandlimit and returns a biased spectrum with
+            size lmax-lwin+1. This returns only the part of the biased spectrum
+            that is not influenced by degrees with l>lmax.
+        show : bool, optional, default = True
+            If True, plot the image to the screen.
+        fname : str, optional, default = None
+            If present, save the image to the file.
         """
         figsize = _mpl.rcParams['figure.figsize']
         figsize[0] = figsize[1]
@@ -3091,18 +3304,20 @@ class SHWindowCap(SHWindow):
 
         Usage
         -----
-        x.rotate(clat, clon [coord_degrees, dj_matrix])
+        x.rotate(clat, clon [coord_degrees, dj_matrix, nwinrot])
 
         Parameters
         ----------
-        clat, clon    : Latitude and longitude of the center of the rotated
-                        spherical-cap localization windows (default in
-                        degrees).
-        coord_degrees : True (default) if clat and clon are in degrees.
-        dj_matrix     : The djpi2 rotation matrix (default=None), computed
-                        by a call to djpi2.
-        nwinrot       : The number of best concentrated windows to rotate.
-                        Default is to rotate all windows.
+        clat, clon : float
+            Latitude and longitude of the center of the rotated spherical-cap
+            localization windows (default in degrees).
+        coord_degrees : bool, optional, default = True
+            True if clat and clon are in degrees.
+        dj_matrix : ndarray, optional, default = None
+            The djpi2 rotation matrix computed by a call to djpi2.
+        nwinrot : int, optional, default = (lwin+1)**2
+            The number of best concentrated windows to rotate, where lwin is
+            the spherical harmonic bandwidth of the localization windows.
 
         Description
         -----------
@@ -3327,7 +3542,7 @@ class SHWindowMask(SHWindow):
     def _get_coeffs(self, itaper, normalization='4pi', csphase=1):
         """
         Return the spherical harmonic coefficients of taper i as an
-        array, where i = 0 is the best concentrated.
+        array, where i=0 is the best concentrated.
         """
         coeffs = _shtools.SHVectorToCilm(self.tapers[:, itaper])
 
@@ -3367,7 +3582,6 @@ class SHWindowMask(SHWindow):
         Return the multitaper power spectrum estimate and uncertainty for an
         input SHCoeffs class instance.
         """
-
         if lmax is None:
             lmax = clm.lmax
 
@@ -3385,7 +3599,6 @@ class SHWindowMask(SHWindow):
         Return the multitaper cross-power spectrum estimate and uncertainty for
         two input SHCoeffs class instances.
         """
-
         if lmax is None:
             lmax = min(clm.lmax, slm.lmax)
 

--- a/pyshtools/shclasses.py
+++ b/pyshtools/shclasses.py
@@ -142,9 +142,9 @@ class SHCoeffs(object):
             '4pi', 'ortho' or 'schmidt' for geodesy 4pi normalized,
             orthonormalized, or Schmidt semi-normalized coefficients,
             respectively.
-        csphase : int, optional, defalt = 1
-            1 if the coefficients exclude the Condon-Shortley phase factor, or
-            -1 if they include it.
+        csphase : int, optional, default = 1
+            Condon-Shortley phase convention: 1 to exclude the phase factor,
+            or -1 to include it.
         kind : str, optional, default = 'real'
             'real' or 'complex' spherical harmonic coefficients.
         """
@@ -195,15 +195,15 @@ class SHCoeffs(object):
 
         Parameters
         ----------
-        array : ndarray, size (2, lmax+1, lmax+1).
+        array : ndarray, shape (2, lmax+1, lmax+1).
             The input spherical harmonic coefficients.
         normalization : str, optional, default = '4pi'
             '4pi', 'ortho' or 'schmidt' for geodesy 4pi normalized,
             orthonormalized, or Schmidt semi-normalized coefficients,
             respectively.
         csphase : int, optional, default = 1
-            1 if the coefficients exclude the Condon-Shortley phase factor, or
-            -1 if they include it.
+            Condon-Shortley phase convention: 1 to exclude the phase factor,
+            or -1 to include it.
         copy : bool, optional, default = True
             If True, make a copy of array when initializing the class instance.
             If False, initialize the class instance with a reference to array.
@@ -259,18 +259,18 @@ class SHCoeffs(object):
 
         Parameters
         ----------
-        power : ndarray, size (lmax+1)
-            numpy array of size (lmax+1) that specifies the expected power per
+        power : ndarray, shape (lmax+1)
+            numpy array of shape (lmax+1) that specifies the expected power per
             degree l of the random coefficients.
         kind : str, optional, default = 'real'
             'real' or 'complex' spherical harmonic coefficients.
-        normalization : str, optional, defaul = '4pi'
+        normalization : str, optional, default = '4pi'
             '4pi', 'ortho' or 'schmidt' for geodesy 4pi normalized,
             orthonormalized, or Schmidt semi-normalized coefficients,
             respectively.
         csphase : int, optional, default = 1
-            1 if the coefficients exclude the Condon-Shortley phase factor, or
-            -1 if they include it.
+            Condon-Shortley phase convention: 1 to exclude the phase factor,
+            or -1 to include it.
         exact_power : bool, optional, default = False
             The total variance of the coefficients is set exactly to the input
             power. This means that the distribution of power at degree l
@@ -370,8 +370,8 @@ class SHCoeffs(object):
             orthonormalized, or Schmidt semi-normalized coefficients,
             respectively.
         csphase : int, optional, default = 1
-            1 if the coefficients exclude the Condon-Shortley phase factor, or
-            -1 if they include it.
+            Condon-Shortley phase convention: 1 to exclude the phase factor,
+            or -1 to include it.
         skip : int, required when format = 'shtools'
             Number of lines to skip at the beginning of the file when format is
             'shtools'.
@@ -650,7 +650,7 @@ class SHCoeffs(object):
 
         Returns
         -------
-        degrees : ndarray, size (lmax+1)
+        degrees : ndarray, shape (lmax+1)
             1-D numpy ndarray listing the spherical harmonic degrees, where
             lmax is the maximum spherical harmonic degree.
         """
@@ -666,7 +666,7 @@ class SHCoeffs(object):
 
         Returns
         -------
-        power : ndarray, size (lmax+1)
+        power : ndarray, shape (lmax+1)
             1-D numpy ndarray of the power per degree l spectrum, where lmax
             is the maximum spherical harmonic degree.
         """
@@ -682,7 +682,7 @@ class SHCoeffs(object):
 
         Returns
         -------
-        power : ndarray, size (lmax+1)
+        power : ndarray, shape (lmax+1)
             1-D numpy ndarray of the power spectrum, where lmax is the maximum
             spherical harmonic degree.
         """
@@ -734,7 +734,7 @@ class SHCoeffs(object):
 
         Returns
         -------
-        coeffs : ndarry, size (2, lmax+1, lmax+1)
+        coeffs : ndarry, shape (2, lmax+1, lmax+1)
             numpy ndarray of the spherical harmonic coefficients.
 
         Parameters
@@ -744,8 +744,8 @@ class SHCoeffs(object):
             'schmidt' for geodesy 4pi normalized, orthonormalized, or Schmidt
             semi-normalized coefficients, respectively.
         csphase : int, optional, default = x.csphase
-            Output Condon-Shortley phase convention. 1 to exlcude the phase
-            factor, or -1 to include it.
+            Condon-Shortley phase convention: 1 to exclude the phase factor,
+            or -1 to include it.
         lmax : int, optional, default = x.lmax
             Maximum spherical harmonic degree to output.
         """
@@ -789,7 +789,7 @@ class SHCoeffs(object):
     def rotate(self, alpha, beta, gamma, degrees=True, dj_matrix=None):
         """
         Rotate the coordinate system used to express the spherical harmonic
-        coeffcients and return a new class instance.
+        coefficients and return a new class instance.
 
         Usage
         -----
@@ -886,8 +886,8 @@ class SHCoeffs(object):
             for geodesy 4pi normalized, orthonormalized, or Schmidt semi-
             normalized coefficients, respectively.
         csphase : int, optional, default = x.csphase
-            Output Condon-Shortley phase convention: 1 to exlcude the phase
-            factor, or -1 to include it.
+            Condon-Shortley phase convention: 1 to exclude the phase factor,
+            or -1 to include it.
         lmax : int, optional, default = x.lmax
             Maximum spherical harmonic degree to output.
         """
@@ -1530,7 +1530,7 @@ class SHGrid(object):
 
         Parameters
         ----------
-        array : ndarray, size (nlat, nlon)
+        array : ndarray, shape (nlat, nlon)
             2-D numpy array of the gridded data, where nlat and nlon are the
             number of latitudinal and longitudinal bands, respectively.
         grid : str, optional, default = 'DH'
@@ -1786,7 +1786,7 @@ class SHGrid(object):
 
         Returns
         -------
-        lats : ndarray, size (nlat)
+        lats : ndarray, shape (nlat)
             1-D numpy array of size nlat containing the latitude of each row
             of the gridded data.
 
@@ -1811,7 +1811,7 @@ class SHGrid(object):
 
         Returns
         -------
-        lons : ndarray, size (nlon)
+        lons : ndarray, shape (nlon)
             1-D numpy array of size nlon containing the longitude of each row
             of the gridded data.
 
@@ -1836,7 +1836,7 @@ class SHGrid(object):
 
         Returns
         -------
-        grid : ndarray, size (nlat, nlon)
+        grid : ndarray, shape (nlat, nlon)
             2-D numpy array of the gridded data.
         """
         return self.data
@@ -1987,7 +1987,8 @@ class SHGrid(object):
             geodesy 4-pi normalized, 'ortho' for orthonormalized, or 'schmidt'
             for Schmidt semi-normalized.
         csphase : int, optional, default = 1
-            Exlcude (1) or use (-1) the Condon-Shortley phase factor.
+            Condon-Shortley phase convention: 1 to exclude the phase factor,
+            or -1 to include it.
         lmax_calc : int, optional, default = x.lmax
             Maximum spherical harmonic degree to return.
         """
@@ -2106,7 +2107,6 @@ class DHRealGrid(SHGrid):
         """Plot the raw data using a simply cylindrical projection."""
         fig, ax = _plt.subplots(1, 1)
         ax.imshow(self.data, origin='upper', extent=(0., 360., -90., 90.))
-        ax.set_title('Driscoll and Healy Grid')
         ax.set_xlabel('longitude')
         ax.set_ylabel('latitude')
         fig.tight_layout(pad=0.5)
@@ -2196,12 +2196,12 @@ class DHComplexGrid(SHGrid):
         fig, ax = _plt.subplots(2, 1)
         ax.flat[0].imshow(self.data.real, origin='upper',
                           extent=(0., 360., -90., 90.))
-        ax.flat[0].set_title('Driscoll and Healy Grid (real component)')
+        ax.flat[0].set_title('Real component')
         ax.flat[0].set_xlabel('longitude')
         ax.flat[0].set_ylabel('latitude')
         ax.flat[1].imshow(self.data.imag, origin='upper',
                           extent=(0., 360., -90., 90.))
-        ax.flat[1].set_title('Driscoll and Healy Grid (imaginary component)')
+        ax.flat[1].set_title('Imaginary component')
         ax.flat[1].set_xlabel('longitude')
         ax.flat[1].set_ylabel('latitude')
         fig.tight_layout(pad=0.5)
@@ -2290,9 +2290,8 @@ class GLQRealGrid(SHGrid):
 
         fig, ax = _plt.subplots(1, 1)
         ax.imshow(self.data, origin='upper')
-        ax.set_title('Gauss-Legendre Quadrature Grid')
-        ax.set_xlabel('longitude index')
-        ax.set_ylabel('latitude index')
+        ax.set_xlabel('GLQ longitude index')
+        ax.set_ylabel('GLQ latitude index')
         fig.tight_layout(pad=0.5)
         return fig, ax
 
@@ -2372,14 +2371,13 @@ class GLQComplexGrid(SHGrid):
         """Plot the raw data using a simply cylindrical projection."""
         fig, ax = _plt.subplots(2, 1)
         ax.flat[0].imshow(self.data.real, origin='upper')
-        ax.flat[0].set_title('Gauss-Legendre Quadrature Grid (real component)')
+        ax.flat[0].set_title('Real component')
         ax.flat[0].set_xlabel('longitude index')
         ax.flat[0].set_ylabel('latitude index')
         ax.flat[1].imshow(self.data.imag, origin='upper')
-        ax.flat[1].set_title('Gauss-Legendre Quadrature Grid ' +
-                             '(imaginary component)')
-        ax.flat[1].set_xlabel('longitude index')
-        ax.flat[1].set_ylabel('latitude index')
+        ax.flat[1].set_title('Imaginary component')
+        ax.flat[1].set_xlabel('GLQ longitude index')
+        ax.flat[1].set_ylabel('GLQ latitude index')
         fig.tight_layout(pad=0.5)
         return fig, ax
 
@@ -2467,7 +2465,7 @@ class SHWindow(object):
     plot_couplingmatrix() : Plot the multitaper coupling matrix.
     info()                : Print a summary of the data stored in the SHWindow
                             instance.
-    copy()          : Return a copy of the class instance.
+    copy()                : Return a copy of the class instance.
 """
 
     def __init__(self):
@@ -2539,7 +2537,7 @@ class SHWindow(object):
 
         Parameters
         ----------
-        dh_mask :ndarray, size (nlat, nlon)
+        dh_mask :ndarray, shape (nlat, nlon)
             A Driscoll and Healy (1994) sampled grid describing the
             concentration region R. All elements should either be 1 (for inside
             the concentration region) or 0 (for outside the concentration
@@ -2590,7 +2588,7 @@ class SHWindow(object):
 
         Returns
         -------
-        degrees : ndarray, size (lwin+1)
+        degrees : ndarray, shape (lwin+1)
             numpy ndarray containing a list of the spherical harmonic degrees.
         """
         return _np.arange(self.lwin + 1)
@@ -2629,7 +2627,7 @@ class SHWindow(object):
 
         Returns
         -------
-        coeffs : ndarray, size (2, lwin+1, lwin+11)
+        coeffs : ndarray, shape (2, lwin+1, lwin+11)
             3-D numpy ndarray of size of the spherical harmonic coefficients
             of the window.
 
@@ -2642,8 +2640,8 @@ class SHWindow(object):
             'schmidt' for geodesy 4pi normalized, orthonormalized, or Schmidt
             semi-normalized coefficients, respectively.
         csphase : int, optional, default = 1
-            1 if the coefficients exclude the Condon-Shortley phase factor, or
-            -1 if they include it.
+            Condon-Shortley phase convention: 1 to exclude the phase factor,
+            or -1 to include it.
         """
         if type(normalization) != str:
             raise ValueError('normalization must be a string. ' +
@@ -2676,7 +2674,7 @@ class SHWindow(object):
 
         Returns
         -------
-        gridout : ndarray, size (nlat, nlon)
+        gridout : ndarray, shape (nlat, nlon)
             2-D numpy array of localization window.
 
         Parameters
@@ -2743,8 +2741,8 @@ class SHWindow(object):
             geodesy 4pi-normalized, orthonormalized, or Schmidt semi-normalized
             coefficients, respectively.
         csphase : int, optional, default = 1
-            Output Condon-Shortley phase convention: 1 to exlcude the phase
-            factor, or -1 to include it.
+            Condon-Shortley phase convention: 1 to exclude the phase factor,
+            or -1 to include it.
         """
         if type(normalization) != str:
             raise ValueError('normalization must be a string. ' +
@@ -2832,10 +2830,10 @@ class SHWindow(object):
 
         Returns
         -------
-        mtse : ndarray, size (lmax-lwin+1)
+        mtse : ndarray, shape (lmax-lwin+1)
             The localized multitaper power spectrum estimate, where lwin is the
             spherical harmonic bandwidth of the localization windows.
-        sd : ndarray, size (lmax-lwin+1)
+        sd : ndarray, shape (lmax-lwin+1)
             The standard error of the localized multitaper power spectral
             estimates.
 
@@ -2871,10 +2869,10 @@ class SHWindow(object):
 
         Returns
         -------
-        mtse : ndarray, size (lmax-lwin+1)
+        mtse : ndarray, shape (lmax-lwin+1)
             The localized multitaper cross-power spectrum estimate, where lwin
             is the spherical harmonic bandwidth of the localization windows.
-        sd : ndarray, size (lmax-lwin+1)
+        sd : ndarray, shape (lmax-lwin+1)
             The standard error of the localized multitaper cross-power spectral
             estimates.
 
@@ -2915,13 +2913,13 @@ class SHWindow(object):
 
         Returns
         -------
-        outspectrum : ndarray, size (ldata+lwin+1)
+        outspectrum : ndarray, shape (ldata+lwin+1)
             The expectation of the windowed power spectrum, where lwin is the
             spherical harmonic bandwidth of the localization windows.
 
         Parameters
         ----------
-        power : ndarray, size (ldata+1)
+        power : ndarray, shape (ldata+1)
             The global power spectrum.
         k : int
             The number of best concentrated localization windows to use in
@@ -2950,7 +2948,7 @@ class SHWindow(object):
 
         Returns
         -------
-        power : ndarray, size (lwin+1, nwin)
+        power : ndarray, shape (lwin+1, nwin)
              A matrix with each column containing the power spectrum of a
              localization window, and where the windows are arranged with
              increasing concentration factors. If itaper is set, only a single
@@ -2993,7 +2991,7 @@ class SHWindow(object):
 
         Returns
         -------
-        Mmt : ndarray, size (lmax+lwin+1, lmax+1) or (lmax+1, lmax+1) or
+        Mmt : ndarray, shape (lmax+lwin+1, lmax+1) or (lmax+1, lmax+1) or
               (lmax-lwin+1, lmax+1)
 
         Parameters
@@ -3005,15 +3003,14 @@ class SHWindow(object):
         weights : ndarray, optional, default = x.weights
             Taper weights used with the multitaper spectral analyses.
         mode : str, opitonal, default = 'full'
-            Can be one of the following: 'full' couples over the data bandlimit
-            and returns a biased output spectrum with size lmax+lwin+1. This
-            assumes implicitly that the input spectrum is zero for degrees
-            l>lmax. 'same' couples exactly to the data bandlimit and returns a
-            biased output spectrum with size lmax+1. This assumes implicitly
-            that the spectrum is zero for degrees l>lmax. 'valid' couples
-            exactly to the data bandlimit and returns a biased spectrum with
-            size lmax-lwin+1. This returns only the part of the biased spectrum
-            that is not influenced by degrees with l>lmax.
+            'full' returns a biased output spectrum of size lmax+lwin+1. The
+            input spectrum is assumed to be zero for degrees l>lmax.
+            'same' returns a biased output spectrum with the same size
+            (lmax+1) as the input spectrum. The input spectrum is assumed to be
+            zero for degrees l>lmax.
+            'valid' returns a biased spectrum with size lmax-lwin+1. This
+            returns only that part of the biased spectrum that is not
+            influenced by the input spectrum beyond degree lmax.
         """
         if weights is not None:
             if nwin is not None:
@@ -3165,15 +3162,14 @@ class SHWindow(object):
         weights : ndarray, optional, default = x.weights
             Taper weights used with the multitaper spectral analyses.
         mode : str, opitonal, default = 'full'
-            Can be one of the following: 'full' couples over the data bandlimit
-            and returns a biased output spectrum with size lmax+lwin+1. This
-            assumes implicitly that the input spectrum is zero for degrees
-            l>lmax. 'same' couples exactly to the data bandlimit and returns a
-            biased output spectrum with size lmax+1. This assumes implicitly
-            that the spectrum is zero for degrees l>lmax. 'valid' couples
-            exactly to the data bandlimit and returns a biased spectrum with
-            size lmax-lwin+1. This returns only the part of the biased spectrum
-            that is not influenced by degrees with l>lmax.
+            'full' returns a biased output spectrum of size lmax+lwin+1. The
+            input spectrum is assumed to be zero for degrees l>lmax.
+            'same' returns a biased output spectrum with the same size
+            (lmax+1) as the input spectrum. The input spectrum is assumed to be
+            zero for degrees l>lmax.
+            'valid' returns a biased spectrum with size lmax-lwin+1. This
+            returns only that part of the biased spectrum that is not
+            influenced by the input spectrum beyond degree lmax.
         show : bool, optional, default = True
             If True, plot the image to the screen.
         fname : str, optional, default = None

--- a/pyshtools/shclasses.py
+++ b/pyshtools/shclasses.py
@@ -192,6 +192,9 @@ class SHCoeffs(object):
                         coefficients, respectively.
         csphase       : 1 (default) if the coefficients exclude the Condon-
                         Shortley phase factor, or -1 if they include it.
+        copy          : If True (default), make a copy of array when
+                        initializing the class instance. If False, initialize
+                        the class instance with a reference to array.
         """
         if _np.iscomplexobj(coeffs):
             kind = 'complex'
@@ -1462,8 +1465,11 @@ class SHGrid(object):
         ----------
 
         array : numpy array of size (nlat, nlon)
-        grid : 'DH' (default) or 'GLQ' for Driscoll and Healy grids or Gauss
+        grid  : 'DH' (default) or 'GLQ' for Driscoll and Healy grids or Gauss
                 Legendre Quadrature grids, respectively.
+        copy  : If True (default), make a copy of array when
+                initializing the class instance. If False, initialize
+                the class instance with a reference to array.
         """
         if _np.iscomplexobj(array):
             kind = 'complex'
@@ -2427,7 +2433,7 @@ class SHWindow(object):
 
         return SHWindowCap(theta, tapers, eigenvalues, taper_order,
                            clat, clon, nwin, theta_degrees, coord_degrees,
-                           dj_matrix, weights)
+                           dj_matrix, weights, copy=False)
 
     @classmethod
     def from_mask(self, dh_mask, lwin, nwin=None, weights=None):
@@ -2475,7 +2481,7 @@ class SHWindow(object):
 
         tapers, eigenvalues = _shtools.SHReturnTapersMap(dh_mask, lwin,
                                                          ntapers=nwin)
-        return SHWindowMask(tapers, eigenvalues, weights)
+        return SHWindowMask(tapers, eigenvalues, weights, copy=False)
 
     def copy(self):
         """Return a deep copy of the class instance."""

--- a/src/pydoc/pymakegriddh.md
+++ b/src/pydoc/pymakegriddh.md
@@ -18,7 +18,7 @@ Create a 2D map from a set of spherical harmonic coefficients using the Driscoll
 
 `lmax` : optional, integer, default = `lmaxin`
 :   The maximum spherical harmonic degree of the function, which determines the sampling of the output grid.
-    
+
 `norm` : optional, integer, default = 1
 :   1 = 4-pi (geodesy) normalized harmonics; 2 = Schmidt semi-normalized harmonics; 3 = unnormalized harmonics;  4 = orthonormal harmonics.
 


### PR DESCRIPTION
Thi pull request is largely cosmetic.
- Python documentation/docstrings were standardized by removing extra line breaks between parameters and headers. Docstrings in the shclasses.py were standardized to follow the conventions of the docstrings for other shtools functions. The class methods now explicitly define "returns", and each parameter starts with a line that describes the data type, and whether it is optional with a default value.
- Optional parametr `copy` was added to the docstrings, where needed.
- Added `copy=False` when initializing SHWindows from a cap or mask.
- Modified `SHCoeffs.get_coeffs` so that the default normalization and csphase correspond to the raw coefficients (and not 4pi and 1).
- Found some typos and missing aspects in the shclasses documentation.
