### PR TITLE
Fix SHWindow plotting routines (plot_spectra and plot_windows) when the number of rows is equal to 1

### DIFF
--- a/pyshtools/shclasses/shwindow.py
+++ b/pyshtools/shclasses/shwindow.py
@@ -730,14 +730,17 @@ class SHWindow(object):
             for ax in axes[:, 1:].flatten():
                 for ylabel_i in ax.get_yticklabels():
                     ylabel_i.set_visible(False)
-        else:
+        elif nwin > 1:
             for ax in axes[1:].flatten():
                 for ylabel_i in ax.get_yticklabels():
                     ylabel_i.set_visible(False)
 
         for itaper in range(min(self.nwin, nwin)):
             evalue = self.eigenvalues[itaper]
-            ax = axes.flatten()[itaper]
+            if min(self.nwin, nwin) == 1:
+                ax = axes
+            else:
+                ax = axes.flatten()[itaper]
             gridout = _shtools.MakeGridDH(self.to_array(itaper), sampling=2,
                                           norm=1, csphase=1)
             ax.imshow(gridout, origin='upper',
@@ -804,14 +807,17 @@ class SHWindow(object):
             for ax in axes[:, 1:].flatten():
                 for ylabel_i in ax.get_yticklabels():
                     ylabel_i.set_visible(False)
-        else:
+        elif nwin > 1:
             for ax in axes[1:].flatten():
                 for ylabel_i in ax.get_yticklabels():
                     ylabel_i.set_visible(False)
 
         for itaper in range(min(self.nwin, nwin)):
             evalue = self.eigenvalues[itaper]
-            ax = axes.flatten()[itaper]
+            if min(self.nwin, nwin) == 1:
+                ax = axes
+            else:
+                ax = axes.flatten()[itaper]
             ax.set_xlabel('degree l')
             if (convention == 'power'):
                 ax.set_ylabel('power')

--- a/pyshtools/shclasses/shwindow.py
+++ b/pyshtools/shclasses/shwindow.py
@@ -723,12 +723,17 @@ class SHWindow(object):
         figsize = ncolumns * 2.4, nrows * 1.2 + 0.5
         fig, axes = _plt.subplots(nrows, ncolumns, figsize=figsize)
 
-        for ax in axes[:-1, :].flatten():
-            for xlabel_i in ax.get_xticklabels():
-                xlabel_i.set_visible(False)
-        for ax in axes[:, 1:].flatten():
-            for ylabel_i in ax.get_yticklabels():
-                ylabel_i.set_visible(False)
+        if nrows > 1:
+            for ax in axes[:-1, :].flatten():
+                for xlabel_i in ax.get_xticklabels():
+                    xlabel_i.set_visible(False)
+            for ax in axes[:, 1:].flatten():
+                for ylabel_i in ax.get_yticklabels():
+                    ylabel_i.set_visible(False)
+        else:
+            for ax in axes[1:].flatten():
+                for ylabel_i in ax.get_yticklabels():
+                    ylabel_i.set_visible(False)
 
         for itaper in range(min(self.nwin, nwin)):
             evalue = self.eigenvalues[itaper]
@@ -792,12 +797,17 @@ class SHWindow(object):
 
         fig, axes = _plt.subplots(nrows, ncolumns, figsize=figsize)
 
-        for ax in axes[:-1, :].flatten():
-            for xlabel_i in ax.get_xticklabels():
-                xlabel_i.set_visible(False)
-        for ax in axes[:, 1:].flatten():
-            for ylabel_i in ax.get_yticklabels():
-                ylabel_i.set_visible(False)
+        if nrows > 1:
+            for ax in axes[:-1, :].flatten():
+                for xlabel_i in ax.get_xticklabels():
+                    xlabel_i.set_visible(False)
+            for ax in axes[:, 1:].flatten():
+                for ylabel_i in ax.get_yticklabels():
+                    ylabel_i.set_visible(False)
+        else:
+            for ax in axes[1:].flatten():
+                for ylabel_i in ax.get_yticklabels():
+                    ylabel_i.set_visible(False)
 
         for itaper in range(min(self.nwin, nwin)):
             evalue = self.eigenvalues[itaper]


### PR DESCRIPTION
The `SHWindow` methods `plot_windows()` and `plot_spectra()` would crash if the desired number of windows caused the number of rows in the plot to be equal to 1. 