### PR TITLE
Add methods to_netcdf() and to_xarray() to the class SHGrid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ install:
         jupyter
         mkl
         astropy
+        xarray
   - conda install -n test-environment -c eumetsat fftw3
   - source activate test-environment
   - pip install --no-deps .

--- a/docs/pages/mydoc/python-shgrid.md
+++ b/docs/pages/mydoc/python-shgrid.md
@@ -56,7 +56,7 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | `to_array()` | Return a numpy array of the gridded data. |
 | `to_xarray()` | Return the gridded data as an xarray DataArray. |
 | `to_file()` | Save raw gridded data to a text or binary file. |
-| `to_netcdf()` | Save gridded data to a netcdf formatted file. |
+| `to_netcdf()` | Return the gridded data as a netcdf formatted file or object. |
 | `lats()` | Return a vector containing the latitudes of each row of the gridded data. |
 | `lons()` | Return a vector containing the longitudes of each column of the gridded data. |
 | `expand()` | Expand the grid into spherical harmonics. |

--- a/docs/pages/mydoc/python-shgrid.md
+++ b/docs/pages/mydoc/python-shgrid.md
@@ -54,6 +54,7 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | Method | Description |
 | ------ | ----------- |
 | `to_file()` | Save raw gridded data to a text or binary file. |
+| `to_netcdf()` | Save gridded data to a netcdf formatted file. |
 | `to_array()` | Return a numpy array of the gridded data. |
 | `lats()` | Return a vector containing the latitudes of each row of the gridded data. |
 | `lons()` | Return a vector containing the longitudes of each column of the gridded data. |

