### PR TITLE
Minor changes before next release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+       brew update;
        brew install fftw --with-fortran;
     else
        sudo apt-get update;

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
       export OS="Linux";
     fi
   - if [[ "${PYTHON_VERSION:0:1}" == '2' ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda-latest-${OS}-x86_64.sh -O miniconda.sh;
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-${OS}-x86_64.sh -O miniconda.sh;
     else
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-${OS}-x86_64.sh -O miniconda.sh;
     fi

--- a/Makefile
+++ b/Makefile
@@ -480,7 +480,7 @@ clean-libs:
 	@-rm -rf build
 	@-rm -rf pyshtools.egg-info
 	@-rm -f src/_SHTOOLS-f2pywrappers.f src/_SHTOOLSmodule.c
-	@-rm -f dist
+	@-rm -rf dist
 	@echo "--> Removed lib, module, object files, compiled Python files and tests"
 	@echo
 	@echo \*\*\* If you installed pyshtools using \"pip install -e .\" you should

--- a/pyshtools/shclasses/shcoeffsgrid.py
+++ b/pyshtools/shclasses/shcoeffsgrid.py
@@ -402,7 +402,7 @@ class SHCoeffs(object):
 
         if format.lower() == 'shtools':
             if kind.lower() == 'real':
-                coeffs, lmax = _shtools.SHRead(fname, lmax, **kwargs)
+                coeffs, lmaxout = _shtools.SHRead(fname, lmax, **kwargs)
             else:
                 raise NotImplementedError(
                     "Complex coefficients are not yet implemented for "
@@ -415,7 +415,8 @@ class SHCoeffs(object):
 
         for cls in self.__subclasses__():
             if cls.istype(kind):
-                return cls(coeffs, normalization=normalization.lower(),
+                return cls(coeffs[:, 0:lmaxout+1, 0:lmaxout+1],
+                           normalization=normalization.lower(),
                            csphase=csphase)
 
     def copy(self):

--- a/pyshtools/shclasses/shcoeffsgrid.py
+++ b/pyshtools/shclasses/shcoeffsgrid.py
@@ -766,7 +766,8 @@ class SHCoeffs(object):
             Condon-Shortley phase convention: 1 to exclude the phase factor,
             or -1 to include it.
         lmax : int, optional, default = x.lmax
-            Maximum spherical harmonic degree to output.
+            Maximum spherical harmonic degree to output. If lmax is greater
+            than x.lmax, the array will be zero padded.
         """
         if normalization is None:
             normalization = self.normalization
@@ -791,13 +792,6 @@ class SHCoeffs(object):
                 .format(repr(csphase))
                 )
 
-        if lmax is not None:
-            if lmax > self.lmax:
-                raise ValueError('Output lmax is greater than the maximum ' +
-                                 'degree of the coefficients. ' +
-                                 'Output lmax = {:d} '.format(lmax) +
-                                 'lmax of coefficients ' +
-                                 '= {:d}'.format(self.lmax))
         if lmax is None:
             lmax = self.lmax
 
@@ -1314,7 +1308,13 @@ class SHRealCoeffs(SHCoeffs):
 
     def _to_array(self, output_normalization, output_csphase, lmax):
         """Return coefficients with a different normalization convention."""
-        coeffs = _np.copy(self.coeffs[:, :lmax+1, :lmax+1])
+        if lmax <= self.lmax:
+            coeffs = _np.copy(self.coeffs[:, :lmax+1, :lmax+1])
+        else:
+            coeffs = _np.copy(self.coeffs[:, :self.lmax+1, :self.lmax+1])
+            coeffs = _np.pad(coeffs, ((0, 0), (0, lmax - self.lmax),
+                                      (0, lmax - self.lmax)), 'constant')
+
         degrees = _np.arange(lmax + 1)
 
         if self.normalization == output_normalization:
@@ -1541,7 +1541,13 @@ class SHComplexCoeffs(SHCoeffs):
 
     def _to_array(self, output_normalization, output_csphase, lmax):
         """Return coefficients with a different normalization convention."""
-        coeffs = _np.copy(self.coeffs[:, :lmax+1, :lmax+1])
+        if lmax <= self.lmax:
+            coeffs = _np.copy(self.coeffs[:, :lmax+1, :lmax+1])
+        else:
+            coeffs = _np.copy(self.coeffs[:, :self.lmax+1, :self.lmax+1])
+            coeffs = _np.pad(coeffs, ((0, 0), (0, lmax - self.lmax),
+                                      (0, lmax - self.lmax)), 'constant')
+
         degrees = _np.arange(lmax + 1)
 
         if self.normalization == output_normalization:

--- a/pyshtools/shclasses/shcoeffsgrid.py
+++ b/pyshtools/shclasses/shcoeffsgrid.py
@@ -155,14 +155,15 @@ class SHCoeffs(object):
                            csphase=csphase)
 
     @classmethod
-    def from_array(self, coeffs, normalization='4pi', csphase=1, copy=True):
+    def from_array(self, coeffs, normalization='4pi', csphase=1, lmax = None,
+                   copy=True):
         """
         Initialize the class with spherical harmonic coefficients from an input
         array.
 
         Usage
         -----
-        x = SHCoeffs.from_array(array, [normalization, csphase, copy])
+        x = SHCoeffs.from_array(array, [normalization, csphase, lmax, copy])
 
         Returns
         -------
@@ -170,7 +171,7 @@ class SHCoeffs(object):
 
         Parameters
         ----------
-        array : ndarray, shape (2, lmax+1, lmax+1).
+        array : ndarray, shape (2, lmaxin+1, lmaxin+1).
             The input spherical harmonic coefficients.
         normalization : str, optional, default = '4pi'
             '4pi', 'ortho' or 'schmidt' for geodesy 4pi normalized,
@@ -179,6 +180,9 @@ class SHCoeffs(object):
         csphase : int, optional, default = 1
             Condon-Shortley phase convention: 1 to exclude the phase factor,
             or -1 to include it.
+        lmax : int, optional, default = None
+            The maximum spherical harmonic degree to include in the returned
+            class instance. This must be less than or equal to lmaxin.
         copy : bool, optional, default = True
             If True, make a copy of array when initializing the class instance.
             If False, initialize the class instance with a reference to array.
@@ -206,9 +210,17 @@ class SHCoeffs(object):
                 .format(repr(csphase))
                 )
 
+        lmaxin = coeffs.shape[1] - 1
+        if lmax is None:
+            lmax = lmaxin
+        else:
+            if lmax > lmaxin:
+                lmax = lmaxin
+
         for cls in self.__subclasses__():
             if cls.istype(kind):
-                return cls(coeffs, normalization=normalization.lower(),
+                return cls(coeffs[:,0:lmax+1,0:lmax+1],
+                           normalization=normalization.lower(),
                            csphase=csphase, copy=copy)
 
     @classmethod

--- a/pyshtools/shclasses/shcoeffsgrid.py
+++ b/pyshtools/shclasses/shcoeffsgrid.py
@@ -155,7 +155,7 @@ class SHCoeffs(object):
                            csphase=csphase)
 
     @classmethod
-    def from_array(self, coeffs, normalization='4pi', csphase=1, lmax = None,
+    def from_array(self, coeffs, normalization='4pi', csphase=1, lmax=None,
                    copy=True):
         """
         Initialize the class with spherical harmonic coefficients from an input
@@ -219,7 +219,7 @@ class SHCoeffs(object):
 
         for cls in self.__subclasses__():
             if cls.istype(kind):
-                return cls(coeffs[:,0:lmax+1,0:lmax+1],
+                return cls(coeffs[:, 0:lmax+1, 0:lmax+1],
                            normalization=normalization.lower(),
                            csphase=csphase, copy=copy)
 

--- a/pyshtools/shclasses/shcoeffsgrid.py
+++ b/pyshtools/shclasses/shcoeffsgrid.py
@@ -795,8 +795,9 @@ class SHCoeffs(object):
             if lmax > self.lmax:
                 raise ValueError('Output lmax is greater than the maximum ' +
                                  'degree of the coefficients. ' +
-                                 'Output lmax = {:d}, lmax of coefficients ' +
-                                 '= {:d}'.format(lmax, self.lmax))
+                                 'Output lmax = {:d} '.format(lmax) +
+                                 'lmax of coefficients ' +
+                                 '= {:d}'.format(self.lmax))
         if lmax is None:
             lmax = self.lmax
 
@@ -2388,9 +2389,9 @@ class DHComplexGrid(SHGrid):
         elif self.nlat == self.nlon:
             self.sampling = 1
         else:
-            raise ValueError('Input array has shape (nlat={:d},nlon={:d})\n' +
+            raise ValueError('Input array has shape (nlat={:d},nlon={:d})\n'
+                             .format(self.nlat, self.nlon) +
                              'but needs nlat=nlon or nlat=2*nlon'
-                             .format(self.nlat, self.nlon)
                              )
 
         self.lmax = int(self.nlat / 2 - 1)
@@ -2475,10 +2476,10 @@ class GLQRealGrid(SHGrid):
         self.lmax = self.nlat - 1
 
         if self.nlat != self.lmax + 1 or self.nlon != 2 * self.lmax + 1:
-            raise ValueError('Input array has shape (nlat={:d}, nlon={:d})\n' +
+            raise ValueError('Input array has shape (nlat={:d}, nlon={:d})\n'
+                             .format(self.nlat, self.nlon) +
                              'but needs (nlat={:d}, {:d})'
-                             .format(self.nlat, self.nlon, self.lmax+1,
-                                     2*self.lmax+1)
+                             .format(self.lmax+1, 2*self.lmax+1)
                              )
 
         if zeros is None or weights is None:
@@ -2561,10 +2562,10 @@ class GLQComplexGrid(SHGrid):
         self.lmax = self.nlat - 1
 
         if self.nlat != self.lmax + 1 or self.nlon != 2 * self.lmax + 1:
-            raise ValueError('Input array has shape (nlat={:d}, nlon={:d})\n' +
+            raise ValueError('Input array has shape (nlat={:d}, nlon={:d})\n'
+                             .format(self.nlat, self.nlon) +
                              'but needs (nlat={:d}, {:d})'
-                             .format(self.nlat, self.nlon, self.lmax+1,
-                                     2*self.lmax+1)
+                             .format(self.lmax+1, 2*self.lmax+1)
                              )
 
         if zeros is None or weights is None:

--- a/pyshtools/shclasses/shcoeffsgrid.py
+++ b/pyshtools/shclasses/shcoeffsgrid.py
@@ -74,6 +74,8 @@ class SHCoeffs(object):
                             class instance.
     convert()             : Return a new class instance using a different
                             normalization convention.
+    pad()                 : Return a new class instance that is zero padded or
+                            truncated to a different lmax.
     expand()              : Evaluate the coefficients either on a spherical
                             grid and return an SHGrid class instance, or for
                             a list of latitude and longitude coordinates.
@@ -881,7 +883,7 @@ class SHCoeffs(object):
     def convert(self, normalization=None, csphase=None, lmax=None, kind=None,
                 check=True):
         """
-        Return a SHCoeff class instance with a different normalization
+        Return a SHCoeffs class instance with a different normalization
         convention.
 
         Usage
@@ -952,6 +954,36 @@ class SHCoeffs(object):
         return SHCoeffs.from_array(coeffs,
                                    normalization=normalization.lower(),
                                    csphase=csphase, copy=False)
+
+    # ---- Return a SHCoeffs class instance zero padded up to lmax
+    def pad(self, lmax):
+        """
+        Return a SHCoeffs class where the coefficients are zero padded or
+        truncated to a different lmax.
+
+        Usage
+        -----
+        clm = x.pad(lmax)
+
+        Returns
+        -------
+        clm : SHCoeffs class instance
+
+        Parameters
+        ----------
+        lmax : int
+            Maximum spherical harmonic degree to output.
+        """
+        clm = self.copy()
+
+        if lmax <= self.lmax:
+            clm.coeffs = clm.coeffs[:, :lmax+1, :lmax+1]
+        else:
+            clm.coeffs = _np.pad(clm.coeffs, ((0, 0), (0, lmax - self.lmax),
+                                 (0, lmax - self.lmax)), 'constant')
+
+        clm.lmax = lmax
+        return clm
 
     # ---- Expand the coefficients onto a grid ----
     def expand(self, grid='DH', lat=None, lon=None, degrees=True, zeros=None,

--- a/src/BAtoHilm.f95
+++ b/src/BAtoHilm.f95
@@ -82,7 +82,7 @@ subroutine BAtoHilm(cilm, ba, grid, lmax, nmax, mass, r0, rho, gridtype, w, &
     integer, intent(in) :: lmax, nmax, gridtype
     integer, intent(in), optional :: filter_type, filter_deg, lmax_calc
     integer, intent(out), optional :: exitstatus
-    real*8 :: prod, pi, d, depth, filter(lmax+1)
+    real*8 :: prod, pi, d, filter(lmax+1)
     real*8, allocatable ::  cilmn(:, :, :), grid2(:,:)
     integer :: j, l, n, nlong, nlat, astat(2), lmax_out, lmax_calc2
 
@@ -408,8 +408,6 @@ subroutine BAtoHilm(cilm, ba, grid, lmax, nmax, mass, r0, rho, gridtype, w, &
     end if
 
     d = cilmn(1,1,1)
-    depth = r0 - d
-    print*, "Average depth of Moho (km) = ", depth / 1.d3
 
     cilm(1,1,1) = d
 

--- a/src/BAtoHilmRhoH.f95
+++ b/src/BAtoHilmRhoH.f95
@@ -85,7 +85,7 @@ subroutine BAtoHilmRhoH(cilm, ba, grid, lmax, nmax, mass, r0, rho, gridtype, &
     integer, intent(in) :: lmax, nmax, gridtype
     integer, intent(in), optional :: filter_type, filter_deg, lmax_calc
     integer, intent(out), optional :: exitstatus
-    real*8 :: prod, pi, d, depth, filter(lmax+1)
+    real*8 :: prod, pi, d, filter(lmax+1)
     real*8, allocatable :: cilmn(:, :, :), grid2(:,:)
     integer  :: j, l, n, nlong, nlat, astat(2), lmax_out, lmax_calc2, n_out
 
@@ -414,8 +414,6 @@ subroutine BAtoHilmRhoH(cilm, ba, grid, lmax, nmax, mass, r0, rho, gridtype, &
     end if
 
     d = cilmn(1,1,1)
-    depth = r0 - d
-    print*, "Average depth of Moho (km) = ", depth/1.d3
 
     ! calculate (rho*h)_00
     grid2(1:nlat,1:nlong) = (grid(1:nlat,1:nlong) - d) * rho(1:nlat,1:nlong)

--- a/src/PythonWrapper.f95
+++ b/src/PythonWrapper.f95
@@ -1720,7 +1720,7 @@
         endif
     end subroutine pyCilmMinusDH
 
-    subroutine pyCilmPlusRhoHDH(exitstatus,cilm,gridin,lmax,nmax,mass,d,rho,&
+    subroutine pyCilmPlusRhoHDH(exitstatus,cilm,gridin,rho,lmax,nmax,mass,d,&
                                 sampling,n,gridin_d0,gridin_d1,cilm_d0,cilm_d1,&
                                 cilm_d2,rho_d0,rho_d1)
         use shtools, only: CilmPlusRhoH

--- a/src/PythonWrapper.f95
+++ b/src/PythonWrapper.f95
@@ -1820,10 +1820,10 @@
         endif
     end subroutine pyBAtoHilmDH
     
-    subroutine pyBAtoHilmRhoHDH(exitstatus,cilm,ba,griddh,lmax,nmax,mass,r0,&
-                                rho,sampling,filter_type,filter_deg,lmax_calc,&
+    subroutine pyBAtoHilmRhoHDH(exitstatus,cilm,ba,griddh,rho,lmax,nmax,mass,&
+                                r0,sampling,filter_type,filter_deg,lmax_calc,&
                                 ba_d0,ba_d1,ba_d2,griddh_d0,griddh_d1,cilm_d0,&
-                                cilm_d1,cilm_d2, rho_d0,rho_d1)
+                                cilm_d1,cilm_d2,rho_d0,rho_d1)
         use shtools, only: BAtoHilmRhoH
         implicit none
         integer, intent(out) :: exitstatus

--- a/src/pydoc/pybatohilmdh.md
+++ b/src/pydoc/pybatohilmdh.md
@@ -4,16 +4,16 @@ Calculate iteratively the relief along an interface of constant density contrast
 
 # Usage
 
-`cilm` = BAtoHilmDH (`ba`, `grid`, `nmax`, `mass`, `r0`, `rho`, [`filtertype`, `filterdeg`, `lmax`, `lmaxcalc`, `smapling`])
+`cilm` = BAtoHilmDH (`ba`, `grid`, `nmax`, `mass`, `r0`, `rho`, [`filter_type`, `filter_deg`, `lmax`, `lmax_calc`, `smapling`])
 
 # Returns
 
-`cilm` : float, dimension (2, `lmaxcalc`+1, `lmaxcalc`+1)
+`cilm` : float, dimension (2, `lmax_calc`+1, `lmax_calc`+1)
 :   An estimate of the real spherical harmonic coefficients (geodesy normalized) of relief along an interface with density contrast `rho` that satisfies the Bouguer anomaly `ba`. The degree zero term corresponds to the mean radius of the relief.
 
 # Parameters
 
-`ba` : float, dimension (2, `lmaxcalc`+1, `lmaxcalc`+1)
+`ba` : float, dimension (2, `lmax_calc`+1, `lmax_calc`+1)
 :   The real spherical harmonic coefficients of the Bouguer anomaly referenced to a spherical interface `r0`.
 
 `grid` : float, dimension (2\*`lmaxin`+2, `sampling`\*(2\*`lmaxin`+2)) 
@@ -31,16 +31,16 @@ Calculate iteratively the relief along an interface of constant density contrast
 `rho` : float
 :   The density contrast of the relief in kg/m^3.
 
-`filtertype` : optional, integer, default = 0
+`filter_type` : optional, integer, default = 0
 :   Apply a filter when calculating the relief in order to minimize the destabilizing effects of downward continuation which amplify uncertainties in the Bouguer anomaly. If 0, no filtering is applied. If 1, use the minimum amplitude filter `DownContFilterMA`. If 2, use the minimum curvature filter `DownContFilterMC`. 
 
-`filterdeg` : optional, integer, default = 0
+`filter_deg` : optional, integer, default = 0
 :   The spherical harmonic degree for which the filter is 0.5.
 
 `lmax` : optional, integer, default = `lmaxin`
-:   The spherical harmonic bandwidth of the input relief `grid`, which determines the dimensions of `grid`. If `lmaxcalc` is not set, this determines also the maximum spherical harmonic degree of the output spherical harmonic coefficients of the relief and the input spherical harmonics of the Bouguer anomaly.
+:   The spherical harmonic bandwidth of the input relief `grid`, which determines the dimensions of `grid`. If `lmax_calc` is not set, this determines also the maximum spherical harmonic degree of the output spherical harmonic coefficients of the relief and the input spherical harmonics of the Bouguer anomaly.
 
-`lmaxcalc` : optional, integer, default = `lmax`
+`lmax_calc` : optional, integer, default = `lmax`
 :   The maximum degree that will be calculated in the spherical harmonic expansions.
 
 `sampling` : optional, integer, default set by dimensions of `grid`

--- a/src/pydoc/pybatohilmrhohdh.md
+++ b/src/pydoc/pybatohilmrhohdh.md
@@ -19,6 +19,9 @@ Calculate iteratively the relief along an interface with lateral density variati
 `grid` : float, dimension (2\*`lmaxin`+2, `sampling`\*(2\*`lmaxin`+2)) 
 :   The initial estimate for the radii of the interface evaluated on a grid corresponding to a function of maximum spherical harmonic degree `lmaxin`. This is calculated by a call to `MakeGridDH` and must contain the degree-0 average radius of the interface.
 
+`rho` : float, dimension (2\*`lmaxin`+2, `sampling`\*(2\*`lmaxin`+2)) 
+:   The density contrast of the relief in kg/m^3, with the same dimensions as `grid`.
+
 `nmax` : integer
 :   The maximum order used in the Taylor-series expansion used in calculating the potential coefficients.
 
@@ -27,9 +30,6 @@ Calculate iteratively the relief along an interface with lateral density variati
 
 `r0` : float
 :   The reference radius of the Bouguer anomaly `ba`.
-
-`rho` : float, dimension (2\*`lmaxin`+2, `sampling`\*(2\*`lmaxin`+2)) 
-:   The density contrast of the relief in kg/m^3, with the same dimensions as `grid`.
 
 `filtertype` : optional, integer, default = 0
 :   Apply a filter when calculating the relief in order to minimize the destabilizing effects of downward continuation which amplify uncertainties in the Bouguer anomaly. If 0, no filtering is applied. If 1, use the minimum amplitude filter `DownContFilterMA`. If 2, use the minimum curvature filter `DownContFilterMC`. 

--- a/src/pydoc/pybatohilmrhohdh.md
+++ b/src/pydoc/pybatohilmrhohdh.md
@@ -4,16 +4,16 @@ Calculate iteratively the relief along an interface with lateral density variati
 
 # Usage
 
-`cilm` = BAtoHilmRhoHDH (`ba`, `grid`, `rho`, `nmax`, `mass`, `r0`, [`filtertype`, `filterdeg`, `lmax`, `lmaxcalc`, `sampling`)
+`cilm` = BAtoHilmRhoHDH (`ba`, `grid`, `rho`, `nmax`, `mass`, `r0`, [`filter_type`, `filter_deg`, `lmax`, `lmax_calc`, `sampling`)
 
 # Returns
 
-`cilm` : float, dimension (2, `lmaxcalc`+1, `lmaxcalc`+1)
+`cilm` : float, dimension (2, `lmax_calc`+1, `lmax_calc`+1)
 :   An estimate of the real spherical harmonic coefficients (geodesy normalized) of relief along an interface with lateraly varying density contrast `rho` that satisfies the Bouguer anomaly `ba`. The degree-zero term corresponds to the mean radius of the relief.
 
 # Parameters
 
-`ba` : float, dimension (2, `lmaxcalc`+1, `lmaxcalc`+1)
+`ba` : float, dimension (2, `lmax_calc`+1, `lmax_calc`+1)
 :   The real spherical harmonic coefficients of the Bouguer anomaly referenced to a spherical interface `r0`.
 
 `grid` : float, dimension (2\*`lmaxin`+2, `sampling`\*(2\*`lmaxin`+2)) 
@@ -31,16 +31,16 @@ Calculate iteratively the relief along an interface with lateral density variati
 `r0` : float
 :   The reference radius of the Bouguer anomaly `ba`.
 
-`filtertype` : optional, integer, default = 0
+`filter_type` : optional, integer, default = 0
 :   Apply a filter when calculating the relief in order to minimize the destabilizing effects of downward continuation which amplify uncertainties in the Bouguer anomaly. If 0, no filtering is applied. If 1, use the minimum amplitude filter `DownContFilterMA`. If 2, use the minimum curvature filter `DownContFilterMC`. 
 
-`filterdeg` : optional, integer, default = 0
+`filter_deg` : optional, integer, default = 0
 :   The spherical harmonic degree for which the filter is 0.5.
 
 `lmax` : optional, integer, default = `lmaxin`
-:   The spherical harmonic bandwidth of the input relief `grid`, which determines the dimensions of `grid`. If `lmaxcalc` is not set, this determines also the maximum spherical harmonic degree of the output spherical harmonic coefficients of the relief and the input spherical harmonics of the Bouguer anomaly.
+:   The spherical harmonic bandwidth of the input relief `grid`, which determines the dimensions of `grid`. If `lmax_calc` is not set, this determines also the maximum spherical harmonic degree of the output spherical harmonic coefficients of the relief and the input spherical harmonics of the Bouguer anomaly.
 
-`lmaxcalc` : optional, integer, default = `lmax`
+`lmax_calc` : optional, integer, default = `lmax`
 :   The maximum degree that will be calculated in the spherical harmonic expansions.
 
 `sampling` : optional, integer, default set by dimensions of `grid`

--- a/src/pydoc/pymakegriddh.md
+++ b/src/pydoc/pymakegriddh.md
@@ -9,7 +9,7 @@ Create a 2D map from a set of spherical harmonic coefficients using the Driscoll
 # Returns
 
 `griddh` : float, dimension (2\*`lmax`+2, `sampling`\*(2\*`lmax`+2))
-:   A 2D equally sampled (default) or equally spaced map in degrees of the spherical harmonic coefficients `cilm` that conforms to the sampling theorem of Driscoll and Healy (1994). The first latitudinal band corresponds to 90 N, the latitudinal band for 90 S is not included, and the latitudinal sampling interval is 180/`n` degrees. The first longitudinal band is 0 E, the longitudinal band for 360 E is not included, and the longitudinal sampling interval is 360/`n` for an equally sampled and 180/`m` for an equally spaced grid, respectively.
+:   A 2D equally sampled (default) or equally spaced map in degrees of the spherical harmonic coefficients `cilm` that conforms to the sampling theorem of Driscoll and Healy (1994). The first latitudinal band corresponds to 90 N, the latitudinal band for 90 S is not included, and the latitudinal sampling interval is 180/`n` degrees, where `n` is 2\*`lmax`+2. The first longitudinal band is 0 E, the longitudinal band for 360 E is not included, and the longitudinal sampling interval is 360/`n` for an equally sampled and 180/`n` for an equally spaced grid, respectively.
 
 # Parameters
 

--- a/src/pydoc/pymakegriddhc.md
+++ b/src/pydoc/pymakegriddhc.md
@@ -9,7 +9,7 @@ Create a 2D complex map from a set of complex spherical harmonic coefficients th
 # Returns
 
 `griddh` : complex, dimension (2\*lmax+2, 2\*lmax+2) or (2\*lmax+2, 4\*lmax+4)
-:   A 2D equally sampled (`n` by `n`, default), or equally spaced (`n` by `2n`) complex map of the input complex spherical harmonic coefficients `cilm` that conforms to the sampling theorem of Driscoll and Healy (1994). The first latitudinal band corresponds to 90 N, the latitudinal band for 90 S is not calculated, and the latitudinal sampling interval is 180/`n` degrees. The first longitudinal band is 0 E, the longitudinal band for 360 E is not calculated, and the longitudinal sampling interval is 360/`n` for an equally sampled and 180/`n` for an equally spaced grid, respectively.
+:   A 2D equally sampled (`n` by `n`, default), or equally spaced (`n` by `2n`) complex map of the input complex spherical harmonic coefficients `cilm` that conforms to the sampling theorem of Driscoll and Healy (1994).  The first latitudinal band corresponds to 90 N, the latitudinal band for 90 S is not included, and the latitudinal sampling interval is 180/`n` degrees, where `n` is 2\*`lmax`+2. The first longitudinal band is 0 E, the longitudinal band for 360 E is not included, and the longitudinal sampling interval is 360/`n` for an equally sampled and 180/`n` for an equally spaced grid, respectively.
 
 # Parameters
 

--- a/src/pydoc/pyshread2error.md
+++ b/src/pydoc/pyshread2error.md
@@ -4,7 +4,7 @@ Read spherical harmonic coefficients from a CHAMP or GRACE-like ascii-formatted 
 
 # Usage
 
-`cilm`, `error`, `lmax`, `gm`, `r0_pot`, `dot`, `doystart`, `doyend`, `epoch` = SHRead2 (`filename`, `lmaxin`)
+`cilm`, `error`, `lmax`, `gm`, `r0_pot`, `dot`, `doystart`, `doyend`, `epoch` = SHRead2Error (`filename`, `lmaxin`)
 
 # Returns
 

--- a/src/pydoc/pyshreaderror.md
+++ b/src/pydoc/pyshreaderror.md
@@ -4,7 +4,7 @@ Read spherical harmonic coefficients and associated errors from an ascii-formatt
 
 # Usage
 
-`cilm`, `error`, `lmax` = SHRead (`filename`,  `lmaxin`, [`skip`])
+`cilm`, `error`, `lmax` = SHReadError (`filename`,  `lmaxin`, [`skip`])
 
 # Returns
 

--- a/src/pydoc/pyshreaderrorh.md
+++ b/src/pydoc/pyshreaderrorh.md
@@ -4,7 +4,7 @@ Read spherical harmonic coefficients and associated errors from an ascii-formatt
 
 # Usage
 
-`cilm`, `error`, `lmax`, `header` = SHRead (`filename`, `lmaxin`, `nhead`, [`skip`])
+`cilm`, `error`, `lmax`, `header` = SHReadErrorH (`filename`, `lmaxin`, `nhead`, [`skip`])
 
 # Returns
 

--- a/src/pydoc/pyshreadh.md
+++ b/src/pydoc/pyshreadh.md
@@ -4,7 +4,7 @@ Read spherical harmonic coefficients from an ascii-formatted file with a header 
 
 # Usage
 
-`cilm`, `lmax`, `header` = SHRead (`filename`, `lmaxin`, `nhead`, [`skip`])
+`cilm`, `lmax`, `header` = SHReadH (`filename`, `lmaxin`, `nhead`, [`skip`])
 
 # Returns
 

--- a/src/pydoc/pyshreadjplerror.md
+++ b/src/pydoc/pyshreadjplerror.md
@@ -1,10 +1,10 @@
-# SHReadJPL
+# SHReadJPLError
 
 Read spherical harmonic coefficients from a JPL ascii-formatted file.
 
 # Usage
 
-`cilm`, `error`, `lmax`, `gm` = SHReadJPL (`filename`, `lmaxin`, [`formatstring`])
+`cilm`, `error`, `lmax`, `gm` = SHReadJPLError (`filename`, `lmaxin`, [`formatstring`])
 
 # Returns
 


### PR DESCRIPTION
This pull request contains some minor improvements and bug fixes:

* Add optional argument `lmax` to `SHCoeffs.from_array()`.
* Zero pad coefficients when `lmax` is greater than the maximum degree in `SHCoeffs.to_array()`.
* Add method `pad()` to `SHCoeffs` class that zero pads or truncates the coefficients to a different `lmax`.
* Fix `SHCoeffs.from_file()` such that the maximum spherical harmonic degree of the class is the maximum spherical harmonic degree of the coeffs (and not lmaxin).
* Fix formatting issues with error messages in `SHCoeffs`.
* Remove print statements from fortran code in `BAtoHilm` and `BAtoHilmRohH` that served no purpose.
* Fix bug in the argument order of the python wrappers of `CilmPlusRhoDH` and `BAtoHilmRhoDH`.
* Fix `makefile` to remove `dist` directory during `clean`.
* Other minor changes to documentations, etc...