### PR TITLE
Fix makefiles so that ifort correctly invokes the preprocessor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,9 +142,9 @@ SYSLIBPATH = /usr/local/lib
 
 FFTW = -L$(SYSLIBPATH) -lfftw3
 FFTW_UNDERSCORE = 0
-LAPACK = -llapack 
+LAPACK ?= -llapack
 LAPACK_UNDERSCORE = 0
-BLAS = -lblas
+BLAS ?= -lblas
 
 SHELL = /bin/sh
 FDOCDIR = src/fdoc
@@ -182,10 +182,12 @@ SYSMODFLAG = -I$(SYSMODPATH)
 OPENMPFLAGS ?= -fopenmp
 else ifeq ($(F95), ifort)
 # Default intel fortran flags
-F95FLAGS ?= -m64 -free -O3 -Tf
+F95FLAGS ?= -m64 -fpp -free -O3 -Tf
 MODFLAG = -I$(MODPATH)
 SYSMODFLAG = -I$(SYSMODPATH)
-OPENMPFLAGS ?=
+OPENMPFLAGS ?= -qopenmp
+LAPACK = -mkl
+BLAS = 
 else ifeq ($(F95), g95)
 # Default g95 flags.
 F95FLAGS ?= -O3 -fno-second-underscore
@@ -244,7 +246,7 @@ fortran-mp:
 	mkdir -pv lib
 	mkdir -pv modules
 	-$(MAKE) -C $(SRCDIR) -f Makefile clean-obs-mod
-	$(MAKE) -C $(SRCDIR) -f Makefile all F95=$(F95) F95FLAGS="$(F95FLAGS) $(OPENMPFLAGS)" LIBNAME="$(LIBNAMEMP)" LAPACK_FLAGS="$(LAPACK_FLAGS)" FFTW3_FLAGS="$(FFTW3_FLAGS)"
+	$(MAKE) -C $(SRCDIR) -f Makefile all F95=$(F95) F95FLAGS="$(OPENMPFLAGS) $(F95FLAGS)" LIBNAME="$(LIBNAMEMP)" LAPACK_FLAGS="$(LAPACK_FLAGS)" FFTW3_FLAGS="$(FFTW3_FLAGS)"
 	-$(MAKE) -C $(SRCDIR) -f Makefile clean-obs-mod
 	@echo
 	@echo MAKE SUCCESSFUL!
@@ -252,7 +254,7 @@ fortran-mp:
 	@echo ---------------------------------------------------------------------------------------------------
 	@echo Compile your Fortran code with the following flags:
 	@echo
-	@echo $(F95) $(MODFLAG) $(F95FLAGS) $(OPENMPFLAGS) -L$(LIBPATH) -l$(LIBNAMEMP) $(FFTW) -lm $(LAPACK) $(BLAS)
+	@echo $(F95) $(MODFLAG) $(OPENMPFLAGS) $(F95FLAGS) -L$(LIBPATH) -l$(LIBNAMEMP) $(FFTW) -lm $(LAPACK) $(BLAS)
 	@echo ---------------------------------------------------------------------------------------------------
 	@echo
 
@@ -481,7 +483,7 @@ fortran-tests: fortran
 	@echo RAN ALL FORTRAN EXAMPLE AND TESTS
 
 fortran-tests-mp: fortran-mp
-	$(MAKE) -C $(FEXDIR) -f Makefile all F95=$(F95) F95FLAGS="$(F95FLAGS) $(OPENMPFLAGS)" LIBNAME="$(LIBNAMEMP)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)"
+	$(MAKE) -C $(FEXDIR) -f Makefile all F95=$(F95) F95FLAGS="$(OPENMPFLAGS) $(F95FLAGS)" LIBNAME="$(LIBNAMEMP)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)"
 	@echo
 	@echo MAKE OF FORTRAN TEST SUITE SUCCESSFUL
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -142,9 +142,7 @@ SYSLIBPATH = /usr/local/lib
 
 FFTW = -L$(SYSLIBPATH) -lfftw3
 FFTW_UNDERSCORE = 0
-LAPACK ?= -llapack
 LAPACK_UNDERSCORE = 0
-BLAS ?= -lblas
 
 SHELL = /bin/sh
 FDOCDIR = src/fdoc
@@ -173,6 +171,8 @@ F95FLAGS ?= -m64 -O3 -YEXT_NAMES=LCS -YEXT_SFX=_ -fpic -speed_math=10
 MODFLAG = -p $(MODPATH)
 SYSMODFLAG = -p $(SYSMODPATH)
 OPENMPFLAGS ?= -openmp
+BLAS ?= -lblas
+LAPACK ?= -llapack
 else ifeq ($(F95), gfortran)
 # Default gfortran flags
 F95FLAGS ?= -m64 -fPIC -O3 -ffast-math
@@ -180,31 +180,39 @@ F95FLAGS ?= -m64 -fPIC -O3 -ffast-math
 MODFLAG = -I$(MODPATH)
 SYSMODFLAG = -I$(SYSMODPATH)
 OPENMPFLAGS ?= -fopenmp
+BLAS ?= -lblas
+LAPACK ?= -llapack
 else ifeq ($(F95), ifort)
 # Default intel fortran flags
 F95FLAGS ?= -m64 -fpp -free -O3 -Tf
 MODFLAG = -I$(MODPATH)
 SYSMODFLAG = -I$(SYSMODPATH)
 OPENMPFLAGS ?= -qopenmp
