### PR TITLE
Fix cross_spectrum without optional argument

### DIFF
--- a/pyshtools/spectralanalysis/cross_spectrum.py
+++ b/pyshtools/spectralanalysis/cross_spectrum.py
@@ -70,7 +70,7 @@ def cross_spectrum(clm1, clm2, normalization='4pi', degrees=None, lmax=None,
         lmax = len(clm1[0, :, 0]) - 1
 
     if (degrees is None):
-        degrees = _np.range(lmax+1)
+        degrees = _np.arange(lmax+1)
 
     if _np.iscomplexobj(clm1) is not _np.iscomplexobj(clm2):
         raise ValueError('clm1 and clm2 must both be either real or ' +


### PR DESCRIPTION
Without the optional argument "degrees" in cross_spectrum
degrees is set using numpy.range(lmax+1). However, this
is not a numpy function and 'nrange' should be used. This
patch makes cross_spectrum work as documented (i.e. without
the degrees argument) and matches the spectrum function.