### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![LOGO](misc/logo.png)
 
 [![Documentation](https://img.shields.io/badge/documentation-shtools.github.io%2FSHTOOLS%2F-yellow.svg)](https://shtools.github.io/SHTOOLS/)
-[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.592762.svg)](http://dx.doi.org/10.5281/zenodo.592762)
-[![Paper](https://img.shields.io/badge/paper-10.1029/2018GC007529-orange.svg)](http://doi.org/10.1029/2018GC007529)
+[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.592762.svg)](https://doi.org/10.5281/zenodo.592762)
+[![Paper](https://img.shields.io/badge/paper-10.1029/2018GC007529-orange.svg)](https://doi.org/10.1029/2018GC007529)
 [![Join the chat at https://gitter.im/SHTOOLS/SHTOOLS](https://badges.gitter.im/SHTOOLS/SHTOOLS.svg)](https://gitter.im/SHTOOLS/SHTOOLS?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Twitter](https://img.shields.io/twitter/follow/pyshtools.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=pyshtools)
 
@@ -108,6 +108,6 @@ available Fourier transform package
 [BLAS](http://www.netlib.org/blas/).
 
 ### CITATION ###
-Mark A. Wieczorek and Matthias Meschede (2018). SHTools --- Tools for working with spherical harmonics, *Geochemistry, Geophysics, Geosystems*, doi:[10.1029/2018GC007529](http://doi.org/10.1029/2018GC007529).
+Mark A. Wieczorek and Matthias Meschede (2018). SHTools --- Tools for working with spherical harmonics, *Geochemistry, Geophysics, Geosystems*, doi:[10.1029/2018GC007529](https://doi.org/10.1029/2018GC007529).
 
-M. A. Wieczorek, M. Meschede, E. Sales de Andrade, I. Oshchepkov, B. Xu, and A. Walker (2018). SHTOOLS, *Zenodo*, doi:[10.5281/zenodo.592762](http://doi.org/10.5281/zenodo.592762).
+M. A. Wieczorek, M. Meschede, E. Sales de Andrade, I. Oshchepkov, B. Xu, and A. Walker (2018). SHTOOLS, *Zenodo*, doi:[10.5281/zenodo.592762](https://doi.org/10.5281/zenodo.592762).

--- a/docs/pages/mydoc/gravity-magnetics.md
+++ b/docs/pages/mydoc/gravity-magnetics.md
@@ -44,5 +44,5 @@ table:nth-of-type(n) th:nth-of-type(2) {
 
 ## References
 
-* Wieczorek, M. A. and R. J. Phillips, Potential anomalies on a sphere: applications to the thickness of the lunar crust, J. Geophys. Res., 103, 1715-1724, doi:[10.1029/97JE03136](https://dx.doi.org/10.1029/97JE03136), 1998.
-* Wieczorek, M. A. Gravity and topography of the terrestrial planets, Treatise on Geophysics, 10, 165-206, doi:[10.1016/B978-044452748-6/00156-5](https://dx.doi.org/10.1016/B978-044452748-6/00156-5), 2007.
+* Wieczorek, M. A. and R. J. Phillips, Potential anomalies on a sphere: applications to the thickness of the lunar crust, J. Geophys. Res., 103, 1715-1724, doi:[10.1029/97JE03136](https://doi.org/10.1029/97JE03136), 1998.
+* Wieczorek, M. A. Gravity and topography of the terrestrial planets, Treatise on Geophysics, 10, 165-206, doi:[10.1016/B978-044452748-6/00156-5](https://doi.org/10.1016/B978-044452748-6/00156-5), 2007.

--- a/docs/pages/mydoc/implementation-details.md
+++ b/docs/pages/mydoc/implementation-details.md
@@ -128,10 +128,10 @@ For the real Gauss-Legendre quadrature routines, the transform time is on the or
 
 ## References
 
-* Driscoll, J. R. and D. M. Healy, Computing Fourier transforms and convolutions on the 2-sphere, Adv. Appl. Math., 15, 202-250, doi:[10.1006/aama.1994.1008](https://dx.doi.org/10.1006/aama.1994.1008), 1994.
+* Driscoll, J. R. and D. M. Healy, Computing Fourier transforms and convolutions on the 2-sphere, Adv. Appl. Math., 15, 202-250, doi:[10.1006/aama.1994.1008](https://doi.org/10.1006/aama.1994.1008), 1994.
 
-* Frigo, M., and S. G. Johnson, The design and implementation of FFTW3, Proc. IEEE, 93, 216–231, doi:[10.1109/JPROC.2004.840301](https://dx.doi.org/10.1109/JPROC.2004.840301), 2005.
+* Frigo, M., and S. G. Johnson, The design and implementation of FFTW3, Proc. IEEE, 93, 216–231, doi:[10.1109/JPROC.2004.840301](https://doi.org/10.1109/JPROC.2004.840301), 2005.
 
-* Holmes, S. A., and W. E. Featherstone, A unified approach to the Clenshaw summation and the recursive computation of very high degree and order normalised associated Legendre functions, J. Geodesy, 76, 279- 299, doi:[10.1007/s00190-002-0216-2](https://dx.doi.org/10.1007/s00190-002-0216-2), 2002.
+* Holmes, S. A., and W. E. Featherstone, A unified approach to the Clenshaw summation and the recursive computation of very high degree and order normalised associated Legendre functions, J. Geodesy, 76, 279- 299, doi:[10.1007/s00190-002-0216-2](https://doi.org/10.1007/s00190-002-0216-2), 2002.
 
 * Press, W. H., S. A. Teukolsky, W. T. Vetterling, and B. P. Flannery, "Numerical Recipes in FORTRAN: The Art of Scientific Computing," 2nd ed., Cambridge Univ. Press, Cambridge, UK, 1992.

--- a/docs/pages/mydoc/localized-spectral-analysis.md
+++ b/docs/pages/mydoc/localized-spectral-analysis.md
@@ -61,4 +61,4 @@ table:nth-of-type(n) th:nth-of-type(2) {
 
 ## References
 
-* Grünbaum, F.A., L. Longhi, and M. Perlstadt, Differential operators commuting with finite convolution integral operators: some non-abelian examples, SIAM J. Appl. Math., 42, 941-955, doi:[10.1137/0142067](https://dx.doi.org/10.1137/0142067), 1982.
+* Grünbaum, F.A., L. Longhi, and M. Perlstadt, Differential operators commuting with finite convolution integral operators: some non-abelian examples, SIAM J. Appl. Math., 42, 941-955, doi:[10.1137/0142067](https://doi.org/10.1137/0142067), 1982.

--- a/docs/pages/mydoc/python-gravity-magnetics.md
+++ b/docs/pages/mydoc/python-gravity-magnetics.md
@@ -43,5 +43,5 @@ table:nth-of-type(n) th:nth-of-type(2) {
 
 ## References
 
-* Wieczorek, M. A. and R. J. Phillips, Potential anomalies on a sphere: applications to the thickness of the lunar crust, J. Geophys. Res., 103, 1715-1724, doi:[10.1029/97JE03136](https://dx.doi.org/10.1029/97JE03136), 1998.
-* Wieczorek, M. A. Gravity and topography of the terrestrial planets, Treatise on Geophysics, 10, 165-206, doi:[10.1016/B978-044452748-6/00156-5](https://dx.doi.org/10.1016/B978-044452748-6/00156-5), 2007.
+* Wieczorek, M. A. and R. J. Phillips, Potential anomalies on a sphere: applications to the thickness of the lunar crust, J. Geophys. Res., 103, 1715-1724, doi:[10.1029/97JE03136](https://doi.org/10.1029/97JE03136), 1998.
+* Wieczorek, M. A. Gravity and topography of the terrestrial planets, Treatise on Geophysics, 10, 165-206, doi:[10.1016/B978-044452748-6/00156-5](https://doi.org/10.1016/B978-044452748-6/00156-5), 2007.

--- a/docs/pages/mydoc/python-spectral-analysis.md
+++ b/docs/pages/mydoc/python-spectral-analysis.md
@@ -70,4 +70,4 @@ table:nth-of-type(n) th:nth-of-type(2) {
 
 ## References
 
-* Grünbaum, F. A., L. Longhi, and M. Perlstadt, Differential operators commuting with finite convolution integral operators: some non-abelian examples, SIAM J. Appl. Math., 42, 941-955, doi:[10.1137/0142067](https://dx.doi.org/10.1137/0142067), 1982.
+* Grünbaum, F. A., L. Longhi, and M. Perlstadt, Differential operators commuting with finite convolution integral operators: some non-abelian examples, SIAM J. Appl. Math., 42, 941-955, doi:[10.1137/0142067](https://doi.org/10.1137/0142067), 1982.

--- a/docs/pages/mydoc/release-notes-v3.md
+++ b/docs/pages/mydoc/release-notes-v3.md
@@ -28,7 +28,7 @@ This release adds missing functionality to the SHGrids, SHCoeffs, and SHWindow c
 
 **Citation:**
 
-M. A. Wieczorek, M. Meschede, I. Oshchepkov, E. Sales de Andrade  (2016). SHTOOLS: Version 3.4. Zenodo. doi:[10.5281/zenodo.61180](http://dx.doi.org/10.5281/zenodo.61180)
+M. A. Wieczorek, M. Meschede, I. Oshchepkov, E. Sales de Andrade  (2016). SHTOOLS: Version 3.4. Zenodo. doi:[10.5281/zenodo.61180](https://doi.org/10.5281/zenodo.61180)
 
 ## Version 3.3
 
@@ -54,7 +54,7 @@ This is a major upgrade to SHTOOLS. Full support for Python 3 has been added, a 
 
 **Citation:**
 
-Mark Wieczorek et al. (2016). SHTOOLS: Version 3.3. Zenodo. doi:[10.5281/zenodo.60010](http://dx.doi.org/10.5281/zenodo.60010)
+Mark Wieczorek et al. (2016). SHTOOLS: Version 3.3. Zenodo. doi:[10.5281/zenodo.60010](https://doi.org/10.5281/zenodo.60010)
 
 ## Version 3.2
 
@@ -68,7 +68,7 @@ Mark Wieczorek et al. (2016). SHTOOLS: Version 3.3. Zenodo. doi:[10.5281/zenodo.
 
 **Citation:**
 
-Mark Wieczorek et al.. (2016). SHTOOLS: Version 3.2. Zenodo. doi:[10.5281/zenodo.55790](http://dx.doi.org/10.5281/zenodo.55790)
+Mark Wieczorek et al.. (2016). SHTOOLS: Version 3.2. Zenodo. doi:[10.5281/zenodo.55790](https://doi.org/10.5281/zenodo.55790)
 
 ## Version 3.1
 
@@ -90,7 +90,7 @@ This release of SHTOOLS adds improved documentation for all Fortran 95 and Pytho
 
 **Citation:**
 
-Mark A. Wieczorek, Matthias Meschede and Ilya Oshchepkov (2015). SHTOOLS - Tools for working with spherical harmonics (v3.1), ZENODO, doi:[10.5281/zenodo.20920](http://dx.doi.org/10.5281/zenodo.20920).
+Mark A. Wieczorek, Matthias Meschede and Ilya Oshchepkov (2015). SHTOOLS - Tools for working with spherical harmonics (v3.1), ZENODO, doi:[10.5281/zenodo.20920](https://doi.org/10.5281/zenodo.20920).
 
 ## Version 3.0
 
@@ -106,6 +106,6 @@ This is a major release of SHTOOLS that adds full support for Python. In additio
 
 **Citation:**
 
-Mark A. Wieczorek and Matthias Meschede (2015). SHTOOLS - Tools for working with spherical harmonics (v3.0), ZENODO, doi:[10.5281/zenodo.15967](http://dx.doi.org/10.5281/zenodo.15967).
+Mark A. Wieczorek and Matthias Meschede (2015). SHTOOLS - Tools for working with spherical harmonics (v3.0), ZENODO, doi:[10.5281/zenodo.15967](https://doi.org/10.5281/zenodo.15967).
 
 

--- a/docs/pages/mydoc/release-notes-v4.md
+++ b/docs/pages/mydoc/release-notes-v4.md
@@ -29,7 +29,7 @@ toc: true
 
 **Citation:**
 
-M. A. Wieczorek, M. Meschede, E. Sales de Andrade, I. Oshchepkov, B. Xu, and A. Walker (2017). SHTOOLS: Version 4.2, Zenodo, doi:[10.5281/zenodo.592762](http://doi.org/10.5281/zenodo.592762)
+M. A. Wieczorek, M. Meschede, E. Sales de Andrade, I. Oshchepkov, B. Xu, and A. Walker (2017). SHTOOLS: Version 4.2, Zenodo, doi:[10.5281/zenodo.592762](https://doi.org/10.5281/zenodo.592762)
 
 
 ## Version 4.1
@@ -54,7 +54,7 @@ This version adds improved functionality to SHTOOLS and fixes a couple of minor 
 
 **Citation:**
 
-M. A. Wieczorek, M. Meschede, E. Sales de Andrade, I. Oshchepkov, B. Xu, and A. Walker (2017). SHTOOLS: Version 4.1, Zenodo, doi:[10.5281/zenodo.1067108](http://doi.org/10.5281/zenodo.1067108)
+M. A. Wieczorek, M. Meschede, E. Sales de Andrade, I. Oshchepkov, B. Xu, and A. Walker (2017). SHTOOLS: Version 4.1, Zenodo, doi:[10.5281/zenodo.1067108](https://doi.org/10.5281/zenodo.1067108)
 
 
 ## Version 4.0
@@ -80,4 +80,4 @@ This is a major update that fixes bugs, adds new functionality, and improves Pyt
 
 **Citation:**
 
-M. A. Wieczorek, M. Meschede, I. Oshchepkov, E. Sales de Andrade, and heroxbd  (2016). SHTOOLS: Version 4.0. Zenodo. doi:[10.5281/zenodo.206114](http://doi.org/10.5281/zenodo.206114)
+M. A. Wieczorek, M. Meschede, I. Oshchepkov, E. Sales de Andrade, and heroxbd  (2016). SHTOOLS: Version 4.0. Zenodo. doi:[10.5281/zenodo.206114](https://doi.org/10.5281/zenodo.206114)


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) and Zenodo started using it for its badges as well. Accordingly, this PR updates all DOI links.

Cheers!