--- a/docs/pages/mydoc/python-shgrid.md
+++ b/docs/pages/mydoc/python-shgrid.md
@@ -53,9 +53,10 @@ table:nth-of-type(n) th:nth-of-type(2) {
 
 | Method | Description |
 | ------ | ----------- |
+| `to_array()` | Return a numpy array of the gridded data. |
+| `to_xarray()` | Return the gridded data as an xarray DataArray. |
 | `to_file()` | Save raw gridded data to a text or binary file. |
 | `to_netcdf()` | Save gridded data to a netcdf formatted file. |
-| `to_array()` | Return a numpy array of the gridded data. |
 | `lats()` | Return a vector containing the latitudes of each row of the gridded data. |
 | `lons()` | Return a vector containing the longitudes of each column of the gridded data. |
 | `expand()` | Expand the grid into spherical harmonics. |

--- a/pyshtools/shclasses/shcoeffsgrid.py
+++ b/pyshtools/shclasses/shcoeffsgrid.py
@@ -14,6 +14,7 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable as _make_axes_locatable
 import copy as _copy
 import warnings as _warnings
 from scipy.special import factorial as _factorial
+import xarray as _xr
 
 from .. import shtools as _shtools
 from ..spectralanalysis import spectrum as _spectrum
@@ -2697,6 +2698,7 @@ class SHGrid(object):
 
     to_array()  : Return the raw gridded data as a numpy array.
     to_file()   : Save gridded data to a text or binary file.
+    to_netcdf() : Save gridded data to a netcdf formatted file.
     lats()      : Return a vector containing the latitudes of each row
                   of the gridded data.
     lons()      : Return a vector containing the longitudes of each column
@@ -3012,6 +3014,50 @@ class SHGrid(object):
         else:
             raise ValueError('binary must be True or False. '
                              'Input value is {:s}'.format(binary))
+
+    def to_netcdf(self, filename, title='', description='',
+                  name='data', dtype='f'):
+        """
+        Save gridded data to a netcdf formatted file.
+
+        Usage
+        -----
+        x.to_file(filename, [title, description, name, dtype])
+
+        Parameters
+        ----------
+        filename : str
+            Name of output file.
+        title : str, optional, default = ''
+            Title of the dataset.
+        description : str, optional, default = ''
+            Description of the dataset ('Remark' in gmt grd files).
+        name : str, optional, default = 'data'
+            Name of the data array.
+        dtype : str, optional, default = 'f'
+            Data type of the output array. Either 'f' or 'd' for single or
+            double precision floating point, respectively.
+        """
+        if self.kind == 'complex':
+            raise RuntimeError('netcdf files do not support complex data '
+                               'formats.')
+
+        if dtype == 'f':
+            _nparray = self.to_array().astype(_np.float32)
+        elif dtype == 'd':
+            _nparray = self.to_array()
+        else:
+            raise ValueError("dtype must be either 'f' or 'd' for single or "
+                             "double precision floating point.")
+
+        _data = _xr.DataArray(_nparray, dims=('latitude', 'longitude'),
+                              coords={'latitude': self.lats(),
+                                      'longitude': self.lons()},
+                              attrs={'actual_range': [self.min(), self.max()]})
+        _dataset = _xr.Dataset({name: data},
+                               attrs={'title': title,
+                                      'description': description})
+        _dataset.to_netcdf(filename)
 
     # ---- Mathematical operators ----
     def min(self):

--- a/pyshtools/shclasses/shcoeffsgrid.py
+++ b/pyshtools/shclasses/shcoeffsgrid.py
@@ -2699,7 +2699,7 @@ class SHGrid(object):
     to_array()  : Return the raw gridded data as a numpy array.
     to_xarray() : Return the gridded data as an xarray DataArray.
     to_file()   : Save gridded data to a text or binary file.
-    to_netcdf() : Save gridded data to a netcdf formatted file.
+    to_netcdf() : Return the gridded data as a netcdf formatted file or object.
     lats()      : Return a vector containing the latitudes of each row
                   of the gridded data.
     lons()      : Return a vector containing the longitudes of each column
@@ -3016,18 +3016,18 @@ class SHGrid(object):
             raise ValueError('binary must be True or False. '
                              'Input value is {:s}'.format(binary))
 
-    def to_netcdf(self, filename, title='', description='',
+    def to_netcdf(self, filename=None, title='', description='',
                   name='data', dtype='f'):
         """
-        Save gridded data to a netcdf formatted file.
+        Return the gridded data as a netcdf formatted file or object.
 
         Usage
         -----
-        x.to_netcdf(filename, [title, description, name, dtype])
+        x.to_netcdf([filename, title, description, name, dtype])
 
         Parameters
         ----------
-        filename : str
+        filename : str, optional, default = None
             Name of output file.
         title : str, optional, default = ''
             Title of the dataset.
@@ -3058,7 +3058,10 @@ class SHGrid(object):
         _dataset = _xr.Dataset({name: _data},
                                attrs={'title': title,
                                       'description': description})
-        _dataset.to_netcdf(filename)
+        if filename is None:
+            return _dataset.to_netcdf()
+        else:
+            _dataset.to_netcdf(filename)
 
     def to_xarray(self):
         """

--- a/pyshtools/shclasses/shcoeffsgrid.py
+++ b/pyshtools/shclasses/shcoeffsgrid.py
@@ -2697,6 +2697,7 @@ class SHGrid(object):
     Each class instance provides the following methods:
 
     to_array()  : Return the raw gridded data as a numpy array.
+    to_xarray() : Return the gridded data as an xarray DataArray.
     to_file()   : Save gridded data to a text or binary file.
     to_netcdf() : Save gridded data to a netcdf formatted file.
     lats()      : Return a vector containing the latitudes of each row
@@ -3022,7 +3023,7 @@ class SHGrid(object):
 
         Usage
         -----
-        x.to_file(filename, [title, description, name, dtype])
+        x.to_netcdf(filename, [title, description, name, dtype])
 
         Parameters
         ----------
@@ -3054,10 +3055,23 @@ class SHGrid(object):
                               coords={'latitude': self.lats(),
                                       'longitude': self.lons()},
                               attrs={'actual_range': [self.min(), self.max()]})
-        _dataset = _xr.Dataset({name: data},
+        _dataset = _xr.Dataset({name: _data},
                                attrs={'title': title,
                                       'description': description})
         _dataset.to_netcdf(filename)
+
+    def to_xarray(self):
+        """
+        Return the gridded data as an xarray DataArray.
+
+        Usage
+        -----
+        x.to_xarray()
+        """
+        return _xr.DataArray(self.to_array(), dims=('latitude', 'longitude'),
+                             coords={'latitude': self.lats(),
+                                     'longitude': self.lons()},
+                             attrs={'actual_range': [self.min(), self.max()]})
 
     # ---- Mathematical operators ----
     def min(self):

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -320,7 +320,8 @@ class SHGravCoeffs(object):
     def from_file(self, fname, format='shtools', gm=None, r0=None,
                   omega=None, lmax=None, normalization='4pi', skip=0,
                   header=True, errors=False, csphase=1, r0_index=0, gm_index=1,
-                  omega_index=None, header_units='m', **kwargs):
+                  omega_index=None, header_units='m', set_degree0=True,
+                  **kwargs):
         """
         Initialize the class with spherical harmonic coefficients from a file.
 
@@ -330,7 +331,7 @@ class SHGravCoeffs(object):
                                               lmax, normalization, csphase,
                                               skip, header, errors, gm_index,
                                               r0_index, omega_index,
-                                              header_units])
+                                              header_units, set_degree0])
         x = SHGravCoeffs.from_file(filename, format='npy', gm, r0,
                                    [omega, normalization, csphase, **kwargs])
 
@@ -373,6 +374,8 @@ class SHGravCoeffs(object):
             The units used for r0 and gm in the header line of an shtools
             formatted file: 'm' or 'km'. If 'km', the values of r0 and gm will
             be converted to meters.
+        set_degree0 : bool, optional, default = True
+            If the degree-0 coefficient is zero, set this to 1.
         normalization : str, optional, default = '4pi'
             '4pi', 'ortho', 'schmidt', or 'unnorm' for geodesy 4pi normalized,
             orthonormalized, Schmidt semi-normalized, or unnormalized
@@ -490,10 +493,7 @@ class SHGravCoeffs(object):
                            category=RuntimeWarning)
             lmaxout = 85
 
-        if coeffs[0, 0, 0] == 0:
-            warnstr = ("The degree 0 term of the file was not set. "
-                       "This will be set to 1.")
-            _warnings.warn(warnstr, category=RuntimeWarning)
+        if coeffs[0, 0, 0] == 0 and set_degree0:
             coeffs[0, 0, 0] = 1.0
 
         if format.lower() == 'shtools' and header is True:

--- a/pyshtools/shio/convert.py
+++ b/pyshtools/shio/convert.py
@@ -114,22 +114,23 @@ def convert(coeffs_in, normalization_in=None, normalization_out=None,
 
         lmaxin = coeffs_in.shape[1] - 1
 
-        if ((normalization_in == 'unnorm' or normalization_out ==
-                'unnorm') and lmaxin > 85):
-            _warnings.warn("Conversions with unnormalized coefficients are " +
-                           "stable only for degrees less than or equal to " +
-                           "85. lmax of the input coefficients will be " +
-                           "truncated after degree 85. The spherical " +
-                           "harmonic degree of the input coefficients was " +
-                           "{:d}.".format(lmaxin), category=RuntimeWarning)
-            lmaxin = 85
-
         if lmax is None:
             lmaxout = lmaxin
         else:
             lmaxout = lmax
 
         lconv = min(lmaxin, lmaxout)
+
+        if ((normalization_in == 'unnorm' or normalization_out ==
+                'unnorm') and lconv > 85):
+            _warnings.warn("Conversions with unnormalized coefficients are " +
+                           "stable only for degrees less than or equal to " +
+                           "85. lmax of the output coefficients will be " +
+                           "truncated after degree 85. The spherical " +
+                           "harmonic degree of the input coefficients was " +
+                           "{:d}.".format(lmaxin), category=RuntimeWarning)
+            lconv = 85
+
         degrees = _np.arange(lconv + 1)
 
         if _np.iscomplexobj(coeffs_in):

--- a/setup.py
+++ b/setup.py
@@ -174,7 +174,8 @@ INSTALL_REQUIRES = [
     'numpy>=' + str(numpy.__version__),
     'scipy>=0.14.0',
     'matplotlib',
-    'astropy'
+    'astropy',
+    'xarray'
 ]
 
 # configure python extension to be compiled with f2py


### PR DESCRIPTION
This PR adds support for saving gridded data in an `SHGrid` class instance to (1) netcdf and (2) xarray formats.
* `to_netcdf()` - export data to netcdf format. When saved to file, these can be used directly with GMT (generic mapping tools), where they are known as 'grd' files. 
* `to_xarray()` - export data to an xarray DataArray.