### PR TITLE
Remove Python 2.7 compatibility from pyshtools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,9 @@ language: c
 
 matrix:
   include:
-    # Test Python 2.7 and 3.7 on Linux and OSX
-    - os: linux
-      env: PYTHON_VERSION=2.7
+    # Test Python 3.7 on Linux and OSX
     - os: linux
       env: PYTHON_VERSION=3.7
-
-    - os: osx
-      env: PYTHON_VERSION=2.7
     - os: osx
       env: PYTHON_VERSION=3.7
 
@@ -29,11 +24,8 @@ install:
     else
       export OS="Linux";
     fi
-  - if [[ "${PYTHON_VERSION:0:1}" == '2' ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-${OS}-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-${OS}-x86_64.sh -O miniconda.sh;
-    fi
+
+    wget https://repo.continuum.io/miniconda/Miniconda3-latest-${OS}-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r

--- a/Makefile
+++ b/Makefile
@@ -15,18 +15,13 @@
 #       make fortran-tests-no-timing-mp : Compile and run the Fortran OpenMP
 #                                         test/example suite (excluding timing
 #                                         tests).
-#       make python-tests     : Run the Python test/example suite (versions
-#                               determined by PYTHON_VERSION).
-#       make python2-tests  :   Run the Python 2 test/example suite.
-#       make python3-tests  :   Run the Python 3 test/example suite.
-#       make python2-tests-no-timing  : Run the Python 2 test/example suite,
-#                                       (excluding timing tests).
-#       make python3-tests-no-timing  : Run the Python 3 test/example suite,
-#                                       (excluding timing tests).
-#       make install        : Place the compiled libraries and docs in
-#                             $(DESTDIR)$(PREFIX) [default is /usr/local].
-#       make uninstall      : Remove files copied to $(DESTDIR)$(PREFIX).
-#       make clean          : Return the folder to its original state.
+#       make python-tests     : Run the Python test/example suite.
+#       make python-tests-no-timing  : Run the Python test/example suite,
+#                                      (excluding timing tests).
+#       make install-fortran  : Place the compiled libraries and docs in
+#                               $(DESTDIR)$(PREFIX) [default is /usr/local].
+#       make uninstall        : Remove files copied to $(DESTDIR)$(PREFIX).
+#       make clean            : Return the folder to its original state.
 #
 #
 #   In some cases, where there are underscore problems when linking to the
@@ -41,10 +36,7 @@
 #       F95         : Name and path of the Fortran-95 compiler.
 #       F95FLAGS    : Fortran-95 compiler flags.
 #       OPENMPFLAGS : Fortran-95 OpenMP compiler flags.
-#       PYTHON      : Name (including path) of the Python 2 executable.
-#       PYTHON3     : Name (including path) of the Python 3 executable.
-#       PYTHON_VERSION : Which Python versions of shtools to use: either
-#                        2, 3, or all.
+#       PYTHON      : Name (including path) of the Python executable.
 #       FFTW        : Name and path of the FFTW3 library of the form
 #                     "-Lpath -lfftw3".
 #       LAPACK      : Name and path of the LAPACK library of the form
@@ -60,14 +52,10 @@
 #   LIST OF ALL SUPPORTED MAKE TARGETS
 #
 #   make, make all, make fortran
-#       Compile the Fortran 95 components the current directory.
+#       Compile the Fortran 95 components.
 #
 #   make fortran-mp
-#       Compile only the fortran 95 component of the archive with OpenMP
-#       support.
-#
-#   make install-fortran
-#       Install only the fortran 95 component of SHTOOLS.
+#       Compile the fortran 95 component of the archive with OpenMP support.
 #
 #   make clean
 #       Remove the compiled lib, module, object, and Python files. Also removes
@@ -87,27 +75,16 @@
 #       Delete compiled Fortran test suite programs.
 #
 #   make python-tests
-#       Run all Python tests, where the variable PYTHON_VERSION determines
-#       which versions to run.
-#
-#   make python2-tests
-#       Run all Python 2 tests.
-#
-#   make python3-tests
-#       Run all Python 3 tests.
+#       Run all Python tests.
 #
 #   make python-tests-no-timing
-#       Run all Python tests (with exception of timing/accuracy tests), where
-#       the variable PYTHON_VERSION determines which versions to run.
-#
-#   make python2-tests-no-timing
-#       Run all Python tests (with exception of timing/accuracy tests).
-#
-#   make python3-tests-no-timing
 #       Run all Python tests (with exception of timing/accuracy tests).
 #
 #   make clean-python-tests
 #       Detele all compiled Python test files.
+#
+#   make clean-python
+#       Detele all compiled Python files.
 #
 #   make notebooks
 #       Run notebooks and convert to html for web documentation.
@@ -116,11 +93,12 @@
 #       Remove html notebooks.
 #
 #   make doc
-#       Create the man pages from input markdown files and create the static
-#       web site. Both of these are PRE-MADE in the distribution. To remake
-#       these files, it will be necessary to install "pandoc", "ghc" and
-#       "cabal-install" (all using brew on macOS), and then execute
-#       "cabal update" and "cabal install pandoc-types".
+#       Create the man pages from input markdown files and reformat
+#       md files for use with the static web site. These files are PRE-MADE in
+#       the distribution. To remake these files for a new release, it will be
+#       necessary to install "pandoc", "ghc" and "cabal-install" (all using
+#       brew on macOS), and then execute "cabal update" and
+#       "cabal install pandoc-types".
 #
 #   make remove-doc
 #       Remove the man and html-man pages.
@@ -138,16 +116,13 @@
 #
 ###############################################################################
 
-VERSION = 4.5
+VERSION = 4.6
 LIBNAME = SHTOOLS
 LIBNAMEMP = SHTOOLS-mp
 
 F95 = gfortran
-PYTHON = python
-PYTHON3 = python3
-PYTHON_VERSION = all
-JUPYTER = "jupyter nbconvert --ExecutePreprocessor.kernel_name=python2"
-JUPYTER3 = "jupyter nbconvert --ExecutePreprocessor.kernel_name=python3"
+PYTHON = python3
+JUPYTER = "jupyter nbconvert --ExecutePreprocessor.kernel_name=python3"
 JEKYLL = bundle exec jekyll
 
 PREFIX = /usr/local
@@ -172,7 +147,7 @@ LIBPATH = $(PWD)/$(LIBDIR)
 MODPATH = $(PWD)/$(INCDIR)
 PYPATH = $(PWD)
 SYSMODPATH = $(PREFIX)/include
-PY3EXT = $(shell $(PYTHON3) -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))' || echo nopy3)
+PY3EXT = $(shell $(PYTHON) -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))' || echo nopy3)
 SYSSHAREPATH = $(PREFIX)/share
 
 ifeq ($(F95), f95)
@@ -231,12 +206,12 @@ LAPACK_FLAGS = -DLAPACK_UNDERSCORE
 endif
 
 
