### PR TITLE
Force doc files to be read as utf-8

### DIFF
--- a/docs/css/customstyles.css
+++ b/docs/css/customstyles.css
@@ -404,7 +404,7 @@ ul#mysidebar {
 }
 
 .nav li a:hover {
-    background-color: #8D8D8D;
+    background-color: #a0a0a0;
 }
 
 .nav ul li a {

--- a/pyshtools/constant/__init__.py
+++ b/pyshtools/constant/__init__.py
@@ -64,7 +64,7 @@ for _name in _constant.planetsconstants.__dict__.keys():
         _path = _os.path.join(_pydocfolder, 'constant_' + _name.lower() +
                               '.doc')
 
-        with open(_path) as _pydocfile:
+        with open(_path, encoding = 'utf-8') as _pydocfile:
             _pydoc = _pydocfile.read()
 
         setattr(locals()[_name], '_infostring', _pydoc)

--- a/pyshtools/constant/__init__.py
+++ b/pyshtools/constant/__init__.py
@@ -64,8 +64,8 @@ for _name in _constant.planetsconstants.__dict__.keys():
         _path = _os.path.join(_pydocfolder, 'constant_' + _name.lower() +
                               '.doc')
 
-        with open(_path, encoding = 'utf-8') as _pydocfile:
-            _pydoc = _pydocfile.read()
+        with open(_path, 'rb') as _pydocfile:
+            _pydoc = _pydocfile.read().decode('utf-8')
 
         setattr(locals()[_name], '_infostring', _pydoc)
 

--- a/pyshtools/shtools/__init__.py
+++ b/pyshtools/shtools/__init__.py
@@ -160,8 +160,8 @@ for _name in __all__:
     try:
         _path = _os.path.join(_pydocfolder, _name.lower() + '.doc')
 
-        with open(_path, encoding = 'utf-8') as _pydocfile:
-            _pydoc = _pydocfile.read()
+        with open(_path, 'rb') as _pydocfile:
+            _pydoc = _pydocfile.read().decode('utf-8')
 
         setattr(locals()[_name], '__doc__', _pydoc)
 

--- a/pyshtools/shtools/__init__.py
+++ b/pyshtools/shtools/__init__.py
@@ -160,7 +160,7 @@ for _name in __all__:
     try:
         _path = _os.path.join(_pydocfolder, _name.lower() + '.doc')
 
-        with open(_path) as _pydocfile:
+        with open(_path, encoding = 'utf-8') as _pydocfile:
             _pydoc = _pydocfile.read()
 
         setattr(locals()[_name], '__doc__', _pydoc)

--- a/src/fdoc/shrotaterealcoef.md
+++ b/src/fdoc/shrotaterealcoef.md
@@ -54,7 +54,7 @@ For a rotation of the physical body without rotation of the coordinate system, u
 
 To perform the inverse transform of `x(alpha, beta, gamma)`, use `x(-gamma, -beta, -alpha)`.
 
-Note that this routine uses the "y convention", where the second rotation is with respect to the new y axis. If alpha, beta, and gamma were orginally defined in terms of the "x convention", where the second rotation was with respect to the newx axis, the Euler angles according to the y convention would be `alpha_y=alpha_x-pi/2`, `beta_x=beta_y`, and `gamma_y=gamma_x+pi/2`.
+Note that this routine uses the "y convention", where the second rotation is with respect to the new y axis. If alpha, beta, and gamma were originally defined in terms of the "x convention", where the second rotation was with respect to the new x axis, the Euler angles according to the y convention would be `alpha_y=alpha_x-pi/2`, `beta_x=beta_y`, and `gamma_y=gamma_x+pi/2`.
 
 This routine first converts the real coefficients to complex form using `SHrtoc`. Then the coefficients are converted to indexed form using `SHCilmToCindex`, these are sent to `SHRotateCoef`, the result if converted back to `cilm` complex form using `SHCindexToCilm`, and these are finally converted back to real form using `SHctor`.
 

--- a/src/pydoc/constant_a_mars.md
+++ b/src/pydoc/constant_a_mars.md
@@ -8,4 +8,4 @@ Semi-major axis radius of Mars.
 
 ## Reference
 
-A. A. Ardalan, R. Karimi, E. W. Grafarend (2010). A New Reference Equipotential Surface, and Reference Ellipsoid for the Planet Mars, Earth Moon Planet, 106, 1–13, DOI 10.1007/s11038-009-9342-7.
+A. A. Ardalan, R. Karimi, E. W. Grafarend (2010). A New Reference Equipotential Surface, and Reference Ellipsoid for the Planet Mars, Earth Moon Planet, 106, 1-13, DOI 10.1007/s11038-009-9342-7.

--- a/src/pydoc/constant_a_moon.md
+++ b/src/pydoc/constant_a_moon.md
@@ -8,4 +8,4 @@ Semi-major axis of the lunar orbit.
 
 ## Reference
 
-Williams, J. G., D. H. Boggs, C. F. Yoder, J. T. Ratcliff, and J. O. Dickey (2001), Lunar rotational dissipation in solid body and molten core, J. Geophys. Res., 106, 27,933–27,968, doi:10.1029/2000JE001396.
+Williams, J. G., D. H. Boggs, C. F. Yoder, J. T. Ratcliff, and J. O. Dickey (2001), Lunar rotational dissipation in solid body and molten core, J. Geophys. Res., 106, 27,933-27,968, doi:10.1029/2000JE001396.

--- a/src/pydoc/constant_b_mars.md
+++ b/src/pydoc/constant_b_mars.md
@@ -8,4 +8,4 @@ Semi-minor axis radius of Mars.
 
 ## Reference
 
-A. A. Ardalan, R. Karimi, E. W. Grafarend (2010). A New Reference Equipotential Surface, and Reference Ellipsoid for the Planet Mars, Earth Moon Planet, 106, 1–13, DOI 10.1007/s11038-009-9342-7.
+A. A. Ardalan, R. Karimi, E. W. Grafarend (2010). A New Reference Equipotential Surface, and Reference Ellipsoid for the Planet Mars, Earth Moon Planet, 106, 1-13, DOI 10.1007/s11038-009-9342-7.

--- a/src/pydoc/constant_beta_moi_moon.md
+++ b/src/pydoc/constant_beta_moi_moon.md
@@ -8,4 +8,4 @@ Libration parameter of the Moon, (C-A)/B.
 
 ## Reference
 
-Williams, J. G., et al. (2014), Lunar interior properties from the GRAIL mission, J. Geophys. Res. Planets, 119, 1546–1578, doi:10.1002/2013JE004559.
+Williams, J. G., et al. (2014), Lunar interior properties from the GRAIL mission, J. Geophys. Res. Planets, 119, 1546-1578, doi:10.1002/2013JE004559.

--- a/src/pydoc/constant_c_moi_moon.md
+++ b/src/pydoc/constant_c_moi_moon.md
@@ -8,4 +8,4 @@ Polar moment of inertia of the Moon, using R=1738 km.
 
 ## Reference
 
-A. S. Konopliv, A, B. Binder, L. L. Hood, A. B. Kucinskas, W. L. Sjogren, and J. G. Williams (1998). Improved gravity field of the Moon from Lunar Prospector. Science, 281, 1476–1480.
+A. S. Konopliv, A, B. Binder, L. L. Hood, A. B. Kucinskas, W. L. Sjogren, and J. G. Williams (1998). Improved gravity field of the Moon from Lunar Prospector. Science, 281, 1476-1480.

--- a/src/pydoc/constant_f_mars.md
+++ b/src/pydoc/constant_f_mars.md
@@ -8,4 +8,4 @@ Topographic flattening of Mars.
 
 ## Reference
 
-A. A. Ardalan, R. Karimi, E. W. Grafarend (2010). A New Reference Equipotential Surface, and Reference Ellipsoid for the Planet Mars, Earth Moon Planet, 106, 1–13, DOI 10.1007/s11038-009-9342-7.
+A. A. Ardalan, R. Karimi, E. W. Grafarend (2010). A New Reference Equipotential Surface, and Reference Ellipsoid for the Planet Mars, Earth Moon Planet, 106, 1-13, DOI 10.1007/s11038-009-9342-7.

--- a/src/pydoc/constant_gamma_moi_moon.md
+++ b/src/pydoc/constant_gamma_moi_moon.md
@@ -8,5 +8,5 @@ Libration parameter of the Moon, (B-A)/C
 
 ## Reference
 
-Williams, J. G., et al. (2014), Lunar interior properties from the GRAIL mission, J. Geophys. Res. Planets, 119, 1546–1578, doi:10.1002/2013JE004559.
+Williams, J. G., et al. (2014), Lunar interior properties from the GRAIL mission, J. Geophys. Res. Planets, 119, 1546-1578, doi:10.1002/2013JE004559.
 

--- a/src/pydoc/constant_gm_mars.md
+++ b/src/pydoc/constant_gm_mars.md
@@ -8,4 +8,4 @@ Gravitational constant times the mass of the Mars.
 
 ## Reference
 
-A. S Konopliv, S. W. Asmar, W. M. Folkner, et al. (2011). Mars high resolution gravity fieldsfrom MRO, Mars seasonal gravity, and other dynamical parameters. Icarus, 211, 401–428, doi:10.1016/j.icarus.2010.10.004.
+A. S Konopliv, S. W. Asmar, W. M. Folkner, et al. (2011). Mars high resolution gravity fieldsfrom MRO, Mars seasonal gravity, and other dynamical parameters. Icarus, 211, 401-428, doi:10.1016/j.icarus.2010.10.004.

--- a/src/pydoc/constant_gm_mercury.md
+++ b/src/pydoc/constant_gm_mercury.md
@@ -8,4 +8,4 @@ Gravitational constant times the mass of the Mercury.
 
 ## Reference
 
-D. E. Smith, M. T. Zuber, R. J. Phillips, et al. (2012). Gravity field and internal structure of Mercury from MESSENGER. Science, 336, 214–217, do:10.1126/science.1218809.
+D. E. Smith, M. T. Zuber, R. J. Phillips, et al. (2012). Gravity field and internal structure of Mercury from MESSENGER. Science, 336, 214-217, do:10.1126/science.1218809.

--- a/src/pydoc/constant_gm_moon.md
+++ b/src/pydoc/constant_gm_moon.md
@@ -8,4 +8,4 @@ Gravitational constant times the mass of the Moon.
 
 ## Reference
 
-Williams, J. G., et al. (2014), Lunar interior properties from the GRAIL mission, J. Geophys. Res. Planets, 119, 15461578, doi:10.1002/2013JE004559.
+Williams, J. G., et al. (2014), Lunar interior properties from the GRAIL mission, J. Geophys. Res. Planets, 119, 1546-1578, doi:10.1002/2013JE004559.

--- a/src/pydoc/constant_gm_venus.md
+++ b/src/pydoc/constant_gm_venus.md
@@ -8,5 +8,5 @@ Gravitational constant times the mass of the Venus.
 
 ## Reference
 
-A. S. Konopliv, W. B. Banerdt, and W. L. Sjogren (1999). Venus gravity: 180th degree and order model. Icarus 139: 3–18.
+A. S. Konopliv, W. B. Banerdt, and W. L. Sjogren (1999). Venus gravity: 180th degree and order model. Icarus 139, 3-18.
 

--- a/src/pydoc/constant_grav_constant.md
+++ b/src/pydoc/constant_grav_constant.md
@@ -8,4 +8,4 @@ Gravitational Constant.
 
 ## Reference
 
-Mohr, P.J., Taylor, B.N., Newell, D.B., 2012. CODATA recommended values of the fundamental physical constants, 2010. Rev. Modern Phys. 84, 1527–1605. doi:doi:10.1103/RevModPhys.84.1527.
+Mohr, P.J., Taylor, B.N., Newell, D.B., 2012. CODATA recommended values of the fundamental physical constants, 2010. Rev. Modern Phys. 84, 1527-1605. doi:doi:10.1103/RevModPhys.84.1527.

--- a/src/pydoc/constant_i_moi_moon.md
+++ b/src/pydoc/constant_i_moi_moon.md
@@ -8,4 +8,4 @@ Average moment of inertia of the Moon, using R=1738 km.
 
 ## Reference
 
-A. S. Konopliv, A, B. Binder, L. L. Hood, A. B. Kucinskas, W. L. Sjogren, and J. G. Williams (1998). Improved gravity field of the Moon from Lunar Prospector. Science, 281, 1476–1480.
+A. S. Konopliv, A, B. Binder, L. L. Hood, A. B. Kucinskas, W. L. Sjogren, and J. G. Williams (1998). Improved gravity field of the Moon from Lunar Prospector. Science, 281, 1476-1480.

--- a/src/pydoc/constant_mass_mercury.md
+++ b/src/pydoc/constant_mass_mercury.md
@@ -8,5 +8,5 @@ gm_mercury / grav_constant kg
 
 ## Reference
 
-D. E. Smith, M. T. Zuber, R. J. Phillips, et al. (2012). Gravity field and internal structure of Mercury from MESSENGER. Science, 336, 214–217, do:10.1126/science.1218809.
+D. E. Smith, M. T. Zuber, R. J. Phillips, et al. (2012). Gravity field and internal structure of Mercury from MESSENGER. Science, 336, 214-217, do:10.1126/science.1218809.
 

--- a/src/pydoc/constant_mu0_constant.md
+++ b/src/pydoc/constant_mu0_constant.md
@@ -4,4 +4,4 @@ Magnetic constant.
 
 ## Value
 
-pi * 4.0e-7 H m1
+pi * 4.0e-7 H m-1

--- a/src/pydoc/constant_mu0_constant.md
+++ b/src/pydoc/constant_mu0_constant.md
@@ -4,4 +4,4 @@ Magnetic constant.
 
 ## Value
 
-pi * 4.0e-7 H m−1
+pi * 4.0e-7 H m1

--- a/src/pydoc/constant_omega_mars.md
+++ b/src/pydoc/constant_omega_mars.md
@@ -8,4 +8,4 @@ Angular rotation rate of Mars.
 
 ## Reference
 
-D. N. Yuan, W. L. Sjogren, A. S. Konopliv, and A. B. Kucinskas (2001). Gravity field of Mars: A 75th degree and order model. Journal of Geophysical Research 106: 23377–23401.
+D. N. Yuan, W. L. Sjogren, A. S. Konopliv, and A. B. Kucinskas (2001). Gravity field of Mars: A 75th degree and order model. Journal of Geophysical Research 106: 23377-23401.

--- a/src/pydoc/constant_omega_mercury_orbit.md
+++ b/src/pydoc/constant_omega_mercury_orbit.md
@@ -8,7 +8,7 @@ Angular rotation rate of Mercury about the Sun.
 
 ## Reference
 
-N. Rambaux and E. Bois (2004). Theory of the Mercury's spin–orbit motion and analysis of its main librations. Astronomy and Astrophysics, 413, 381-393, doi:10.1051/0004-6361:20031446.
+N. Rambaux and E. Bois (2004). Theory of the Mercury's spinorbit motion and analysis of its main librations. Astronomy and Astrophysics, 413, 381-393, doi:10.1051/0004-6361:20031446.
 
 
 

--- a/src/pydoc/constant_omega_mercury_orbit.md
+++ b/src/pydoc/constant_omega_mercury_orbit.md
@@ -8,7 +8,7 @@ Angular rotation rate of Mercury about the Sun.
 
 ## Reference
 
-N. Rambaux and E. Bois (2004). Theory of the Mercury's spinorbit motion and analysis of its main librations. Astronomy and Astrophysics, 413, 381-393, doi:10.1051/0004-6361:20031446.
+N. Rambaux and E. Bois (2004). Theory of the Mercury's spin-orbit motion and analysis of its main librations. Astronomy and Astrophysics, 413, 381-393, doi:10.1051/0004-6361:20031446.
 
 
 

--- a/src/pydoc/constant_omega_mercury_orbit.md
+++ b/src/pydoc/constant_omega_mercury_orbit.md
@@ -8,7 +8,7 @@ Angular rotation rate of Mercury about the Sun.
 
 ## Reference
 
-N. Rambaux and E. Bois (2004). Theory of the Mercury's spin–orbit motion and analysis of its main librations. Astronomy and Astrophysics, 413, 381–393, doi:10.1051/0004-6361:20031446.
+N. Rambaux and E. Bois (2004). Theory of the Mercury's spin–orbit motion and analysis of its main librations. Astronomy and Astrophysics, 413, 381-393, doi:10.1051/0004-6361:20031446.
 
 
 

--- a/src/pydoc/constant_omega_moon.md
+++ b/src/pydoc/constant_omega_moon.md
@@ -8,4 +8,4 @@ Angular rotation rate of the Moon.
 
 ## Reference
 
-C. F. Yoder (1995). Astrometric and geodetic properties of Earth and the solar system. In: Ahrens TJ (ed.) Global Earth Physics: A Handbook of Physical Constants. AGU Reference Shelf, vol. 1, pp. 1–31. American Geophysical Union.
+C. F. Yoder (1995). Astrometric and geodetic properties of Earth and the solar system. In: Ahrens TJ (ed.) Global Earth Physics: A Handbook of Physical Constants. AGU Reference Shelf, vol. 1, pp. 131. American Geophysical Union.

--- a/src/pydoc/constant_omega_moon.md
+++ b/src/pydoc/constant_omega_moon.md
@@ -8,4 +8,4 @@ Angular rotation rate of the Moon.
 
 ## Reference
 
-C. F. Yoder (1995). Astrometric and geodetic properties of Earth and the solar system. In: Ahrens TJ (ed.) Global Earth Physics: A Handbook of Physical Constants. AGU Reference Shelf, vol. 1, pp. 131. American Geophysical Union.
+C. F. Yoder (1995). Astrometric and geodetic properties of Earth and the solar system. In: Ahrens TJ (ed.) Global Earth Physics: A Handbook of Physical Constants. AGU Reference Shelf, vol. 1, pp. 1-31. American Geophysical Union.

--- a/src/pydoc/constant_omega_venus.md
+++ b/src/pydoc/constant_omega_venus.md
@@ -8,5 +8,5 @@ Angular rotation rate of Venus.
 
 ## Reference
 
-A. S. Konopliv, W. B. Banerdt, and W. L. Sjogren (1999). Venus gravity: 180th degree and order model. Icarus 139: 3–18.
+A. S. Konopliv, W. B. Banerdt, and W. L. Sjogren (1999). Venus gravity: 180th degree and order model. Icarus 139, 3-18.
 

--- a/src/pydoc/constant_r0_pot_mars.md
+++ b/src/pydoc/constant_r0_pot_mars.md
@@ -8,4 +8,4 @@ Reference radius of the martian gravitational-potential models.
 
 ## Reference
 
-Konopliv AS, Asmar SW, Folkner WM, et al. (2011) Mars high resolution gravity fieldsfrom MRO, Mars seasonal gravity, and other dynamical parameters. Icarus, 211, 401–428, doi:10.1016/j.icarus.2010.10.004.
+Konopliv AS, Asmar SW, Folkner WM, et al. (2011) Mars high resolution gravity fieldsfrom MRO, Mars seasonal gravity, and other dynamical parameters. Icarus, 211, 401-428, doi:10.1016/j.icarus.2010.10.004.

--- a/src/pydoc/constant_r0_pot_mercury.md
+++ b/src/pydoc/constant_r0_pot_mercury.md
@@ -8,5 +8,5 @@ Reference radius used for the spherical harmonic gravity solutions for Mercury.
 
 ## Reference
 
-D. E. Smith, M. T. Zuber, R. J. Phillips, et al. (2012). Gravity field and internal structure of Mercury from MESSENGER. Science, 336, 214–217, do:10.1126/science.1218809.
+D. E. Smith, M. T. Zuber, R. J. Phillips, et al. (2012). Gravity field and internal structure of Mercury from MESSENGER. Science, 336, 214-217, do:10.1126/science.1218809.
 

--- a/src/pydoc/constant_r0_pot_moon.md
+++ b/src/pydoc/constant_r0_pot_moon.md
@@ -8,6 +8,6 @@ Reference radius of the lunar gravitational-potential models.
 
 ## References
 
-Konopliv, A. S., et al. (2014), High-resolution lunar gravity fields from the GRAIL Primary and Extended Missions, Geophys. Res. Lett., 41, 1452–1458, doi:10.1002/2013GL059066.
+Konopliv, A. S., et al. (2014), High-resolution lunar gravity fields from the GRAIL Primary and Extended Missions, Geophys. Res. Lett., 41, 1452-1458, doi:10.1002/2013GL059066.
 
-Lemoine, F. G., et al. (2014), GRGM900C: A degree 900 lunar gravity model from GRAIL primary and extended mission data, Geophys. Res. Lett., 41, 3382–3389, doi:10.1002/2014GL060027.
+Lemoine, F. G., et al. (2014), GRGM900C: A degree 900 lunar gravity model from GRAIL primary and extended mission data, Geophys. Res. Lett., 41, 3382-3389, doi:10.1002/2014GL060027.

--- a/src/pydoc/constant_r0_pot_venus.md
+++ b/src/pydoc/constant_r0_pot_venus.md
@@ -8,4 +8,4 @@ Reference radius of the gravitational-potential models of Venus.
 
 ## Reference
 
-A. S. Konopliv, W. B. Banerdt, and W. L. Sjogren (1999). Venus gravity: 180th degree and order model. Icarus 139: 3–18.
+A. S. Konopliv, W. B. Banerdt, and W. L. Sjogren (1999). Venus gravity: 180th degree and order model. Icarus 139, 3-18.

--- a/src/pydoc/constant_r_mercury.md
+++ b/src/pydoc/constant_r_mercury.md
@@ -8,5 +8,5 @@ Average radius of Mercury.
 
 ## Reference
 
-D. E. Smith, M. T. Zuber, R. J. Phillips, et al. (2012). Gravity field and internal structure of Mercury from MESSENGER. Science, 336, 214–217, do:10.1126/science.1218809.
+D. E. Smith, M. T. Zuber, R. J. Phillips, et al. (2012). Gravity field and internal structure of Mercury from MESSENGER. Science, 336, 214-217, do:10.1126/science.1218809.
 

--- a/src/pydoc/constant_w0_mars.md
+++ b/src/pydoc/constant_w0_mars.md
@@ -8,4 +8,4 @@ Reference potential of Mars.
 
 ## Reference
 
-A. A. Ardalan, R. Karimi, E. W. Grafarend (2010). A New Reference Equipotential Surface, and Reference Ellipsoid for the Planet Mars, Earth Moon Planet, 106, 1–13, DOI 10.1007/s11038-009-9342-7.
+A. A. Ardalan, R. Karimi, E. W. Grafarend (2010). A New Reference Equipotential Surface, and Reference Ellipsoid for the Planet Mars, Earth Moon Planet, 106, 1-13, DOI 10.1007/s11038-009-9342-7.

--- a/src/pydoc/pyshrotatecoef.md
+++ b/src/pydoc/pyshrotatecoef.md
@@ -53,7 +53,7 @@ For a rotation of the physical body without rotation of the coordinate system, u
 
 To perform the inverse transform of `x(alpha, beta, gamma)`, use `x(-gamma, -beta, -alpha)`.
 
-Note that this routine uses the "y convention", where the second rotation is with respect to the new y axis. If alpha, beta, and gamma were orginally defined in terms of the "x convention", where the second rotation was with respect to the newx axis, the Euler angles according to the y convention would be `alpha_y=alpha_x-pi/2`, `beta_x=beta_y`, and `gamma_y=gamma_x+pi/2`.
+Note that this routine uses the "y convention", where the second rotation is with respect to the new y axis. If alpha, beta, and gamma were originally defined in terms of the "x convention", where the second rotation was with respect to the new x axis, the Euler angles according to the y convention would be `alpha_y=alpha_x-pi/2`, `beta_x=beta_y`, and `gamma_y=gamma_x+pi/2`.
 
 # See also
 

--- a/src/pydoc/pyshrotaterealcoef.md
+++ b/src/pydoc/pyshrotaterealcoef.md
@@ -53,7 +53,7 @@ For a rotation of the physical body without rotation of the coordinate system, u
 
 To perform the inverse transform of `x(alpha, beta, gamma)`, use `x(-gamma, -beta, -alpha)`.
 
-Note that this routine uses the "y convention", where the second rotation is with respect to the new y axis. If alpha, beta, and gamma were orginally defined in terms of the "x convention", where the second rotation was with respect to the newx axis, the Euler angles according to the y convention would be `alpha_y=alpha_x-pi/2`, `beta_x=beta_y`, and `gamma_y=gamma_x+pi/2`.
+Note that this routine uses the "y convention", where the second rotation is with respect to the new y axis. If alpha, beta, and gamma were originally defined in terms of the "x convention", where the second rotation was with respect to the new x axis, the Euler angles according to the y convention would be `alpha_y=alpha_x-pi/2`, `beta_x=beta_y`, and `gamma_y=gamma_x+pi/2`.
 
 This routine first converts the real coefficients to complex form using `SHrtoc`. Then the coefficients are converted to indexed form using `SHCilmToCindex`, these are sent to `SHRotateCoef`, the result if converted back to `cilm` complex form using `SHCindexToCilm`, and these are finally converted back to real form using `SHctor`.
 


### PR DESCRIPTION
This PR

* removes some non-standard ascii dashes in the documentation files
* forces all doc files to be opened as `utf-8`
* Fixes a few typos in the documentation.

Non ascii characters were causing pyshtools to fail when importing on some windows machines (https://github.com/SHTOOLS/SHTOOLS/issues/121).