### PR TITLE
Reorder shread() variables

### DIFF
--- a/examples/python/GravMag/TestCT.py
+++ b/examples/python/GravMag/TestCT.py
@@ -45,7 +45,7 @@ def TestCrustalThickness():
     half = 0
 
     gravfile = '../../ExampleDataFiles/jgmro_110b_sha.tab'
-    pot, header, lmaxp = shio.shread(gravfile, lmax=degmax, header=True)
+    pot, lmaxp, header = shio.shread(gravfile, lmax=degmax, header=True)
     gm = float(header[1]) * 1.e9
     mass = gm / constant.grav_constant
     r_grav = float(header[0]) * 1.e3

--- a/examples/python/GravMag/TestGrav.py
+++ b/examples/python/GravMag/TestGrav.py
@@ -37,7 +37,7 @@ def main():
 
 def TestMakeGravGrid():
     infile = '../../ExampleDataFiles/jgmro_110b_sha.tab'
-    clm, header, lmax = shio.shread(infile, header=True)
+    clm, lmax, header = shio.shread(infile, header=True)
     r0 = float(header[0]) * 1.e3
     gm = float(header[1]) * 1.e9
     clm[0, 0, 0] = 1.0
@@ -140,7 +140,7 @@ def TestFilter():
 
 def TestMakeMagGrid():
     infile = '../../ExampleDataFiles/FSU_mars90.sh'
-    clm, header, lmax = shio.shread(infile, header=True, skip=1)
+    clm, lmax, header  = shio.shread(infile, header=True, skip=1)
     r0 = float(header[0]) * 1.e3
     a = constant.r_mars + 145.0e3  # radius to evaluate the field
 

--- a/pyshtools/shio/shread.py
+++ b/pyshtools/shio/shread.py
@@ -15,9 +15,9 @@ def shread(filename, lmax=None, error=False, header=False, skip=0):
     Usage
     -----
     coeffs, lmaxout = shread(filename, [lmax, skip])
-    coeffs, header, lmaxout = shread(filename, header=True, [lmax, skip])
+    coeffs, lmaxout, header = shread(filename, header=True, [lmax, skip])
     coeffs, errors, lmaxout = shread(filename, error=True, [lmax, skip])
-    coeffs, errors, header, lmaxout = shread(filename, error=True,
+    coeffs, errors, lmaxout, header = shread(filename, error=True,
                                              header=True, [lmax, skip])
 
     Returns
@@ -26,11 +26,11 @@ def shread(filename, lmax=None, error=False, header=False, skip=0):
         The spherical harmonic coefficients.
     errors : ndarray, size(2, lmaxout+1, lmaxout+1)
         The errors associated with the spherical harmonic coefficients.
+    lmaxout : int
+        The maximum spherical harmonic degree read from the file.
     header : list of type str
         A list of values in the header line found before the start of the
         spherical harmonic coefficients.
-    lmaxout : int
-        The maximum spherical harmonic degree read from the file.
 
     Parameters
     ----------
@@ -228,11 +228,11 @@ def shread(filename, lmax=None, error=False, header=False, skip=0):
                         errors[1, l, m] = complex(line.split()[5])
 
     if error is True and header is True:
-        return coeffs, errors, header_list, lmaxout
+        return coeffs, errors, lmaxout, header_list
     elif error is True and header is False:
         return coeffs, errors, lmaxout
     elif error is False and header is True:
-        return coeffs, header_list, lmaxout
+        return coeffs, lmaxout, header_list
     else:
         return coeffs, lmaxout
 


### PR DESCRIPTION
Reorder the output of `shread()` to be:

`coeffs, [errors], lmax, [header]`