-.PHONY: all fortran install doc remove-doc\
-	fortran-tests run-fortran-tests python-tests\
-	python2-tests python3-tests python-tests-no-timing python2-tests-no-timing\
-	python3-tests-no-timing install-fortran uninstall fortran-mp clean\
-	clean-fortran-tests clean-python-tests clean-python2 clean-python3\
-	clean-libs remove-notebooks notebooks notebooks2 notebooks3 www remove-www
+.PHONY: all fortran fortran-mp install-fortran fortran-tests fortran-tests-mp \
+	fortran-tests-no-timing fortran-tests-no-timing-mp run-fortran-tests \
+	run-fortran-tests-no-timing doc remove-doc python-tests \
+	python-tests-no-timing uninstall clean clean-fortran-tests \
+	clean-python-tests clean-python clean-libs remove-notebooks notebooks \
+	www remove-www
 
 
 all: fortran
@@ -266,34 +241,6 @@ fortran-mp:
 	@echo $(F95) $(MODFLAG) $(OPENMPFLAGS) $(F95FLAGS) -L$(LIBPATH) -l$(LIBNAMEMP) $(FFTW) -lm $(LAPACK) $(BLAS)
 	@echo
 
-ifeq ($(PYTHON_VERSION),all)
-python-tests: python2-tests python3-tests
-python-tests-no-timing: python2-tests-no-timing python3-tests-no-timing
-notebooks: notebooks3 notebooks2
-else ifeq ($(PYTHON_VERSION),2)
-python-tests: python2-tests
-python-tests-no-timing: python2-tests-no-timing
-notebooks: notebooks2
-else ifeq ($(PYTHON_VERSION),3)
-python-tests: python3-tests
-python-tests-no-timing: python3-tests-no-timing
-notebooks: notebooks3
-else
-$(error $(PYTHON_VERSION) is unsupported.)
-endif
-
-install: install-fortran
-
-uninstall:
-	-rm -r $(SYSLIBPATH)/lib$(LIBNAME).a
-	-rm -r $(SYSLIBPATH)/lib$(LIBNAMEMP).a
-	-rm -r $(SYSMODPATH)/fftw3.mod
-	-rm -r $(SYSMODPATH)/planetsconstants.mod
-	-rm -r $(SYSMODPATH)/shtools.mod
-	-rm -r $(SYSSHAREPATH)/shtools/examples/
-	$(MAKE) -C $(FDOCDIR) -f Makefile VERSION=$(VERSION) uninstall
-	$(MAKE) -C $(PYDOCDIR) -f Makefile VERSION=$(VERSION) uninstall
-
 install-fortran: fortran
 	-rm -r $(DESTDIR)$(SYSMODPATH)/fftw3.mod
 	-rm -r $(DESTDIR)$(SYSMODPATH)/planetsconstants.mod
@@ -318,6 +265,16 @@ install-fortran: fortran
 	@echo $(F95) $(SYSMODFLAG) $(F95FLAGS) -L$(SYSLIBPATH) -l$(LIBNAME) $(FFTW) -lm $(LAPACK) $(BLAS)
 	@echo
 
+uninstall:
+	-rm -r $(SYSLIBPATH)/lib$(LIBNAME).a
+	-rm -r $(SYSLIBPATH)/lib$(LIBNAMEMP).a
+	-rm -r $(SYSMODPATH)/fftw3.mod
+	-rm -r $(SYSMODPATH)/planetsconstants.mod
+	-rm -r $(SYSMODPATH)/shtools.mod
+	-rm -r $(SYSSHAREPATH)/shtools/examples/
+	$(MAKE) -C $(FDOCDIR) -f Makefile VERSION=$(VERSION) uninstall
+	$(MAKE) -C $(PYDOCDIR) -f Makefile VERSION=$(VERSION) uninstall
+
 doc:
 	@$(MAKE) -C $(FDOCDIR) -f Makefile VERSION=$(VERSION)
 	@$(MAKE) -C $(PYDOCDIR) -f Makefile VERSION=$(VERSION)
@@ -335,15 +292,15 @@ www:
 remove-www:
 	@-rm -rf $(WWWDEST)
 
-notebooks2:
+notebooks:
 	@$(MAKE) -C $(NBDIR) -f Makefile JUPYTER=$(JUPYTER)
-	@echo "--> Notebook html files created successfully with Python 2"
+	@echo "--> Notebook html files created successfully"
 
-notebooks3:
-	@$(MAKE) -C $(NBDIR) -f Makefile JUPYTER=$(JUPYTER3)
-	@echo "--> Notebook html files created successfully with Python 3"
+remove-notebooks:
+	@$(MAKE) -C $(NBDIR) -f Makefile clean
+	@echo "--> Removed notebook html files"
 
-clean: clean-fortran-tests clean-python-tests clean-python2 clean-python3 clean-libs remove-www
+clean: clean-fortran-tests clean-python-tests clean-python clean-libs remove-www
 
 clean-fortran-tests:
 	@$(MAKE) -C $(FEXDIR) -f Makefile clean
@@ -353,17 +310,7 @@ clean-python-tests:
 	@$(MAKE) -C $(PEXDIR) -f Makefile clean
 	@echo "--> Removed Python test suite executables and files"
 