-LAPACK = -mkl
-BLAS = 
+LAPACK ?= -mkl
+BLAS ?= 
 else ifeq ($(F95), g95)
 # Default g95 flags.
 F95FLAGS ?= -O3 -fno-second-underscore
 MODFLAG = -I$(MODPATH)
 SYSMODFLAG = -I$(SYSMODPATH)
 OPENMPFLAGS ?=
+BLAS ?= -lblas
+LAPACK ?= -llapack
 else ifeq ($(F95), pgf90)
 # Default pgf90 flags
 F95FLAGS ?= -fast 
 MODFLAG = -Imodpath
 SYSMODFLAG = -Imodpath
 OPENMPFLAGS ?=
+BLAS ?= -lblas
+LAPACK ?= -llapack
 else ifeq ($(origin F95FLAGS), undefined)
 F95FLAGS = -m64 -O3
 MODFLAG = -I$(MODPATH)
 SYSMODFLAG = -I$(SYSMODPATH)
 OPENMPFLAGS ?=
+BLAS ?= -lblas
+LAPACK ?= -llapack
 endif
 
 ifeq ($(LAPACK_UNDERSCORE),1)

--- a/examples/fortran/Makefile
+++ b/examples/fortran/Makefile
@@ -13,9 +13,9 @@
 
 F95 = gfortran
 
-FFTW = -lfftw3
-LAPACK = -llapack
-BLAS = -lblas
+FFTW ?= -lfftw3
+LAPACK ?= -llapack
+BLAS ?= -lblas
 
 LIBPATH = ../../lib
 MODPATH = ../../modules/
@@ -44,7 +44,7 @@ EXAMPLES = \
 all: $(EXAMPLES)
 
 %: %.f95 $(LIBPATH)/lib$(LIBNAME).a
-	$(F95) $< $(MODFLAG) $(F95FLAGS) -L$(LIBPATH) -l$(LIBNAME) $(FFTW) -lm $(LAPACK) $(BLAS) -o $@
+	$(F95) $(F95FLAGS) $< $(MODFLAG) -L$(LIBPATH) -l$(LIBNAME) $(FFTW) -lm $(LAPACK) $(BLAS) -o $@
 
 run-fortran-tests: $(EXAMPLES)
 	 @echo MARS-CRUSTAL-THICKNESS
@@ -106,8 +106,10 @@ MODFLAG = -I$(MODPATH)
 endif
 
 ifeq ($(F95),ifort)
-F95FLAGS ?= -m64 -free -O3 -Tf
+F95FLAGS ?= -m64 -fpp -free -O3 -Tf
 MODFLAG = -I$(MODPATH)
+LAPACK ?= -mkl
+BLAS ?= 
 endif
 
 ifeq ($(F95),g95)

--- a/examples/fortran/Makefile
+++ b/examples/fortran/Makefile
@@ -14,8 +14,6 @@
 F95 = gfortran
 
 FFTW ?= -lfftw3
-LAPACK ?= -llapack
-BLAS ?= -lblas
 
 LIBPATH = ../../lib
 MODPATH = ../../modules/
@@ -98,11 +96,15 @@ run-fortran-tests: $(EXAMPLES)
 ifeq ($(F95),f95)
 F95FLAGS ?= -m64 -O3 -YEXT_NAMES=LCS -YEXT_SFX=_ -fpic
 MODFLAG = -p $(MODPATH)
+LAPACK ?= -llapack
+BLAS ?= -lblas
 endif
 
 ifeq ($(F95),gfortran)
 F95FLAGS ?= -m64 -fPIC -O3
 MODFLAG = -I$(MODPATH)
+LAPACK ?= -llapack
+BLAS ?= -lblas
 endif
 
 ifeq ($(F95),ifort)
@@ -115,16 +117,22 @@ endif
 ifeq ($(F95),g95)
 F95FLAGS ?= -O3 -fno-second-underscore 
 MODFLAG = -I$(MODPATH)
+LAPACK ?= -llapack
+BLAS ?= -lblas
 endif
 
 ifeq ($(F95),pgf90)
 F95FLAGS ?= -fast 
 MODFLAG = -Imodpath
+LAPACK ?= -llapack
+BLAS ?= -lblas
 endif
 
 ifeq ($(origin F95FLAGS), undefined)
 F95FLAGS = -m64 -O3
 MODFLAG = -I$(MODPATH)
+LAPACK ?= -llapack
+BLAS ?= -lblas
 endif
 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -34,7 +34,7 @@ else ifeq ($(F95),gfortran)
 F95FLAGS ?= -m64 -fPIC -O3 -ffast-math
 else ifeq ($(F95),ifort)
 # Default intel fortran flags
-F95FLAGS ?= -m64 -free -O3 -Tf
+F95FLAGS ?= -m64 -fpp -free -O3 -Tf
 else ifeq ($(origin F95FLAGS), undefined)
 F95FLAGS = -m64 -O3
 endif


### PR DESCRIPTION
Fix Makefile so that ifort invokes the preprocessor `-fpp` when compiling. Also add default option for openmp `-openmp`.