### PR TITLE
Fail install if dependencies are not found.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -244,15 +244,15 @@ def configuration(parent_package='', top_path=None):
     kwargs['library_dirs'].extend([libdir])
 
     # FFTW info
-    fftw_info = get_info('fftw')
+    fftw_info = get_info('fftw', notfound_action=2)
     dict_append(kwargs, **fftw_info)
 
     if sys.platform != 'win32':
         kwargs['libraries'].extend(['m'])
 
     # BLAS / Lapack info
-    lapack_info = get_info('lapack_opt')
-    blas_info = get_info('blas_opt')
+    lapack_info = get_info('lapack_opt', notfound_action=2)
+    blas_info = get_info('blas_opt', notfound_action=2)
     dict_append(kwargs, **blas_info)
     dict_append(kwargs, **lapack_info)
 


### PR DESCRIPTION
The default simply does nothing, so you could build and not link with the required libraries leaving the Python extensions broken.