-clean-python2:
-	@-rm -rf _SHTOOLS.so.dSYM/
-	@-rm -rf pyshtools/_SHTOOLS.so.dSYM/
-	@-rm -f *.so
-	@-rm -f pyshtools/*.so
-	@-rm -f pyshtools/*.pyc
-	@-rm -rf pyshtools/__pycache__/
-	@-rm -rf pyshtools/doc
-	@echo "--> Removed Python 2 files"
-
-clean-python3:
+clean-python:
 	@-rm -rf _SHTOOLS$(PY3EXT).dSYM/
 	@-rm -rf pyshtools/_SHTOOLS$(PY3EXT).dSYM/
 	@-rm -rf _SHTOOLS.so.dSYM/
@@ -373,7 +320,7 @@ clean-python3:
 	@-rm -f pyshtools/*.pyc
 	@-rm -rf pyshtools/__pycache__/
 	@-rm -rf pyshtools/doc
-	@echo "--> Removed Python 3 files"
+	@echo "--> Removed Python files"
 
 clean-libs:
 	@-$(MAKE) -C $(SRCDIR) -f Makefile clean
@@ -388,10 +335,6 @@ clean-libs:
 	@echo
 	@echo \*\*\* If you installed pyshtools using \"pip install -e .\" you should
 	@echo \*\*\* also execute \"pip uninstall pyshtools\".
-
-remove-notebooks:
-	@$(MAKE) -C $(NBDIR) -f Makefile clean
-	@echo "--> Removed notebook html files"
 
 fortran-tests: fortran
 	@$(MAKE) -C $(FEXDIR) -f Makefile all F95="$(F95)" F95FLAGS="$(F95FLAGS)" LIBNAME="$(LIBNAME)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)"
@@ -439,22 +382,12 @@ run-fortran-tests-no-timing: fortran
 	@echo
 	@echo "--> Ran all Fortran examples and tests"
 
-python2-tests:
+python-tests:
 	@$(MAKE) -C $(PEXDIR) -f Makefile all PYTHON=$(PYTHON)
 	@echo
-	@echo "--> Ran all Python 2 tests"
+	@echo "--> Ran all Python tests"
 
-python3-tests:
-	@$(MAKE) -C $(PEXDIR) -f Makefile all PYTHON=$(PYTHON3)
-	@echo
-	@echo "--> Ran all Python 3 tests"
-
-python2-tests-no-timing:
+python-tests-no-timing:
 	@$(MAKE) -C $(PEXDIR) -f Makefile no-timing PYTHON=$(PYTHON)
 	@echo
-	@echo "--> Ran all Python 2 tests"
-
-python3-tests-no-timing:
-	@$(MAKE) -C $(PEXDIR) -f Makefile no-timing PYTHON=$(PYTHON3)
-	@echo
-	@echo "--> Ran all Python 3 tests"
+	@echo "--> Ran all Python tests"

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-SHTOOLS Version: 4.5
-Release date: September 23, 2019
+SHTOOLS Version: 4.6
+Release date: 

--- a/docs/_data/sidebars/mydoc_sidebar.yml
+++ b/docs/_data/sidebars/mydoc_sidebar.yml
@@ -3,7 +3,7 @@
 entries:
 - title: sidebar
   product: SHTOOLS
-  version: 4.5
+  version: 4.6
   folders:
 
   - title:

--- a/docs/pages/mydoc/faq.md
+++ b/docs/pages/mydoc/faq.md
@@ -35,16 +35,20 @@ Please see [this page](how-to-contribute.html).
 
 Probably, but we have not yet implemented this. If you get this to work, let us know how you did it and we will add the instructions and source files to the distribution.
 
-## How do I cite SHTOOLS in a publication?
+## Which FFT libraries work with SHTOOLS?
 
-SHTOOLS can be cited in two ways. First, one could cite the shtools paper that was published in Geochemistry, Geophysics, Geosystems (the reference is on the main web page). Secondly, one could cite a specific version of the code using the [Zenodo](https://zenodo.org/) DOI (digital object identifier) that is provided in the release notes.
+SHTOOLS was developed initially to use the [FFTW](http://www.fftw.org) library. Since then, Intel's [MKL](https://software.intel.com/en-us/mkl) has added wrapper functions to their FFT routines that use the same syntax as FFTW. SHTOOLS can be linked either to FFTW or MKL with no impact on performance.
 
-## Where can I find more information about spherical harmonics?
+## Does SHTOOLS work with Python 2.7?
 
-Two online resources are:
-
-* [Mathworld - Spherical Harmonic](http://mathworld.wolfram.com/SphericalHarmonic.html)
-* [Wikipedia - Spherical harmonics](https://en.wikipedia.org/wiki/Spherical_harmonics)
+The last version of pyshtools that supported Python 2.7 was version 4.5. Precompiled binaries of this release can be installed using the command
+```bash
+pip install pyshtools==4.5
+```
+Occassionally, critical updates may be made to the Python 2.7 code in the `python2.7` branch of the GitHub project. Though Python 2.7 compatible binaries will not be distributed for any of these updates, these can be installed from souce using the command
+```bash
+pip install git+https://github.com/SHTOOLS/SHTOOLS.git@python2.7
+```
 
 ## Will you help me with my homework?
 
@@ -60,10 +64,11 @@ If you are using the Fortran version of SHTOOLS, the output is typically in the 
 
 If you are using the Python version of SHTOOLS, the classes for working with spherical harmonic coefficients and grids contain methods for making publication quality graphics that make use of the `matplotlib` package.
 
-## Which FFT libraries work with SHTOOLS?
-
-SHTOOLS was developed initially to use the [FFTW](http://www.fftw.org) library. Since then, Intel's [MKL](https://software.intel.com/en-us/mkl) has added wrapper functions to their FFT routines that use the same syntax as FFTW. SHTOOLS can be linked either to FFTW or MKL with no impact on performance.
-
 ## Who maintains SHTOOLS?
 
 This software package was created initially in 2004 by [Mark Wieczorek](https://www.oca.eu/fr/mark-wieczorek) who is the lead developer. Matthias Meschede was responsible for the initial Python implementation of version 3. A list of all contributors can be found [here](contributors.html).
+
+## How do I cite SHTOOLS in a publication?
+
+SHTOOLS can be cited in two ways. First, one could cite the shtools paper that was published in Geochemistry, Geophysics, Geosystems (the reference is on the main web page). Secondly, one could cite a specific version of the code using the [Zenodo](https://zenodo.org/) DOI (digital object identifier) that is provided in the release notes.
+

--- a/examples/notebooks/Introduction-1.ipynb
+++ b/examples/notebooks/Introduction-1.ipynb
@@ -17,7 +17,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function # only necessary if using Python 2.x\n",
     "%matplotlib inline\n",
     "\n",
     "import matplotlib.pyplot as plt\n",

--- a/examples/notebooks/Introduction-2.ipynb
+++ b/examples/notebooks/Introduction-2.ipynb
@@ -15,7 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function # only necessary if using Python 2.x\n",
     "%matplotlib inline\n",
     "\n",
     "import matplotlib.pyplot as plt\n",

--- a/examples/notebooks/Introduction-3.ipynb
+++ b/examples/notebooks/Introduction-3.ipynb
@@ -22,7 +22,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function # only necessary if using Python 2.x\n",
     "%matplotlib inline\n",
     "\n",
     "import matplotlib.pyplot as plt\n",

--- a/examples/notebooks/test_notebooks.py
+++ b/examples/notebooks/test_notebooks.py
@@ -1,8 +1,6 @@
 """
 This script will run all jupyter notebooks in order to test for errors.
 """
-from __future__ import print_function
-
 import sys
 import os
 
@@ -21,9 +19,7 @@ notebooks = ('Introduction-1.ipynb',
              'tutorial_5.ipynb',
              'tutorial_6.ipynb')
 
-if sys.version_info.major == 2:
-    kname = 'python2'
-elif sys.version_info.major == 3:
+if sys.version_info.major == 3:
     kname = 'python3'
 else:
     raise ('Python version {:d} not supported.'.format(sys.version_info.major))

--- a/examples/notebooks/test_notebooks.py
+++ b/examples/notebooks/test_notebooks.py
@@ -24,8 +24,6 @@ if sys.version_info.major == 3:
 else:
     raise ('Python version {:d} not supported.'.format(sys.version_info.major))
 
-print('Python kernel name = {:s}'.format(kname))
-
 for i in range(len(notebooks)):
     with open(notebooks[i]) as f:
         nb = nbformat.read(f, as_version=4)

--- a/examples/notebooks/tutorial_1.ipynb
+++ b/examples/notebooks/tutorial_1.ipynb
@@ -15,7 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function # only necessary if using Python 2.x\n",
     "%matplotlib inline\n",
     "\n",
     "import matplotlib.pyplot as plt\n",

--- a/examples/notebooks/tutorial_2.ipynb
+++ b/examples/notebooks/tutorial_2.ipynb
@@ -17,7 +17,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function # only necessary if using Python 2.x\n",
     "%matplotlib inline\n",
     "\n",
     "import matplotlib.pyplot as plt\n",

--- a/examples/notebooks/tutorial_3.ipynb
+++ b/examples/notebooks/tutorial_3.ipynb
@@ -21,7 +21,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function # only necessary if using Python 2.x\n",
     "%matplotlib inline\n",
     "\n",
     "import matplotlib.pyplot as plt\n",

--- a/examples/notebooks/tutorial_4.ipynb
+++ b/examples/notebooks/tutorial_4.ipynb
@@ -24,7 +24,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function # only necessary if using Python 2.x\n",
     "%matplotlib inline\n",
     "\n",
     "import matplotlib.pyplot as plt\n",

--- a/examples/notebooks/tutorial_5.ipynb
+++ b/examples/notebooks/tutorial_5.ipynb
@@ -19,7 +19,6 @@
    },
    "outputs": [],
    "source": [
-    "from __future__ import print_function # only necessary if using Python 2.x\n",
     "%matplotlib inline\n",
     "\n",
     "import matplotlib.pyplot as plt\n",

--- a/examples/notebooks/tutorial_6.ipynb
+++ b/examples/notebooks/tutorial_6.ipynb
@@ -15,7 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function # only necessary if using Python 2.x\n",
     "%matplotlib inline\n",
     "\n",
     "import numpy as np\n",

--- a/examples/python/ClassInterface/ClassExample.py
+++ b/examples/python/ClassInterface/ClassExample.py
@@ -1,10 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This script tests the python class interface
 """
-
-from __future__ import absolute_import, division, print_function
-
 import os
 import sys
 

--- a/examples/python/ClassInterface/WindowExample.py
+++ b/examples/python/ClassInterface/WindowExample.py
@@ -1,11 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This script tests the python class interface
 """
-
-from __future__ import absolute_import, division, print_function
-
-# standard imports:
 import os
 import sys
 

--- a/examples/python/ClassInterface/exact_power.py
+++ b/examples/python/ClassInterface/exact_power.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Test the phaseonly keyword."""
 
 import matplotlib.pyplot as plt

--- a/examples/python/GlobalSpectralAnalysis/GlobalSpectralAnalysis.py
+++ b/examples/python/GlobalSpectralAnalysis/GlobalSpectralAnalysis.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This script tests the different Spherical Harmonics Transforms on the Mars
 topography data set
 """
-from __future__ import absolute_import, division, print_function
-
 import os
 import sys
 import numpy as np

--- a/examples/python/GravMag/TestCT.py
+++ b/examples/python/GravMag/TestCT.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This script creates a crustal thickness map of Mars.
 """
-from __future__ import absolute_import, division, print_function
-
 import os
 import sys
 import numpy as np

--- a/examples/python/GravMag/TestGrav.py
+++ b/examples/python/GravMag/TestGrav.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This script tests the gravity and magnetics routines.
 """
-from __future__ import absolute_import, division, print_function
-
 import os
 import sys
 import numpy as np

--- a/examples/python/IOStorageConversions/SHConversions.py
+++ b/examples/python/IOStorageConversions/SHConversions.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This script tests the conversions between real and complex spherical harmonics
 coefficients
 """
-from __future__ import absolute_import, division, print_function
-
 import os
 import sys
 import numpy as np

--- a/examples/python/IOStorageConversions/SHStorage.py
+++ b/examples/python/IOStorageConversions/SHStorage.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This script tests the conversions between real and complex spherical harmonics
 coefficients
 """
-from __future__ import absolute_import, division, print_function
-
 import os
 import sys
 import numpy as np

--- a/examples/python/LocalizedSpectralAnalysis/SHMTCouplingMatrix.py
+++ b/examples/python/LocalizedSpectralAnalysis/SHMTCouplingMatrix.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This script tests the SHMTCouplingMatrix routine
 """
-from __future__ import absolute_import, division, print_function
-
 import os
 import sys
 import numpy as np

--- a/examples/python/LocalizedSpectralAnalysis/SHMultitaperSE.py
+++ b/examples/python/LocalizedSpectralAnalysis/SHMultitaperSE.py
@@ -1,10 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This script tests the localized spectral analysis routines
 """
-from __future__ import absolute_import, division, print_function
-
-# standard imports:
 import os
 import sys
 import numpy as np

--- a/examples/python/LocalizedSpectralAnalysis/SHWindowsBiasOther.py
+++ b/examples/python/LocalizedSpectralAnalysis/SHWindowsBiasOther.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This script tests other routines related to localized spectral analyses
 """
-from __future__ import absolute_import, division, print_function
-
 import os
 import sys
 import numpy as np

--- a/examples/python/Other/TestOther.py
+++ b/examples/python/Other/TestOther.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This script tests the gravity and magnetics routines.
 """
-from __future__ import absolute_import, division, print_function
-
 import os
 import sys
 import numpy as np

--- a/examples/python/SHRotations/SHRotations.py
+++ b/examples/python/SHRotations/SHRotations.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This script tests the rotation of spherical harmonic coefficients
 """
-from __future__ import absolute_import, division, print_function
-
 import os
 import sys
 import numpy as np

--- a/examples/python/TestLegendre/TestLegendre.py
+++ b/examples/python/TestLegendre/TestLegendre.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This script tests and plots all Geodesy normalized Legendre functions.
 Parameters can be changed in the main function.
 """
-from __future__ import absolute_import, division, print_function
-
 import os
 import sys
 import numpy as np

--- a/examples/python/TimingAccuracy/TimingAccuracyDH.py
+++ b/examples/python/TimingAccuracy/TimingAccuracyDH.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This script is a python version of TimingAccuracy. We use some numpy functions
 to simplify the creation of random coefficients.
 """
-from __future__ import absolute_import, division, print_function
-
 import os
 import sys
 import time

--- a/examples/python/TimingAccuracy/TimingAccuracyDHC.py
+++ b/examples/python/TimingAccuracy/TimingAccuracyDHC.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This script is a python version of TimingAccuracyDHC. We use numpy functions to
 simplify the creation of random coefficients.
 """
-from __future__ import absolute_import, division, print_function
-
 import os
 import sys
 import time

--- a/examples/python/TimingAccuracy/TimingAccuracyGLQ.py
+++ b/examples/python/TimingAccuracy/TimingAccuracyGLQ.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This script is a python version of TimingAccuracyGLQ. We use numpy functions to
 simplify the creation of random coefficients.
 """
-from __future__ import absolute_import, division, print_function
-
 import os
 import sys
 import time

--- a/examples/python/TimingAccuracy/TimingAccuracyGLQC.py
+++ b/examples/python/TimingAccuracy/TimingAccuracyGLQC.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This script is a python version of TimingAccuracyGLQC. We use numpy
 functions to simplify the creation of random coefficients.
 """
-from __future__ import absolute_import, division, print_function
-
 import os
 import sys
 import time

--- a/pyshtools/__init__.py
+++ b/pyshtools/__init__.py
@@ -45,12 +45,7 @@ and the GitHub project page at
 
    https://github.com/SHTOOLS/SHTOOLS
 """
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
-__version__ = '4.5'
+__version__ = '4.6'
 __author__ = 'SHTOOLS developers'
 
 import os as _os

--- a/pyshtools/constant/Earth.py
+++ b/pyshtools/constant/Earth.py
@@ -4,11 +4,6 @@ pyshtools constants for the planet Earth.
 Each object is an astropy Constant that possesses the attributes name, value,
 unit, uncertainty, and reference.
 """
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 import numpy as _np
 
 from astropy.constants import Constant as _Constant

--- a/pyshtools/constant/Mars.py
+++ b/pyshtools/constant/Mars.py
@@ -4,11 +4,6 @@ pyshtools constants for the planet Mars.
 Each object is an astropy Constant that possesses the attributes name, value,
 unit, uncertainty, and reference.
 """
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 import numpy as _np
 
 from astropy.constants import Constant as _Constant

--- a/pyshtools/constant/Mercury.py
+++ b/pyshtools/constant/Mercury.py
@@ -4,11 +4,6 @@ pyshtools constants for the planet Mercury.
 Each object is an astropy Constant that possesses the attributes name, value,
 unit, uncertainty, and reference.
 """
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 import numpy as _np
 
 from astropy.constants import Constant as _Constant

--- a/pyshtools/constant/Moon.py
+++ b/pyshtools/constant/Moon.py
@@ -4,11 +4,6 @@ pyshtools constants for Earth's Moon.
 Each object is an astropy Constant that possesses the attributes name, value,
 unit, uncertainty, and reference.
 """
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 import numpy as _np
 
 from astropy.constants import Constant as _Constant

--- a/pyshtools/constant/Venus.py
+++ b/pyshtools/constant/Venus.py
@@ -4,11 +4,6 @@ pyshtools constants for the planet Venus.
 Each object is an astropy Constant that possesses the attributes name, value,
 unit, uncertainty, and reference.
 """
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 import numpy as _np
 
 from astropy.constants import Constant as _Constant

--- a/pyshtools/constant/__init__.py
+++ b/pyshtools/constant/__init__.py
@@ -26,11 +26,6 @@ Inspect a constant using the print function:
       Unit  = m3 / (kg s2)
       Reference = CODATA 2014
 """
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 import numpy as _np
 
 try:

--- a/pyshtools/expand/__init__.py
+++ b/pyshtools/expand/__init__.py
@@ -50,12 +50,6 @@ spharm         Compute all the spherical harmonic functions up to a maximum
 spharm_lm      Compute the spherical harmonic function for a specific degree l
                and order m.
 """
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
-
 from ..shtools import SHExpandDH
 from ..shtools import MakeGridDH
 from ..shtools import SHExpandDHC

--- a/pyshtools/gravmag/__init__.py
+++ b/pyshtools/gravmag/__init__.py
@@ -53,11 +53,6 @@ MakeMagGradGridDH   Calculate the components of the magnetic field tensor
 mag_spectrum        Compute the spectrum of either the magnetic potential
                     or magnetic field strength.
 """
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 from ..shtools import MakeGravGridDH
 from ..shtools import MakeGravGradGridDH
 from ..shtools import MakeGeoidGridDH

--- a/pyshtools/legendre/__init__.py
+++ b/pyshtools/legendre/__init__.py
@@ -51,11 +51,6 @@ Other
 PlmIndex      Compute the index of an array of Legendre function corresponding
               to degree L and angular order M.
 """
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 from ..shtools import PlmBar
 from ..shtools import PlmBar_d1
 from ..shtools import PlBar

--- a/pyshtools/make_docs.py
+++ b/pyshtools/make_docs.py
@@ -4,10 +4,6 @@ customized markdown files. The processed documentation is saved as ascii text
 files which are loaded on runtime and replace the __doc__ string of the f2py
 wrapped functions.
 """
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 import sys
 import os
 import re

--- a/pyshtools/rotate/__init__.py
+++ b/pyshtools/rotate/__init__.py
@@ -10,11 +10,6 @@ SHRotateCoef      Determine the spherical harmonic coefficients of a complex
 SHRotateRealCoef  Determine the spherical harmonic coefficients of a real
                   function rotated by three Euler angles.
 """
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 from ..shtools import djpi2
 from ..shtools import SHRotateCoef
 from ..shtools import SHRotateRealCoef

--- a/pyshtools/shclasses/__init__.py
+++ b/pyshtools/shclasses/__init__.py
@@ -47,11 +47,6 @@ Class structure:
 
 For more information, see the documentation for the top level classes.
 """
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 from .shcoeffsgrid import SHCoeffs
 from .shcoeffsgrid import SHRealCoeffs
 from .shcoeffsgrid import SHComplexCoeffs

--- a/pyshtools/shclasses/shcoeffsgrid.py
+++ b/pyshtools/shclasses/shcoeffsgrid.py
@@ -917,42 +917,10 @@ class SHCoeffs(object):
         """
         return self.__mul__(other)
 
-    def __div__(self, other):
-        """
-        Divide two similar sets of coefficients or coefficients and a scalar
-        when __future__.division is not in effect: self / other.
-        """
-        if isinstance(other, SHCoeffs):
-            if (self.normalization == other.normalization and self.csphase ==
-                    other.csphase and self.kind == other.kind and
-                    self.lmax == other.lmax):
-                coeffs = _np.empty([2, self.lmax+1, self.lmax+1],
-                                   dtype=self.coeffs.dtype)
-                coeffs[self.mask] = (self.coeffs[self.mask] /
-                                     other.coeffs[self.mask])
-                return SHCoeffs.from_array(coeffs, csphase=self.csphase,
-                                           normalization=self.normalization)
-            else:
-                raise ValueError('The two sets of coefficients must have the '
-                                 'same kind, normalization, csphase and '
-                                 'lmax.')
-        elif _np.isscalar(other) is True:
-            coeffs = _np.empty([2, self.lmax+1, self.lmax+1],
-                               dtype=self.coeffs.dtype)
-            if self.kind == 'real' and _np.iscomplexobj(other):
-                raise ValueError('Can not divide real coefficients by '
-                                 'a complex constant.')
-            coeffs[self.mask] = self.coeffs[self.mask] / other
-            return SHCoeffs.from_array(coeffs, csphase=self.csphase,
-                                       normalization=self.normalization)
-        else:
-            raise NotImplementedError('Mathematical operator not implemented '
-                                      'for these operands.')
-
     def __truediv__(self, other):
         """
-        Divide two similar sets of coefficients or coefficients and a scalar
-        when __future__.division is in effect: self / other.
+        Divide two similar sets of coefficients or coefficients and a scalar:
+        self / other.
         """
         if isinstance(other, SHCoeffs):
             if (self.normalization == other.normalization and self.csphase ==
@@ -3181,33 +3149,9 @@ class SHGrid(object):
         """Multiply two similar grids or a grid and a scaler: other * self."""
         return self.__mul__(other)
 
-    def __div__(self, other):
-        """
-        Divide two similar grids or a grid and a scalar, when
-        __future__.division is not in effect.
-        """
-        if isinstance(other, SHGrid):
-            if (self.grid == other.grid and self.data.shape ==
-                    other.data.shape and self.kind == other.kind):
-                data = self.data / other.data
-                return SHGrid.from_array(data, grid=self.grid)
-            else:
-                raise ValueError('The two grids must be of the ' +
-                                 'same kind and have the same shape.')
-        elif _np.isscalar(other) is True:
-            if self.kind == 'real' and _np.iscomplexobj(other):
-                raise ValueError('Can not divide a real grid by a complex '
-                                 'constant.')
-            data = self.data / other
-            return SHGrid.from_array(data, grid=self.grid)
-        else:
-            raise NotImplementedError('Mathematical operator not implemented '
-                                      'for these operands.')
-
     def __truediv__(self, other):
         """
-        Divide two similar grids or a grid and a scalar, when
-        __future__.division is in effect.
+        Divide two similar grids or a grid and a scalar.
         """
         if isinstance(other, SHGrid):
             if (self.grid == other.grid and self.data.shape ==

--- a/pyshtools/shclasses/shcoeffsgrid.py
+++ b/pyshtools/shclasses/shcoeffsgrid.py
@@ -3,10 +3,6 @@
 
         SHCoeffs : SHRealCoeffs, SHComplexCoeffs
 """
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 import numpy as _np
 import matplotlib as _mpl
 import matplotlib.pyplot as _plt

--- a/pyshtools/shclasses/shgeoid.py
+++ b/pyshtools/shclasses/shgeoid.py
@@ -1,10 +1,6 @@
 """
     Class for the height of the geoid.
 """
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 import numpy as _np
 import matplotlib as _mpl
 import matplotlib.pyplot as _plt

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -1144,47 +1144,10 @@ class SHGravCoeffs(object):
         """
         return self.__mul__(other)
 
-    def __div__(self, other):
-        """
-        Divide an SHGravCoeffs instance by an SHCoeffs instance or scalar
-        when __future__.division is not in effect: self / other.
-        """
-        if isinstance(other, _SHCoeffs):
-            if (self.normalization == other.normalization and
-                    self.csphase == other.csphase and self.kind == other.kind
-                    and self.lmax == other.lmax):
-                coeffs = _np.empty([2, self.lmax+1, self.lmax+1],
-                                   dtype=self.coeffs.dtype)
-                coeffs[self.mask] = (self.coeffs[self.mask] /
-                                     other.coeffs[self.mask])
-                return SHGravCoeffs.from_array(
-                    coeffs, gm=self.gm, r0=self.r0, omega=self.omega,
-                    csphase=self.csphase, normalization=self.normalization)
-            else:
-                raise ValueError('The two sets of coefficients must have the '
-                                 'same kind, normalization, csphase, and '
-                                 'lmax.')
-        elif _np.isscalar(other) is True:
-            if self.kind == 'real' and _np.iscomplexobj(other):
-                raise ValueError('Can not divide real gravitational '
-                                 'potential coefficients by a complex '
-                                 'constant.')
-            coeffs = _np.empty([2, self.lmax+1, self.lmax+1],
-                               dtype=self.coeffs.dtype)
-            coeffs[self.mask] = self.coeffs[self.mask] / other
-            return SHGravCoeffs.from_array(
-                coeffs, gm=self.gm, r0=self.r0, omega=self.omega,
-                csphase=self.csphase, normalization=self.normalization)
-        else:
-            raise TypeError('Division of an SHGravCoeffs instance is '
-                            'permitted only with either an SHCoeffs instance '
-                            'or a scalar. '
-                            'Type of other is {:s}'.format(repr(type(other))))
-
     def __truediv__(self, other):
         """
-        Divide an SHGravCoeffs instance by an SHCoeffs instance or scalar
-        when __future__.division is in effect: self / other.
+        Divide an SHGravCoeffs instance by an SHCoeffs instance or scalar:
+        self / other.
         """
         if isinstance(other, _SHCoeffs):
             if (self.normalization == other.normalization and

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -1,10 +1,6 @@
 """
     Class for spherical harmonic coefficients of the gravitational potential.
 """
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 import numpy as _np
 import matplotlib as _mpl
 import matplotlib.pyplot as _plt

--- a/pyshtools/shclasses/shgravgrid.py
+++ b/pyshtools/shclasses/shgravgrid.py
@@ -2,10 +2,6 @@
     Class for grids of the three components of the gravity field, the
     gravitational disturbance, and the gravitational potential.
 """
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 import numpy as _np
 import matplotlib as _mpl
 import matplotlib.pyplot as _plt

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -1,10 +1,6 @@
 """
     Class for spherical harmonic coefficients of the magnetic potential.
 """
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 import numpy as _np
 import matplotlib as _mpl
 import matplotlib.pyplot as _plt

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -931,47 +931,10 @@ class SHMagCoeffs(object):
         """
         return self.__mul__(other)
 
-    def __div__(self, other):
-        """
-        Divide an SHMagCoeffs instance by an SHCoeffs instance or scalar
-        when __future__.division is not in effect: self / other.
-        """
-        if isinstance(other, _SHCoeffs):
-            if (self.normalization == other.normalization and
-                    self.csphase == other.csphase and self.kind == other.kind
-                    and self.lmax == other.lmax):
-                coeffs = _np.empty([2, self.lmax+1, self.lmax+1],
-                                   dtype=self.coeffs.dtype)
-                coeffs[self.mask] = (self.coeffs[self.mask] /
-                                     other.coeffs[self.mask])
-                return SHMagCoeffs.from_array(
-                    coeffs, r0=self.r0, csphase=self.csphase,
-                    normalization=self.normalization)
-            else:
-                raise ValueError('The two sets of coefficients must have the '
-                                 'same kind, normalization, csphase, and '
-                                 'lmax.')
-        elif _np.isscalar(other) is True:
-            if self.kind == 'real' and _np.iscomplexobj(other):
-                raise ValueError('Can not divide real magnetic '
-                                 'potential coefficients by a complex '
-                                 'constant.')
-            coeffs = _np.empty([2, self.lmax+1, self.lmax+1],
-                               dtype=self.coeffs.dtype)
-            coeffs[self.mask] = self.coeffs[self.mask] / other
-            return SHMagCoeffs.from_array(
-                coeffs, r0=self.r0, csphase=self.csphase,
-                normalization=self.normalization)
-        else:
-            raise TypeError('Division of an SHMagCoeffs instance is '
-                            'permitted only with either an SHCoeffs instance '
-                            'or a scalar. '
-                            'Type of other is {:s}'.format(repr(type(other))))
-
     def __truediv__(self, other):
         """
-        Divide an SHMagCoeffs instance by an SHCoeffs instance or scalar
-        when __future__.division is in effect: self / other.
+        Divide an SHMagCoeffs instance by an SHCoeffs instance or scalar:
+        self / other.
         """
         if isinstance(other, _SHCoeffs):
             if (self.normalization == other.normalization and

--- a/pyshtools/shclasses/shmaggrid.py
+++ b/pyshtools/shclasses/shmaggrid.py
@@ -2,10 +2,6 @@
     Class for grids of the three components of the magnetic field, the
     magnetic intensity, and the magnetic potential.
 """
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 import numpy as _np
 import matplotlib as _mpl
 import matplotlib.pyplot as _plt

--- a/pyshtools/shclasses/shtensor.py
+++ b/pyshtools/shclasses/shtensor.py
@@ -1,10 +1,6 @@
 """
     Class for the gravity and magnetic field 'gradient' tensors.
 """
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 import numpy as _np
 import matplotlib as _mpl
 import matplotlib.pyplot as _plt

--- a/pyshtools/shclasses/shwindow.py
+++ b/pyshtools/shclasses/shwindow.py
@@ -3,11 +3,6 @@
 
         SHWindow: SHWindowCap, SHWindowMask
 """
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 import numpy as _np
 import matplotlib as _mpl
 import matplotlib.pyplot as _plt

--- a/pyshtools/shclasses/slepian.py
+++ b/pyshtools/shclasses/slepian.py
@@ -3,11 +3,6 @@
 
         Slepian: SlepianCap, SlepianMask
 """
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 import numpy as _np
 import matplotlib as _mpl
 import matplotlib.pyplot as _plt

--- a/pyshtools/shclasses/slepiancoeffs.py
+++ b/pyshtools/shclasses/slepiancoeffs.py
@@ -1,11 +1,6 @@
 """
     Class for Slepian expansion coefficients.
 """
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 import numpy as _np
 import matplotlib as _mpl
 import matplotlib.pyplot as _plt

--- a/pyshtools/shio/__init__.py
+++ b/pyshtools/shio/__init__.py
@@ -37,11 +37,6 @@ convert          Convert an array of spherical harmonic coefficients to a
 SHrtoc           Convert real spherical harmonics to complex form.
 SHctor           Convert complex spherical harmonics to real form.
 """
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 from ..shtools import SHRead2
 from ..shtools import SHRead2Error
 from ..shtools import SHReadJPL

--- a/pyshtools/shio/convert.py
+++ b/pyshtools/shio/convert.py
@@ -2,10 +2,6 @@
     Functions for converting spherical harmonic coefficients to a different
     normalization conventions.
 """
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 import numpy as _np
 import warnings as _warnings
 from scipy.special import factorial as _factorial

--- a/pyshtools/shio/icgem.py
+++ b/pyshtools/shio/icgem.py
@@ -1,10 +1,6 @@
 """
 ICGEM-format read support
 """
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-
 import numpy as _np
 
 from pyshtools.utils.datetime import _yyyymmdd_to_year_fraction

--- a/pyshtools/shio/shread.py
+++ b/pyshtools/shio/shread.py
@@ -240,19 +240,14 @@ def shread(filename, lmax=None, error=False, header=False, skip=0):
 def _iscomment(line):
     """
     Determine if a line is a comment line. A valid line contains at least three
-    words, with the first two being integers. Note that Python 2 and 3 deal
-    with strings differently.
+    words, with the first two being integers.
     """
     if line.isspace():
         return True
     elif len(line.split()) >= 3:
-        try:  # python 3 str
-            if line.split()[0].isdecimal() and line.split()[1].isdecimal():
-                return False
-        except:  # python 2 str
-            if (line.decode().split()[0].isdecimal() and
-                    line.split()[1].decode().isdecimal()):
-                return False
-        return True
+        if line.split()[0].isdecimal() and line.split()[1].isdecimal():
+            return False
+        else:
+            return True
     else:
         return True

--- a/pyshtools/shtools/__init__.py
+++ b/pyshtools/shtools/__init__.py
@@ -1,11 +1,6 @@
 """
 pyshtools subpackage that includes all Python wrapped Fortran routines.
 """
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 import os as _os
 import numpy as _np
 

--- a/pyshtools/spectralanalysis/__init__.py
+++ b/pyshtools/spectralanalysis/__init__.py
@@ -89,11 +89,6 @@ Other
 SphericalCapCoef       Calculate the spherical harmonic coefficients of a
                        spherical cap.
 """
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 from ..shtools import SHAdmitCorr
 from ..shtools import SHConfidence
 

--- a/pyshtools/utils/__init__.py
+++ b/pyshtools/utils/__init__.py
@@ -13,11 +13,6 @@ DHaj               Compute the latitudinal weights used in the Driscoll and
 figstyle           Set Matplotlib parameters for creating publication quality
                    graphics.
 """
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
-
 from ..shtools import MakeCircleCoord
 from ..shtools import MakeEllipseCoord
 from ..shtools import Wigner3j

--- a/pyshtools/utils/datetime.py
+++ b/pyshtools/utils/datetime.py
@@ -1,10 +1,6 @@
 """
 Date and time utils for SHTOOLS
 """
-
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-
 import datetime as _datetime
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """Setup script for SHTOOLS."""
 
-from __future__ import absolute_import as _absolute_import
-from __future__ import division as _division
-from __future__ import print_function as _print_function
 import os
 import re
 import sys
@@ -156,7 +153,6 @@ CLASSIFIERS = [
     'Operating System :: OS Independent',
     'Programming Language :: Fortran',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 3',
     'Topic :: Scientific/Engineering',
     'Topic :: Scientific/Engineering :: GIS',

--- a/setup.py
+++ b/setup.py
@@ -243,6 +243,9 @@ def configuration(parent_package='', top_path=None):
     dict_append(kwargs, **blas_info)
     dict_append(kwargs, **lapack_info)
 
+    if sys.platform == 'win32':
+        kwargs['runtime_library_dirs'] = []
+
     config.add_extension('pyshtools._SHTOOLS',
                          sources=['src/pyshtools.pyf',
                                   'src/PythonWrapper.f95'],

--- a/setup.py
+++ b/setup.py
@@ -190,25 +190,6 @@ INSTALL_REQUIRES = [
 # configure python extension to be compiled with f2py
 
 
-def get_compiler_flags():
-    """Set fortran flags depending on the compiler."""
-    compiler = get_default_fcompiler()
-    if compiler == 'absoft':
-        flags = ['-m64', '-O3', '-YEXT_NAMES=LCS', '-YEXT_SFX=_',
-                 '-fpic', '-speed_math=10']
-    elif compiler == 'gnu95':
-        flags = ['-m64', '-fPIC', '-O3', '-std=f2003', '-ffast-math']
-    elif compiler == 'intel':
-        flags = ['-m64', '-fpp', '-free', '-O3', '-Tf']
-    elif compiler == 'g95':
-        flags = ['-O3', '-fno-second-underscore']
-    elif compiler == 'pg':
-        flags = ['-fast']
-    else:
-        flags = ['-m64', '-O3']
-    return flags
-
-
 def configuration(parent_package='', top_path=None):
     """Configure all packages that need to be built."""
     config = Configuration('', parent_package, top_path)
@@ -218,11 +199,6 @@ def configuration(parent_package='', top_path=None):
         'include_dirs': [],
         'library_dirs': []
     }
-
-    # F95FLAGS = get_compiler_flags()
-    # kwargs['extra_f90_compile_args'] = F95FLAGS
-    # These options don't seem to be necessary as the default flags already
-    # include what is required.
 
     # numpy.distutils.fcompiler.FCompiler doesn't support .F95 extension
     compiler = FCompiler(get_default_fcompiler())
@@ -246,9 +222,7 @@ def configuration(parent_package='', top_path=None):
     print('searching SHTOOLS in:', libdir)
 
     # Fortran compilation
-    config.add_library('SHTOOLS',
-                       sources=sources,
-                       **kwargs)
+    config.add_library('SHTOOLS', sources=sources)
 
     # SHTOOLS
     kwargs['libraries'].extend(['SHTOOLS'])

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,16 @@ from numpy.distutils.system_info import get_info, dict_append
 from subprocess import CalledProcessError, check_output, check_call
 
 
+min_version = (3, 4)
+
+if sys.version_info < min_version:
+    error = """\n
+*** Beginning with pysthools 4.6, Python {0} or above is required. ***
+*** This error may be due to using a python-2.7 version of pip.    ***
+""".format('.'.join(str(n) for n in min_version))
+    raise SystemError(error)
+
+
 # Convert markdown README.md to restructured text (.rst) for PyPi, and
 # remove the first 5 lines that contain a reference to the shtools LOGO.
 # pandoc can be installed either by conda or pip:
@@ -166,6 +176,9 @@ KEYWORDS = ['Spherical Harmonics', 'Spectral Estimation', 'Slepian Functions',
             'Magnetic Field']
 
 
+PYTHON_REQUIRES='>={}'.format('.'.join(str(n) for n in min_version))
+
+
 INSTALL_REQUIRES = [
     'numpy>=' + str(numpy.__version__),
     'scipy>=0.14.0',
@@ -275,6 +288,7 @@ metadata = dict(
     author_email="mark.a.wieczorek@gmail.com",
     license='BSD',
     keywords=KEYWORDS,
+    python_requires=PYTHON_REQUIRES,
     install_requires=INSTALL_REQUIRES,
     platforms='OS Independent',
     packages=setuptools.find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from numpy.distutils.system_info import get_info, dict_append
 from subprocess import CalledProcessError, check_output, check_call
 
 
-min_version = (3, 4)
+min_version = (3, 5)
 
 if sys.version_info < min_version:
     error = """\n

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,19 @@
 
 """Setup script for SHTOOLS."""
 
+import sys
+
+min_version = (3, 5)
+
+if sys.version_info < min_version:
+    error = """\n
+*** Beginning with pysthools 4.6, Python {0} or above is required. ***
+*** This error may be a result of using a python-2.7 version of pip.    ***
+""".format('.'.join(str(n) for n in min_version))
+    raise SystemError(error)
+
 import os
 import re
-import sys
 import sysconfig
 # the setuptools import dummy patches the distutil commands such that
 # python setup.py develop works
@@ -20,16 +30,6 @@ from numpy.distutils.fcompiler import FCompiler, get_default_fcompiler
 from numpy.distutils.misc_util import Configuration
 from numpy.distutils.system_info import get_info, dict_append
 from subprocess import CalledProcessError, check_output, check_call
-
-
-min_version = (3, 5)
-
-if sys.version_info < min_version:
-    error = """\n
-*** Beginning with pysthools 4.6, Python {0} or above is required. ***
-*** This error may be due to using a python-2.7 version of pip.    ***
-""".format('.'.join(str(n) for n in min_version))
-    raise SystemError(error)
 
 
 # Convert markdown README.md to restructured text (.rst) for PyPi, and
@@ -176,7 +176,7 @@ KEYWORDS = ['Spherical Harmonics', 'Spectral Estimation', 'Slepian Functions',
             'Magnetic Field']
 
 
-PYTHON_REQUIRES='>={}'.format('.'.join(str(n) for n in min_version))
+PYTHON_REQUIRES = '>={}'.format('.'.join(str(n) for n in min_version))
 
 
 INSTALL_REQUIRES = [

--- a/src/Makefile
+++ b/src/Makefile
@@ -43,6 +43,8 @@ SRCMOD = ftypes.f95 SHTOOLS.f95 FFTW3.f95 PlanetsConstants.f95
 
 MOD = ftypes.mod SHTOOLS.mod FFTW3.mod PlanetsConstants.mod
 
+OBJSMOD = ftypes.o SHTOOLS.o FFTW3.o PlanetsConstants.o
+
 SRCS0 = CilmPlus.f95 CilmMinus.f95 \
 	ComputeDG82.f95 ComputeDm.f95 DHaj.f95 djpi2.f95 BAtoHilm.f95 \
 	MakeGrid2D.f95 GLQGridCoord.f95 MakeGridPoint.f95 MakeGridPointC.f95 \
@@ -132,6 +134,7 @@ clean: clean-obs-mod clean-prog-mod
 
 clean-obs-mod:
 	@-rm -f $(OBJS0)
+	@-rm -f $(OBJSMOD)
 	@-rm -f $(OBJSLAPACK)
 	@-rm -f $(OBJSFFTW)
 	@-rm -f *.mod

--- a/src/create_signature.py
+++ b/src/create_signature.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Automatically creates python-wrapper subroutines from the interface file
 SHTOOLS.f95. Unfortunately all assumed array shapes have to be changed because
@@ -6,9 +6,6 @@ their structure is only known by the Fortran compiler and can not be directly
 exposed to C. It is possible that newer f2py versions can handle assumed array
 shapes using a similar procedure.
 """
-from __future__ import absolute_import, division, print_function
-
-#==== IMPORTS ====
 from numpy.f2py import crackfortran
 
 #==== MAIN FUNCTION ====

--- a/src/create_wrapper.py
+++ b/src/create_wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Automatically creates python-wrapper subroutines from the interface file
 SHTOOLS.f95. Unfortunately all assumed array shapes have to be changed because
@@ -6,9 +6,6 @@ their structure is only known by the Fortran compiler and can not be directly
 exposed to C. It is possible that newer f2py versions can handle assumed array
 shapes using a similar procedure.
 """
-from __future__ import absolute_import, division, print_function
-
-#==== IMPORTS ====
 from numpy.f2py import crackfortran
 import re
 from copy import deepcopy


### PR DESCRIPTION
From this point onwards, pyshtools will not support python 2.7. This pull request removes all Python 2.7 specific instructions from the code base (such as calls to `__future__`). The Python2.7-compatible code will no longer be actively developed, and only critical updates will be made on the branch `python2.7`.

The pull request also makes a few small changes to the setup.py file.
* The `get_compiler_flags` function was removed as it was never used. The keyword arguement was misspelled, so adding flags to this has no effect on compilation.
* For windows (`win32`) I have set the `runtime_library_dir` to `[]` based on some discussions I've found on other projects. This will hopefully get the appveyor windows builds to work.