### PR TITLE
Rotation bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ spherical harmonic transforms, multitaper spectral analyses on the sphere, expan
 ### INSTALLATION ###
 #### pyshtools for Python ####
 
-Binary install for linux/macOS/windows:
+Binary install for linux and macOS:
 ```bash
 pip install pyshtools
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ SHTOOLS is extremely versatile:
 
 ## Installation
 
-The Python components of SHTOOLS can be installed using the Python package manager `pip`. Binaries are pre-built for linux, macOS, and windows architectures, and you need only to execute the following command in a unix terminal:
+The Python components of SHTOOLS can be installed using the Python package manager `pip`. Binaries are pre-built for linux and macOS architectures, and you need only to execute the following command in a unix terminal:
 
 ```bash
 pip install pyshtools

--- a/pyshtools/shclasses/shcoeffsgrid.py
+++ b/pyshtools/shclasses/shcoeffsgrid.py
@@ -2322,7 +2322,7 @@ class SHRealCoeffs(SHCoeffs):
         # Convert 4pi normalized coefficients to the same normalization
         # as the unrotated coefficients.
         if self.normalization != '4pi' or self.csphase != 1:
-            temp = _convert(coeffs, normalization_in='4pi', csphase=1,
+            temp = _convert(coeffs, normalization_in='4pi', csphase_in=1,
                             normalization_out=self.normalization,
                             csphase_out=self.csphase)
             return SHCoeffs.from_array(

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -2347,7 +2347,7 @@ class SHGravRealCoeffs(SHGravCoeffs):
         # Convert 4pi normalized coefficients to the same normalization
         # as the unrotated coefficients.
         if self.normalization != '4pi' or self.csphase != 1:
-            temp = _convert(coeffs, normalization_in='4pi', csphase=1,
+            temp = _convert(coeffs, normalization_in='4pi', csphase_in=1,
                             normalization_out=self.normalization,
                             csphase_out=self.csphase)
             return SHGravCoeffs.from_array(

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -1979,7 +1979,7 @@ class SHMagRealCoeffs(SHMagCoeffs):
         # Convert 4pi normalized coefficients to the same normalization
         # as the unrotated coefficients.
         if self.normalization != '4pi' or self.csphase != 1:
-            temp = _convert(coeffs, normalization_in='4pi', csphase=1,
+            temp = _convert(coeffs, normalization_in='4pi', csphase_in=1,
                             normalization_out=self.normalization,
                             csphase_out=self.csphase)
             return SHMagCoeffs.from_array(temp, r0=r0,


### PR DESCRIPTION
Fix a small bug when rotating coefficients in the `SHCoeffs`, `SHMagCoeffs` and `SHGravCoeffs` classes when the input csphase is different from the default value.