### PR TITLE
netcdf support for gravity and magnetic field coeffiecients

### DIFF
--- a/Contributors.txt
+++ b/Contributors.txt
@@ -1,9 +1,0 @@
-Mark Wieczorek
-Matthias Meschede
-Ilya Oshchepkov
-Elliott Sales de Andrade
-Andrew Walker
-Benda Xu
-Xoviat
-Katrin Leinweber
-Aaryaman Vasishta

--- a/docs/pages/mydoc/contributors.md
+++ b/docs/pages/mydoc/contributors.md
@@ -7,11 +7,17 @@ summary:
 toc: true
 ---
 
-* Mark Wieczorek / [MarkWieczorek](https://github.com/MarkWieczorek) (admin)
-* Matthias Meschede / [MMesch](https://github.com/MMesch) (admin)
+## Maintainers
+* Mark Wieczorek / [MarkWieczorek](https://github.com/MarkWieczorek)
+* Matthias Meschede / [MMesch](https://github.com/MMesch)
+
+## Contributors
 * Elliott Sales de Andrade / [QuLogic](https://github.com/QuLogic)
 * Ilya Oshchepkov / [ioshchepkov](https://github.com/ioshchepkov)
 * [xoviat](https://github.com/xoviat)
 * Benda Xu / [heroxbd](https://github.com/heroxbd)
-* Andrew Walker / [andreww](https://github.com/andreww)
 * Katrin Leinweber / [katrinleinweber](https://github.com/katrinleinweber)
+* Andrew Walker / [andreww](https://github.com/andreww)
+* Stefan Schröder / [Nasuyo](https://github.com/Nasuyo)
+* Akihisa Hattori / [HattoriAkihisa](https://github.com/HattoriAkihisa)
+* Aaryaman Vasishta / [jammm](https://github.com/jammm)

--- a/docs/pages/mydoc/contributors.md
+++ b/docs/pages/mydoc/contributors.md
@@ -14,3 +14,4 @@ toc: true
 * [xoviat](https://github.com/xoviat)
 * Benda Xu / [heroxbd](https://github.com/heroxbd)
 * Andrew Walker / [andreww](https://github.com/andreww)
+* Katrin Leinweber / [katrinleinweber](https://github.com/katrinleinweber)

--- a/docs/pages/mydoc/python-examples.md
+++ b/docs/pages/mydoc/python-examples.md
@@ -17,6 +17,8 @@ table:nth-of-type(n) th:nth-of-type(2) {
 }
 </style>
 
+{% include note.html content="In order to access the notebooks, example programs, and example datasets, it will be necessary to download or clone the entire shtools repo from [GitHub](https://github.com/SHTOOLS/SHTOOLS/). These files are not included when installing via pip." %}
+
 ## Notebooks
 
 | Notebook name | Description |

--- a/docs/pages/mydoc/python-shcoeffs.md
+++ b/docs/pages/mydoc/python-shcoeffs.md
@@ -32,6 +32,7 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | `x = SHCoeffs.from_random()` | Initialize using random coefficients with a prescribed power spectrum. |
 | `x = SHCoeffs.from_zeros()` | Initialize with coefficients set to zero. |
 | `x = SHCoeffs.from_file()` | Initialize using coefficients from a file. |
+| `x = SHCoeffs.from_netcdf()` | Initialize using coefficients from a netcdf file. |
 | `x = SHCoeffs.from_cap()` | Initialize using coefficients of a spherical cap. |
 
 ## Class attributes
@@ -65,5 +66,6 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | `plot_cross_spectrum2d()` | Plot the cross-spectrum of all spherical-harmonic coefficients. |
 | `to_array()` | Return an array of spherical harmonics coefficients with a different normalization convention. |
 | `to_file()` | Save raw spherical harmonic coefficients to a text or binary file. |
+| `to_netcdf()` | Return the coefficient data as a netcdf formatted file or object. |
 | `copy()` | Return a copy of the class instance. |
 | `info()` | Print a summary of the data stored in the SHCoeffs instance. |

--- a/docs/pages/mydoc/python-shgravcoeffs.md
+++ b/docs/pages/mydoc/python-shgravcoeffs.md
@@ -1,8 +1,8 @@
 ---
-title: "SHMagCoeffs class"
+title: "SHGravCoeffs class"
 keywords: spherical harmonics software package, spherical harmonic transform, legendre functions, multitaper spectral analysis, fortran, Python, gravity, magnetic field
 sidebar: mydoc_sidebar
-permalink: python-shmagcoeffs.html
+permalink: python-shgravcoeffs.html
 summary:
 toc: true
 ---
@@ -21,16 +21,18 @@ table:nth-of-type(n) th:nth-of-type(2) {
 
 | Subclass name | Description |
 | ------------- | ----------- |
-| SHMagRealCoeffs | Real magnetic potential spherical harmonic coefficient class. |
+| SHGravRealCoeffs | Real gravitational potential spherical harmonic coefficient class. |
 
 ## Initialization
 
 | Initialization method | Description |
 | --------------------- | ----------- |
-| `x = SHMagCoeffs.from_array()` | Initialize using coefficients from an array. |
-| `x = SHMagCoeffs.from_random()` | Initialize using random coefficients with a prescribed power spectrum. |
-| `x = SHMagCoeffs.from_zeros()` | Initialize with coefficients set to zero. |
-| `x = SHMagCoeffs.from_file()` | Initialize using coefficients from a file. |
+| `x = SHGravCoeffs.from_array()` | Initialize using coefficients from an array. |
+| `x = SHGravCoeffs.from_random()` | Initialize using random coefficients with a prescribed power spectrum. |
+| `x = SHGravCoeffs.from_zeros()` | Initialize with coefficients set to zero. |
+| `x = SHGravCoeffs.from_file()` | Initialize using coefficients from a file. |
+| `x = SHGravCoeffs.from_netcdf()` | Initialize using coefficients from a netcdf file. |
+| `x = SHGravCoeffs.from_shape()` | Initialize using the gravitational potential predicted from surface relief. |
 
 ## Class attributes
 
@@ -38,7 +40,9 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | --------- | ----------- |
 | `lmax` | The maximum spherical harmonic degree of the coefficients. |
 | `coeffs` | The raw coefficients with the specified normalization and phase conventions. |
-| `r0` | The reference radius of the magnetic potential coefficients. |
+| `gm` | The gravitational constant times the mass that is associated with the gravitational potential coefficients. |
+| `r0` | The reference radius of the gravitational potential coefficients. |
+| `omega` | The angular rotation rate of the body. |
 | `normalization` | The normalization of the coefficients: `'4pi'`, `'ortho'`, `'schmidt'`, or `'unnorm'`.|
 | `csphase` | Defines whether the Condon-Shortley phase is used (`1`) or not (`-1`). |
 | `mask` | A boolean mask that is `True` for the permissible values of degree `l` and order `m`. |
@@ -51,16 +55,19 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | ------ | ----------- |
 | `degrees()` | Return an array listing the spherical harmonic degrees from `0` to `lmax`. |
 | `spectrum()` | Return the spectrum of the function. |
+| `set_omega()` | Set the angular rotation rate of the body. |
 | `set_coeffs()` | Set coefficients in-place to specified values.|
-| `change_ref()` | Return a new class instance referenced to a different reference radius, r0. |
+| `change_ref()` | Return a new class instance referenced to a different gm, r0, or omega. |
 | `rotate()` | Rotate the coordinate system used to express the spherical harmonics coefficients and return a new class instance.|
 | `convert()` | Return a new class instance using a different normalization convention. |
 | `pad()` | Return a new class instance that is zero padded or truncated to a different `lmax`. |
-| `expand()` | Calculate the three vector components of the magnetic field, the total field, and the magnetic potential, and return an SHMagGrid class instance. |
-| `tensor()` | Calculate the 9 components of the magnetic field tensor and return an SHMagTensor class instance. |
+| `expand()` | Calculate the three vector components of the gravity field, the total field, and the gravitational potential, and return an SHGravGrid class instance. |
+| `tensor()` | Calculate the 9 components of the gravity tensor and return an SHGravTensor class instance. |
+| `geoid()` | Calculate the height of the geoid and return an SHGeoid class instance. |
 | `plot_spectrum()` | Plot the spectrum as a function of spherical harmonic degree. |
 | `plot_spectrum2d()` | Plot the spectrum of all spherical-harmonic coefficients. |
 | `to_array()` | Return an array of spherical harmonics coefficients with a different normalization convention. |
 | `to_file()` | Save raw spherical harmonic coefficients to a text or binary file. |
+| `to_netcdf()` | Return the coefficient data as a netcdf formatted file or object. |
 | `copy()` | Return a copy of the class instance. |
-| `info()` | Print a summary of the data stored in the SHMagCoeffs instance.|
+| `info()` | Print a summary of the data stored in the SHGravCoeffs instance.|

--- a/docs/pages/mydoc/python-shgrid.md
+++ b/docs/pages/mydoc/python-shgrid.md
@@ -32,6 +32,7 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | --------------------- | ----------- |
 | `x = SHGrid.from_array()` | Initialize using an array. |
 | `x = SHGrid.from_xarray()` | Initialize using an xarray DataArray. |
+| `x = SHGrid.from_netcdf()` | Initialize using a netcdf file or object. |
 | `x = SHGrid.from_file()` | Initialize using an array from a file. |
 | `x = SHGrid.from_zeros()` | Initialize using an array of zeros. |
 | `x = SHGrid.from_cap()` | Initialize using a rotated spherical cap. |
@@ -58,8 +59,8 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | ------ | ----------- |
 | `to_array()` | Return a numpy array of the gridded data. |
 | `to_xarray()` | Return the gridded data as an xarray DataArray. |
-| `to_file()` | Save raw gridded data to a text or binary file. |
 | `to_netcdf()` | Return the gridded data as a netcdf formatted file or object. |
+| `to_file()` | Save raw gridded data to a text or binary file. |
 | `to_real()` | Return a new SHGrid class instance of the real component of the data. |
 | `to_imag()` | Return a new SHGrid class instance of the imaginary component of the data. |
 | `lats()` | Return a vector containing the latitudes of each row of the gridded data. |

--- a/docs/pages/mydoc/python-shmagcoeffs.md
+++ b/docs/pages/mydoc/python-shmagcoeffs.md
@@ -1,8 +1,8 @@
 ---
-title: "SHGravCoeffs class"
+title: "SHMagCoeffs class"
 keywords: spherical harmonics software package, spherical harmonic transform, legendre functions, multitaper spectral analysis, fortran, Python, gravity, magnetic field
 sidebar: mydoc_sidebar
-permalink: python-shgravcoeffs.html
+permalink: python-shmagcoeffs.html
 summary:
 toc: true
 ---
@@ -21,17 +21,17 @@ table:nth-of-type(n) th:nth-of-type(2) {
 
 | Subclass name | Description |
 | ------------- | ----------- |
-| SHGravRealCoeffs | Real gravitational potential spherical harmonic coefficient class. |
+| SHMagRealCoeffs | Real magnetic potential spherical harmonic coefficient class. |
 
 ## Initialization
 
 | Initialization method | Description |
 | --------------------- | ----------- |
-| `x = SHGravCoeffs.from_array()` | Initialize using coefficients from an array. |
-| `x = SHGravCoeffs.from_random()` | Initialize using random coefficients with a prescribed power spectrum. |
-| `x = SHGravCoeffs.from_zeros()` | Initialize with coefficients set to zero. |
-| `x = SHGravCoeffs.from_file()` | Initialize using coefficients from a file. |
-| `x = SHGravCoeffs.from_shape()` | Initialize using the gravitational potential predicted from surface relief. |
+| `x = SHMagCoeffs.from_array()` | Initialize using coefficients from an array. |
+| `x = SHMagCoeffs.from_random()` | Initialize using random coefficients with a prescribed power spectrum. |
+| `x = SHMagCoeffs.from_zeros()` | Initialize with coefficients set to zero. |
+| `x = SHMagCoeffs.from_file()` | Initialize using coefficients from a file. |
+| `x = SHMagCoeffs.from_netcdf()` | Initialize using coefficients from a netcdf file. |
 
 ## Class attributes
 
@@ -39,9 +39,7 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | --------- | ----------- |
 | `lmax` | The maximum spherical harmonic degree of the coefficients. |
 | `coeffs` | The raw coefficients with the specified normalization and phase conventions. |
-| `gm` | The gravitational constant times the mass that is associated with the gravitational potential coefficients. |
-| `r0` | The reference radius of the gravitational potential coefficients. |
-| `omega` | The angular rotation rate of the body. |
+| `r0` | The reference radius of the magnetic potential coefficients. |
 | `normalization` | The normalization of the coefficients: `'4pi'`, `'ortho'`, `'schmidt'`, or `'unnorm'`.|
 | `csphase` | Defines whether the Condon-Shortley phase is used (`1`) or not (`-1`). |
 | `mask` | A boolean mask that is `True` for the permissible values of degree `l` and order `m`. |
@@ -54,18 +52,17 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | ------ | ----------- |
 | `degrees()` | Return an array listing the spherical harmonic degrees from `0` to `lmax`. |
 | `spectrum()` | Return the spectrum of the function. |
-| `set_omega()` | Set the angular rotation rate of the body. |
 | `set_coeffs()` | Set coefficients in-place to specified values.|
-| `change_ref()` | Return a new class instance referenced to a different gm, r0, or omega. |
+| `change_ref()` | Return a new class instance referenced to a different reference radius, r0. |
 | `rotate()` | Rotate the coordinate system used to express the spherical harmonics coefficients and return a new class instance.|
 | `convert()` | Return a new class instance using a different normalization convention. |
 | `pad()` | Return a new class instance that is zero padded or truncated to a different `lmax`. |
-| `expand()` | Calculate the three vector components of the gravity field, the total field, and the gravitational potential, and return an SHGravGrid class instance. |
-| `tensor()` | Calculate the 9 components of the gravity tensor and return an SHGravTensor class instance. |
-| `geoid()` | Calculate the height of the geoid and return an SHGeoid class instance. |
+| `expand()` | Calculate the three vector components of the magnetic field, the total field, and the magnetic potential, and return an SHMagGrid class instance. |
+| `tensor()` | Calculate the 9 components of the magnetic field tensor and return an SHMagTensor class instance. |
 | `plot_spectrum()` | Plot the spectrum as a function of spherical harmonic degree. |
 | `plot_spectrum2d()` | Plot the spectrum of all spherical-harmonic coefficients. |
 | `to_array()` | Return an array of spherical harmonics coefficients with a different normalization convention. |
 | `to_file()` | Save raw spherical harmonic coefficients to a text or binary file. |
+| `to_netcdf()` | Return the coefficient data as a netcdf formatted file or object. |
 | `copy()` | Return a copy of the class instance. |
-| `info()` | Print a summary of the data stored in the SHGravCoeffs instance.|
+| `info()` | Print a summary of the data stored in the SHMagCoeffs instance.|

--- a/pyshtools/shclasses/shcoeffsgrid.py
+++ b/pyshtools/shclasses/shcoeffsgrid.py
@@ -2661,6 +2661,7 @@ class SHGrid(object):
 
         x = SHGrid.from_array(array)
         x = SHGrid.from_xarray(data_array)
+        x = SHGrid.from_netcdf(netcdf)
         x = SHGrid.from_file('fname.dat')
         x = SHGrid.from_zeros(lmax)
         x = SHGrid.from_cap(theta, clat, clon, lmax)
@@ -2714,6 +2715,7 @@ class SHGrid(object):
         print('Initialize the class using one of the class methods:\n'
               '>>> pyshtools.SHGrid.from_array\n'
               '>>> pyshtools.SHGrid.from_xarray\n'
+              '>>> pyshtools.SHGrid.from_netcdf\n'
               '>>> pyshtools.SHGrid.from_file\n'
               '>>> pyshtools.SHGrid.from_zeros\n'
               '>>> pyshtools.SHGrid.from_cap\n')
@@ -2953,7 +2955,7 @@ class SHGrid(object):
 
         Usage
         -----
-        x = SHGrid.from_xarray(data_array)
+        x = SHGrid.from_xarray(data_array, [grid])
 
         Returns
         -------
@@ -2970,6 +2972,30 @@ class SHGrid(object):
             'DH' or 'GLQ' for Driscoll and Healy grids or Gauss-Legendre
             Quadrature grids, respectively.
         """
+        return self.from_array(data_array.values, grid=grid)
+
+    @classmethod
+    def from_netcdf(self, netcdf, grid='DH'):
+        """
+        Initialize the class instance from a netcdf formatted file or object.
+
+        Usage
+        -----
+        x = SHGrid.from_netcdf(netcdf, [grid])
+
+        Returns
+        -------
+        x : SHGrid class instance
+
+        Parameters
+        ----------
+        netcdf : str or netcdf object
+            The name of a netcdf file or object.
+        grid : str, optional, default = 'DH'
+            'DH' or 'GLQ' for Driscoll and Healy grids or Gauss-Legendre
+            Quadrature grids, respectively.
+        """
+        data_array = _xr.open_dataarray(netcdf)
         return self.from_array(data_array.values, grid=grid)
 
     def copy(self):

--- a/pyshtools/shclasses/shcoeffsgrid.py
+++ b/pyshtools/shclasses/shcoeffsgrid.py
@@ -110,7 +110,7 @@ class SHCoeffs(object):
     to_array()            : Return an array of spherical harmonic coefficients
                             with a different normalization convention.
     to_file()             : Save raw spherical harmonic coefficients as a file.
-    to_netcdf()           : Save raw spherical harmonic coefficients as a 
+    to_netcdf()           : Save raw spherical harmonic coefficients as a
                             netcdf file.
     copy()                : Return a copy of the class instance.
     info()                : Print a summary of the data stored in the SHCoeffs
@@ -635,11 +635,11 @@ class SHCoeffs(object):
                                    degrees=False)
 
         return temp
-    
+
     @classmethod
     def from_netcdf(self, filename, lmax=None, normalization='4pi', csphase=1):
         """
-        Initialize the class with spherical harmonic coefficients from a 
+        Initialize the class with spherical harmonic coefficients from a
         netcdf file.
 
         Usage
@@ -649,7 +649,7 @@ class SHCoeffs(object):
         Returns
         -------
         x : SHCoeffs class instance.
-        
+
         Parameters
         ----------
         filename : str
@@ -657,39 +657,50 @@ class SHCoeffs(object):
         lmax : int, optional, default = None
             The maximum spherical harmonic degree to read.
         normalization : str, optional, default = '4pi'
-            '4pi', 'ortho', 'schmidt', or 'unnorm' for geodesy 4pi normalized,
-            orthonormalized, Schmidt semi-normalized, or unnormalized
-            coefficients, respectively.
+            Spherical harmonic normalization if not specified in the netcdf
+            file: '4pi', 'ortho', 'schmidt', or 'unnorm' for geodesy 4pi
+            normalized, orthonormalized, Schmidt semi-normalized, or
+            unnormalized coefficients, respectively.
         csphase : int, optional, default = 1
-            Condon-Shortley phase convention: 1 to exclude the phase factor,
-            or -1 to include it.
-            
+            Condon-Shortley phase convention if not specified in the netcdf
+            file: 1 to exclude the phase factor, or -1 to include it.
+
         Description
         -----------
         The format of the netcdf file has to be exactly as the format that is
         used in SHCoeffs.to_netcdf().
         """
+        ds = _xr.open_dataset(filename)
+
+        try:
+            normalization = ds.coeffs.normalization
+        except:
+            pass
+
         if type(normalization) != str:
             raise ValueError('normalization must be a string. '
                              'Input type was {:s}'
                              .format(str(type(normalization))))
-
         if normalization.lower() not in ('4pi', 'ortho', 'schmidt', 'unnorm'):
             raise ValueError(
-                "The input normalization must be '4pi', 'ortho', 'schmidt', "
-                "or 'unnorm'. Provided value was {:s}"
+                "The input normalization must be '4pi', 'ortho', "
+                "'schmidt', or 'unnorm'. Provided value was {:s}"
                 .format(repr(normalization))
                 )
+
+        try:
+            csphase = ds.coeffs.csphase
+        except:
+            pass
 
         if csphase != 1 and csphase != -1:
             raise ValueError(
                 "csphase must be 1 or -1. Input value was {:s}"
                 .format(repr(csphase))
                 )
-        
-        ds = _xr.open_dataset(filename)
+
         lmaxout = ds.dims['degree'] - 1
-            
+
         c = _np.tril(ds.coeffs.data)
         s = _np.triu(ds.coeffs.data, k=1)
         s = _np.vstack([s[-1], s[:-1]])
@@ -712,7 +723,7 @@ class SHCoeffs(object):
             kind = 'complex'
         else:
             kind = 'real'
-            
+
         for cls in self.__subclasses__():
             if cls.istype(kind):
                 return cls(coeffs, normalization=normalization.lower(),
@@ -805,13 +816,14 @@ class SHCoeffs(object):
             raise NotImplementedError(
                 'format={:s} not implemented.'.format(repr(format)))
 
-    def to_netcdf(self, filename, title='', description=''):
-        """Return the coefficient data as a netcdf formatted file or object.
-        
+    def to_netcdf(self, filename, title='', description='', lmax=None):
+        """
+        Return the coefficient data as a netcdf formatted file or object.
+
         Usage
         -----
-        x.to_netcdf(filename, [title, description])
-        
+        x.to_netcdf(filename, [title, description, lmax])
+
         Parameters
         ----------
         filename : str
@@ -820,20 +832,26 @@ class SHCoeffs(object):
             Title of the dataset
         description : str, optional, default = ''
             Description of the data.
+        lmax : int, optional, default = self.lmax
+            The maximum spherical harmonic degree to output.
         """
-        
+        if lmax is None:
+            lmax = self.lmax
+
         ds = _xr.Dataset()
-        ds.coords['degree'] = ('degree', _np.arange(self.lmax+1))
-        ds.coords['order'] = ('order', _np.arange(self.lmax+1))
+        ds.coords['degree'] = ('degree', _np.arange(lmax+1))
+        ds.coords['order'] = ('order', _np.arange(lmax+1))
         # c coeffs as lower triangular matrix
-        c = self.coeffs[0, :, :]
+        c = self.coeffs[0, :lmax+1, :lmax+1]
         # s coeffs as upper triangular matrix
-        s = _np.transpose(self.coeffs[1, :, :])
+        s = _np.transpose(self.coeffs[1, :lmax+1, :lmax+1])
         s = _np.vstack([s[1:], s[0]])
         ds['coeffs'] = (('degree', 'order'), c + s)
         ds['coeffs'].attrs['title'] = title
         ds['coeffs'].attrs['description'] = description
-        
+        ds['coeffs'].attrs['normalization'] = self.normalization
+        ds['coeffs'].attrs['csphase'] = self.csphase
+
         ds.to_netcdf(filename)
 
     def to_array(self, normalization=None, csphase=None, lmax=None):
@@ -3542,7 +3560,7 @@ class SHGrid(object):
         fname : str, optional, default = None
             If present, save the image to the specified file.
         """
-        from mpl_toolkits.mplot3d import Axes3D
+        from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
 
         nlat, nlon = self.nlat, self.nlon
         cmap = _plt.get_cmap(cmap)

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -6,6 +6,7 @@ import matplotlib as _mpl
 import matplotlib.pyplot as _plt
 import copy as _copy
 import warnings as _warnings
+import xarray as _xr
 from scipy.special import factorial as _factorial
 
 from .shcoeffsgrid import SHCoeffs as _SHCoeffs
@@ -43,6 +44,7 @@ class SHGravCoeffs(object):
         x = SHGravCoeffs.from_random(powerspectrum, gm, r0)
         x = SHGravCoeffs.from_zeros(lmax, gm, r0)
         x = SHGravCoeffs.from_file('fname.dat')
+        x = SHGravCoeffs.from_netcdf('ncname.nc')
         x = SHGravCoeffs.from_shape(grid, rho, gm)
 
     The normalization convention of the input coefficents is specified
@@ -114,6 +116,8 @@ class SHGravCoeffs(object):
     to_array()            : Return an array of spherical harmonic coefficients
                             with a different normalization convention.
     to_file()             : Save the spherical harmonic coefficients as a file.
+    to_netcdf()           : Save raw spherical harmonic coefficients as a
+                            netcdf file.
     copy()                : Return a copy of the class instance.
     info()                : Print a summary of the data stored in the
                             SHGravCoeffs instance.
@@ -126,6 +130,7 @@ class SHGravCoeffs(object):
               '>>> pyshtools.SHGravCoeffs.from_random\n'
               '>>> pyshtools.SHGravCoeffs.from_zeros\n'
               '>>> pyshtools.SHGravCoeffs.from_file\n'
+              '>>> pyshtools.SHGravCoeffs.from_netcdf\n'
               '>>> pyshtools.SHGravCoeffs.from_shape\n')
 
     # ---- Factory methods ----
@@ -674,6 +679,122 @@ class SHGravCoeffs(object):
         return clm
 
     @classmethod
+    def from_netcdf(self, filename, lmax=None, normalization='4pi', csphase=1):
+        """
+        Initialize the class with spherical harmonic coefficients from a
+        netcdf file.
+
+        Usage
+        -----
+        x = SHGravCoeffs.from_netcdf(filename, [lmax, normalization, csphase])
+
+        Returns
+        -------
+        x : SHGravCoeffs class instance.
+
+        Parameters
+        ----------
+        filename : str
+            Name of the file, including path.
+        lmax : int, optional, default = None
+            The maximum spherical harmonic degree to read.
+        normalization : str, optional, default = '4pi'
+            Spherical harmonic normalization if not specified in the netcdf
+            file: '4pi', 'ortho', 'schmidt', or 'unnorm' for geodesy 4pi
+            normalized, orthonormalized, Schmidt semi-normalized, or
+            unnormalized coefficients, respectively.
+        csphase : int, optional, default = 1
+            Condon-Shortley phase convention if not specified in the netcdf
+            file: 1 to exclude the phase factor, or -1 to include it.
+
+        Description
+        -----------
+        The format of the netcdf file has to be exactly as the format that is
+        used in SHGravCoeffs.to_netcdf().
+        """
+        ds = _xr.open_dataset(filename)
+
+        try:
+            normalization = ds.coeffs.normalization
+        except:
+            pass
+
+        if type(normalization) != str:
+            raise ValueError('normalization must be a string. '
+                             'Input type was {:s}'
+                             .format(str(type(normalization))))
+        if normalization.lower() not in ('4pi', 'ortho', 'schmidt', 'unnorm'):
+            raise ValueError(
+                "The input normalization must be '4pi', 'ortho', "
+                "'schmidt', or 'unnorm'. Provided value was {:s}"
+                .format(repr(normalization))
+                )
+
+        try:
+            csphase = ds.coeffs.csphase
+        except:
+            pass
+
+        if csphase != 1 and csphase != -1:
+            raise ValueError(
+                "csphase must be 1 or -1. Input value was {:s}"
+                .format(repr(csphase))
+                )
+
+        try:
+            gm = ds.coeffs.GM
+        except:
+            raise ValueError("coeffs.GM must be specified in the netcdf file.")
+        try:
+            r0 = ds.coeffs.r0
+        except:
+            raise ValueError("coeffs.r0 must be specified in the netcdf file.")
+        try:
+            omega = ds.coeffs.omega
+        except:
+            omega = None
+
+        lmaxout = ds.dims['degree'] - 1
+        c = _np.tril(ds.coeffs.data)
+        s = _np.triu(ds.coeffs.data, k=1)
+        s = _np.vstack([s[-1], s[:-1]])
+        s = _np.transpose(s)
+        if isinstance(lmax, int):
+            c, s = c[:lmax+1, :lmax+1], s[:lmax+1, :lmax+1]
+            lmaxout = lmax
+
+        if normalization.lower() == 'unnorm' and lmaxout > 85:
+            _warnings.warn("Calculations using unnormalized coefficients " +
+                           "are stable only for degrees less than or equal " +
+                           "to 85. lmax for the coefficients will be set to " +
+                           "85. Input value was {:d}.".format(lmaxout),
+                           category=RuntimeWarning)
+            lmaxout = 85
+            c, s = c[:lmaxout+1, :lmaxout+1], s[:lmaxout+1, :lmaxout+1]
+        coeffs = _np.array([c, s])
+
+        try:
+            cerrors = _np.tril(ds.errors.data)
+            serrors = _np.triu(ds.errors.data, k=1)
+            serrors = _np.vstack([serrors[-1], serrors[:-1]])
+            serrors = _np.transpose(serrors)
+            cerrors = cerrors[:lmaxout+1, :lmaxout+1]
+            serrors = serrors[:lmaxout+1, :lmaxout+1]
+            errors = _np.array([cerrors, serrors])
+        except:
+            errors = None
+
+        if _np.iscomplexobj(coeffs):
+            raise ValueError('Gravitational potential coefficients must be '
+                             'real. Input coefficients are complex.')
+
+        clm = SHGravRealCoeffs(coeffs, gm=gm, r0=r0, omega=omega,
+                               errors=errors,
+                               normalization=normalization.lower(),
+                               csphase=csphase)
+        return clm
+
+    @classmethod
     def from_shape(self, shape, rho, gm, nmax=7, lmax=None, lmax_grid=None,
                    lmax_calc=None, omega=None):
         """
@@ -935,6 +1056,60 @@ class SHGravCoeffs(object):
         else:
             raise NotImplementedError(
                 'format={:s} not implemented.'.format(repr(format)))
+
+    def to_netcdf(self, filename, title='', description='', lmax=None):
+        """
+        Return the coefficient data as a netcdf formatted file or object.
+
+        Usage
+        -----
+        x.to_netcdf(filename, [title, description, lmax])
+
+        Parameters
+        ----------
+        filename : str
+            Name of the output file.
+        title : str, optional, default = ''
+            Title of the dataset
+        description : str, optional, default = ''
+            Description of the data.
+        lmax : int, optional, default = self.lmax
+            The maximum spherical harmonic degree to output.
+        """
+        if lmax is None:
+            lmax = self.lmax
+
+        ds = _xr.Dataset()
+        ds.coords['degree'] = ('degree', _np.arange(lmax+1))
+        ds.coords['order'] = ('order', _np.arange(lmax+1))
+        # c coeffs as lower triangular matrix
+        c = self.coeffs[0, :lmax+1, :lmax+1]
+        # s coeffs as upper triangular matrix
+        s = _np.transpose(self.coeffs[1, :lmax+1, :lmax+1])
+        s = _np.vstack([s[1:], s[0]])
+        ds['coeffs'] = (('degree', 'order'), c + s)
+        ds['coeffs'].attrs['title'] = title
+        ds['coeffs'].attrs['description'] = description
+        ds['coeffs'].attrs['normalization'] = self.normalization
+        ds['coeffs'].attrs['csphase'] = self.csphase
+        ds['coeffs'].attrs['GM'] = self.gm
+        ds['coeffs'].attrs['r0'] = self.r0
+        if self.omega is not None:
+            ds['coeffs'].attrs['omega'] = self.omega
+
+        if self.errors is not None:
+            cerrors = self.errors[0, :lmax+1, :lmax+1]
+            serrors = _np.transpose(self.errors[1, :lmax+1, :lmax+1])
+            serrors = _np.vstack([serrors[1:], serrors[0]])
+            ds['errors'] = (('degree', 'order'), cerrors + serrors)
+            ds['errors'].attrs['normalization'] = self.normalization
+            ds['errors'].attrs['csphase'] = self.csphase
+            ds['errors'].attrs['GM'] = self.gm
+            ds['errors'].attrs['r0'] = self.r0
+            if self.omega is not None:
+                ds['errors'].attrs['omega'] = self.omega
+
+        ds.to_netcdf(filename)
 
     def to_array(self, normalization=None, csphase=None, lmax=None):
         """

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -106,8 +106,8 @@ class SHGravCoeffs(object):
                             gravitational potential, and return an SHGravGrid
                             class instance.
     mass                  : Return the mass of the planet.
-    center_of_mass        : Return coordinates of the center of mass
-                            of the planet.
+    center_of_mass        : Return coordinates of the center of mass of the
+                            planet.
     inertia_tensor()      : Return an array of the inertia tensor.
     tensor()              : Calculate the 9 components of the gravity tensor
                             and return an SHGravTensor class instance.
@@ -933,18 +933,18 @@ class SHGravCoeffs(object):
 
     @property
     def center_of_mass(self):
-        """Return coordinates of the center of mass of the planet in metres.
+        """Return coordinates of the center of mass of the planet in meters.
 
-        This method will return cartesian coordinates of the center of mass with respect
-        to the coordinate system of the spherical harmonic coefficients.
+        This method will return Cartesian coordinates of the center of mass
+        with respect to the coordinate system of the spherical harmonic
+        coefficients.
 
         Returns
         -------
         x, y, z : float
-            Cartesian coordinates of the center of mass, in metres.
+            Cartesian coordinates of the center of mass, in meters.
         """
-        coeffs = self.convert(normalization='unnorm',
-                csphase=1, lmax=1).coeffs
+        coeffs = self.convert(normalization='unnorm', csphase=1, lmax=1).coeffs
 
         x_cm = coeffs[0, 1, 1] * self.r0
         y_cm = coeffs[1, 1, 1] * self.r0
@@ -958,7 +958,8 @@ class SHGravCoeffs(object):
         Parameters
         ----------
         dynamical_flattening : float
-            Dynamical flattening (or precession constant) of the planet.
+            Dynamical flattening (or precession constant) of the planet,
+            defined as [C-(A+B)/2]/C.
 
         Returns
         -------
@@ -973,8 +974,8 @@ class SHGravCoeffs(object):
             (Iyx, Iyy, Iyz)
             (Izx, Izy, Izz)
 
-        The diagonal elements Ixx, Iyy, Izz are the axial moments of inertia.
-        The off-diagonal elements
+        The diagonal elements Ixx, Iyy, Izz are the axial moments of inertia,
+        and the off-diagonal elements
 
             Ixy = Iyx, Ixz = Izx, Iyz = Izy
 
@@ -986,12 +987,11 @@ class SHGravCoeffs(object):
         WH Freeman, 1967.
 
         Chen, W., Li, J.C., Ray, J., Shen, W.B. and Huang, C.L.,
-        Consistent estimates of the dynamic figure parameters of the earth.
+        Consistent estimates of the dynamic figure parameters of the Earth.
         J. Geod., 89(2), 179-188, 2015.
         """
 
-        coeffs = self.convert(normalization='unnorm',
-                csphase=1, lmax=2).coeffs
+        coeffs = self.convert(normalization='unnorm', csphase=1, lmax=2).coeffs
 
         mr02 = self.mass * self.r0**2
 
@@ -1002,9 +1002,9 @@ class SHGravCoeffs(object):
 
         # Axial moments of inertia
         xx = mr02 * ((1 - 1 / dynamical_flattening) * coeffs[0, 2, 0] -
-                2 * coeffs[0, 2, 2])
+                     2 * coeffs[0, 2, 2])
         yy = mr02 * ((1 - 1 / dynamical_flattening) * coeffs[0, 2, 0] +
-                2 * coeffs[0, 2, 2])
+                     2 * coeffs[0, 2, 2])
         zz = -mr02 * coeffs[0, 2, 0] / dynamical_flattening
 
         tensor = _np.array([

--- a/pyshtools/shclasses/shgravgrid.py
+++ b/pyshtools/shclasses/shgravgrid.py
@@ -540,10 +540,10 @@ class SHGravGrid(object):
         acceleration, the output will be displayed in mGals.
         """
         if self.normal_gravity:
-            if cb_label is not None:
+            if cb_label is not None and cb_ylabel is None:
                 cb_label += ', mGal'
         else:
-            if cb_label is not None:
+            if cb_label is not None and cb_ylabel is None:
                 cb_label += ', m s$^{-2}$'
 
         if self.normal_gravity:

--- a/pyshtools/utils/figstyle.py
+++ b/pyshtools/utils/figstyle.py
@@ -60,7 +60,7 @@ def figstyle(rel_width=0.75, screen_dpi=114, aspect_ratio=4/3,
         'ytick.labelsize': 8,
         'legend.fontsize': 9,
         'text.usetex': False,
-        'axes.formatter.limits': (-3, 3),
+        'axes.formatter.limits': (-3, 4),
         'mathtext.fontset': 'stix',
         # figure
         'figure.dpi': screen_dpi,


### PR DESCRIPTION
* Add the methods the methods `to_netcdf()` and `from_netcdf()` to the `SHGravCoeffs` and `SHMagCoeffs` classes.
