### PR TITLE
BLD: autoconfigure lapack

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,10 @@ class develop(_develop):
         doc_builder = os.path.join(self.setup_path, 'pyshtools',
                                    'make_docs.py')
         doc_source = '.'
-        check_call([sys.executable, doc_builder, doc_source, self.setup_path])
+        try:
+            check_call([sys.executable, doc_builder, doc_source, self.setup_path])
+        except CalledProcessError:
+            print('WARNING: FAILED TO BUILD DOCS')
 
         print('---- ALL DONE ----')
 

--- a/setup.py
+++ b/setup.py
@@ -237,9 +237,9 @@ def configuration(parent_package='', top_path=None):
 
     # SHTOOLS
     kwargs['libraries'].extend(['SHTOOLS', 'fftw3', 'm'])
+    kwargs['include_dirs'].extend([libdir])
+    kwargs['library_dirs'].extend([libdir])
     config.add_extension('pyshtools._SHTOOLS',
-                         include_dirs=[libdir],
-                         library_dirs=[libdir],
                          sources=['src/pyshtools.pyf',
                                   'src/PythonWrapper.f95'],
                          **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -235,8 +235,10 @@ def configuration(parent_package='', top_path=None):
                        **kwargs)
     
     # BLAS / Lapack info
-    blas_info = get_info('lapack_opt')
+    lapack_info = get_info('lapack_opt')
+    blas_info = get_info('blas_opt')
     dict_append(kwargs, **blas_info)
+    dict_append(kwargs, **lapack_info)
 
     # SHTOOLS
     kwargs['libraries'].extend(['SHTOOLS', 'fftw3', 'm'])

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ from numpy.distutils.command.install import install as _install
 from numpy.distutils.command.develop import develop as _develop
 from numpy.distutils.fcompiler import FCompiler, get_default_fcompiler
 from numpy.distutils.misc_util import Configuration
+from numpy.distutils.system_info import get_info, dict_append
 from subprocess import CalledProcessError, check_output, check_call
 
 
@@ -229,12 +230,16 @@ def configuration(parent_package='', top_path=None):
     config.add_library('SHTOOLS',
                        sources=sources,
                        **kwargs)
+    
+    # BLAS / Lapack info
+    blas_info = get_info('lapack_opt')
+    dict_append(kwargs, **blas_info)
 
     # SHTOOLS
+    kwargs['libraries'].extend(['SHTOOLS', 'fftw3', 'm'])
     config.add_extension('pyshtools._SHTOOLS',
                          include_dirs=[libdir],
                          library_dirs=[libdir],
-                         libraries=['SHTOOLS', 'fftw3', 'm', 'lapack', 'blas'],
                          sources=['src/pyshtools.pyf',
                                   'src/PythonWrapper.f95'],
                          **kwargs)


### PR DESCRIPTION
This PR uses numpy's autoconfiguration feature in order to correctly detect the lapack version that we are linking against. This is needed so that we can potentially link against OpenBLAS, MKL, or other BLAS options.