### PR TITLE
Datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 NONE/
 build/
 dist/
+docs/vendor/
 pyshtools/doc/
 examples/notebooks/.ipynb_checkpoints/
 pyshtools.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
         requests
         cartopy
         pygmt
-        gmt=6.0.0
+        gmt
         pooch
         tqdm
         palettable

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,10 +47,12 @@ install:
         xarray
         requests
         cartopy
+        pygmt
         gmt=6.0.0
+        pooch
+        tqdm
+        palettable
   - source activate test-environment
-  - pip install git+https://github.com/GenericMappingTools/pygmt.git
-  - pip install palettable
   - pip install --no-deps .
 
 script:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ spherical harmonic transforms, multitaper spectral analyses on the sphere, expan
 
 * Integrated support for working with xarray and netcdf data.
 
-* Publication quality maps using [Cartopy](https://scitools.org.uk/cartopy) or [pygmt](https://www.pygmt.org/dev/).
+* Publication quality maps using [Cartopy](https://scitools.org.uk/cartopy) or [pygmt](https://www.pygmt.org/).
 
 * SHTOOLS is open source software (3-clause BSD license).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ SHTOOLS/pyshtools is extremely versatile:
 
 * Standard data formats such as *xarray* and *netcdf* are supported.
 
-* Publication quality maps using [Cartopy](https://scitools.org.uk/cartopy) or [pygmt](https://www.pygmt.org/dev/).
+* Publication quality maps using [Cartopy](https://scitools.org.uk/cartopy) or [pygmt](https://www.pygmt.org/).
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ SHTOOLS/pyshtools is extremely versatile:
 
 * The Fortran routines are OpenMP compatible and OpenMP thread-safe.
 
-* Standard data formats such as *xarray* and *netcdf* are supported.
+* Standard data formats are supported, such as *xarray* and *netcdf*.
 
 * Publication quality maps using [Cartopy](https://scitools.org.uk/cartopy) or [pygmt](https://www.pygmt.org/).
 

--- a/docs/pages/mydoc/installing-python.md
+++ b/docs/pages/mydoc/installing-python.md
@@ -66,12 +66,14 @@ In order to use the most basic aspects of pyshtools, it will be necessary to ins
 * [numpy](https://numpy.org/)
 * [scipy](https://www.scipy.org/)
 * [matplotlib](https://matplotlib.org/)
-* [astropy](https://www.astropy.org/) (required for the planetary constants module)
-* [xarray](https://xarray.pydata.org/en/stable/#) (required for netcdf file support)
-* [requests](https://2.python-requests.org/en/master/#) (required when reading files from urls).
+* [astropy](https://www.astropy.org/): required for the planetary constants module.
+* [xarray](https://xarray.pydata.org/en/stable/#): required for netcdf file support.
+* [requests](https://2.python-requests.org/en/master/#): required when reading files from urls.
+* [pooch](https://www.fatiando.org/pooch/latest/index.html): required for reading datasets.
+* [tqdm](https://tqdm.github.io/): required for showing progress bars when downloading datasets.
 
 All of the above packages should be installed automatically when installing pyshtools with pip or conda. For more specialized operations, it will be necessary to install manually the following packages:
 
-* [Cartopy](https://scitools.org.uk/cartopy/docs/latest/) (required for Cartopy map projections)
-* [pygmt](https://www.pygmt.org) (required for pygmt map projections)
-* [palettable](https://jiffyclub.github.io/palettable/) (scientific color maps required by one of the tutorials).
+* [Cartopy](https://scitools.org.uk/cartopy/docs/latest/): required for Cartopy map projections.
+* [pygmt](https://www.pygmt.org): required for pygmt map projections.
+* [palettable](https://jiffyclub.github.io/palettable/): scientific color maps required by one of the tutorials.

--- a/docs/pages/mydoc/python-io.md
+++ b/docs/pages/mydoc/python-io.md
@@ -22,11 +22,12 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | Function name | Description |
 | ------------- | ----------- |
 | [shread](pyshread.html) | Read spherical harmonic coefficients from a text file. |
+| [read_icgem_gfc](read_icgem_gfc.html) | Read real spherical harmonic coefficients from an ICGEM GFC-formatted file. |
+| [read_bsch](read_icgem_gfc.html) | Read real spherical harmonic coefficients from a binary bsch-formatted file. |
 | [SHRead2](pyshread2.html) | Read spherical harmonic coefficients from a CHAMP or GRACE-like ascii-formatted file. |
 | [SHRead2Error](pyshread2error.html) | Read spherical harmonic coefficients and associated errors from a CHAMP or GRACE-like ascii-formatted file. |
 | [SHReadJPL](pyshreadjpl.html) | Read spherical harmonic coefficients from a JPL ascii-formatted file. |
 | [SHReadJPLError](pyshreadjplerror.html) | Read spherical harmonic coefficients and associated errors from a JPL ascii-formatted file. |
-| [read_icgem_gfc](read_icgem_gfc.html) | Read spherical harmonic coefficients from an ICGEM GFC ascii-formatted file. |
 
 ## Spherical harmonic storage
 

--- a/docs/pages/mydoc/python-io.md
+++ b/docs/pages/mydoc/python-io.md
@@ -22,6 +22,7 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | Function name | Description |
 | ------------- | ----------- |
 | [shread](pyshread.html) | Read spherical harmonic coefficients from a text file. |
+| [read_dov](read_dov.html) | Read spherical harmonic coefficients from a text file formatted as [degree, order, value]. |
 | [read_icgem_gfc](read_icgem_gfc.html) | Read real spherical harmonic gravitational potential coefficients and associated errors from an ICGEM GFC formatted file. |
 | [read_bsch](read_bshc.html) | Read real spherical harmonic coefficients from a binary bsch-formatted file. |
 | [read_igrf](read_igrf.html) | Read IGRF real spherical harmonic coefficients, and return the magnetic potential coefficients for the specified year. |

--- a/docs/pages/mydoc/python-io.md
+++ b/docs/pages/mydoc/python-io.md
@@ -22,8 +22,9 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | Function name | Description |
 | ------------- | ----------- |
 | [shread](pyshread.html) | Read spherical harmonic coefficients from a text file. |
-| [read_icgem_gfc](read_icgem_gfc.html) | Read real spherical harmonic coefficients from an ICGEM GFC-formatted file. |
-| [read_bsch](read_icgem_gfc.html) | Read real spherical harmonic coefficients from a binary bsch-formatted file. |
+| [read_icgem_gfc](read_icgem_gfc.html) | Read real spherical harmonic gravitational potential coefficients and associated errors from an ICGEM GFC formatted file. |
+| [read_bsch](read_bshc.html) | Read real spherical harmonic coefficients from a binary bsch-formatted file. |
+| [read_igrf](read_igrf.html) | Read IGRF real spherical harmonic coefficients, and return the magnetic potential coefficients for the specified year. |
 | [SHRead2](pyshread2.html) | Read spherical harmonic coefficients from a CHAMP or GRACE-like ascii-formatted file. |
 | [SHRead2Error](pyshread2error.html) | Read spherical harmonic coefficients and associated errors from a CHAMP or GRACE-like ascii-formatted file. |
 | [SHReadJPL](pyshreadjpl.html) | Read spherical harmonic coefficients from a JPL ascii-formatted file. |

--- a/pyshtools/__init__.py
+++ b/pyshtools/__init__.py
@@ -52,6 +52,7 @@ __author__ = 'SHTOOLS developers'
 # ---- Import shtools subpackages ----
 from . import shtools
 from . import constant
+from . import datasets
 from . import shclasses
 from . import legendre
 from . import expand
@@ -80,4 +81,4 @@ __all__ = ['constant', 'shclasses', 'legendre', 'expand', 'shio', 'shtools',
            'spectralanalysis', 'rotate', 'gravmag', 'utils', 'SHCoeffs',
            'SHGrid', 'SHWindow', 'Slepian', 'SlepianCoeffs', 'SHGravCoeffs',
            'SHGravGrid', 'SHGravTensor', 'SHGeoid', 'SHMagCoeffs', 'SHMagGrid',
-           'SHMagTensor']
+           'SHMagTensor', 'datasets']

--- a/pyshtools/datasets/Ceres.py
+++ b/pyshtools/datasets/Ceres.py
@@ -1,0 +1,43 @@
+'''
+Datasets related to the dwarf planet (1) Ceres.
+
+Gravity
+-------
+CERES18D :  Konopliv et al. (2018)
+'''
+from pooch import os_cache as _os_cache
+from pooch import retrieve as _retrieve
+from pooch import HTTPDownloader as _HTTPDownloader
+from ..shclasses import SHGravCoeffs as _SHGravCoeffs
+
+
+def CERES18D(lmax=18):
+    '''
+    CERES18D is a JPL 18 degree and order spherical harmonic model of the
+    gravitational potential of (1) Ceres.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Konopliv, A.S., Park, R.S., Vaughan, A.T., Bills, B.G., Asmar, S.W.,
+        Ermakov, A.I., Rambaux, N., Raymond, C.A., Castillo-Rogez, J.C.,
+        Russell, C.T., Smith, D.E., Zuber, M.T. (2018). The Ceres gravity
+        field, spin pole, rotation period and orbit from the Dawn radiometric
+        tracking and optical data, Icarus, 299, 411-429,
+        doi:10.1016/j.icarus.2017.08.005.
+    '''
+    fname = _retrieve(
+        url="https://sbnarchive.psi.edu/pds3/dawn/grav/DWNCGRS_2_v3_181005/DATA/SHADR/JGDWN_CER18D_SHA.TAB",  # noqa: E501
+        known_hash="sha256:e7ccb1f0c689f77fe5dae4e0bb5d514db1cf5acb5be927bbcaa8576aca153981",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
+                                   r0_index=0, gm_index=1, errors=True)
+
+
+__all__ = ['CERES18D']

--- a/pyshtools/datasets/Earth/Earth2012/__init__.py
+++ b/pyshtools/datasets/Earth/Earth2012/__init__.py
@@ -1,0 +1,235 @@
+'''
+Earth2012: Shape and topography of Earth expanded to degree and order 2160.
+
+shape_air       :  Earth's shape (with water)
+shape_bathy     :  Earth's shape (without water)
+shape_bathy_bed :  Earth's shape (without water and ice)
+shape_RET       :  Earth's rock-equivalent topography as shape model
+
+topo_air        :  Earth's surface (with water)
+topo_bathy      :  Earth's surface (without water)
+topo_bathy_bed  :  Earth's surface (without water and ice)
+RET             :  Earth's rock-equivalent topography
+
+Reference
+---------
+Hirt, C., Kuhn, M., Featherstone, W.E., Goettl, F. (2012). Topographic/
+isostatic evaluation of new-generation GOCE gravity field models, Journal of
+Geophysical Research: Solid Earth, B05407, doi:10.1029/2011JB008878.
+'''
+from pooch import os_cache as _os_cache
+from pooch import retrieve as _retrieve
+from pooch import HTTPDownloader as _HTTPDownloader
+from ....shclasses import SHCoeffs as _SHCoeffs
+
+
+def shape_air(lmax=2160):
+    '''
+    Earth's shape (with water): Harmonic shape model of the interface between
+    Earth and its atmosphere, providing radii of the terrain and ice.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Hirt, C., Kuhn, M., Featherstone, W.E., Goettl, F. (2012). Topographic/
+    isostatic evaluation of new-generation GOCE gravity field models, Journal
+    of Geophysical Research: Solid Earth, B05407, doi:10.1029/2011JB008878.
+    '''
+    fname = _retrieve(
+        url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.shape_air.SHCto2160.zip",  # noqa: E501
+        known_hash="sha256:07b948727c96022f40375d82cb3e505732fb3e1bf72f41b1cc072445dafab059",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHCoeffs.from_file(fname, lmax=lmax)
+
+
+def shape_bathy(lmax=2160):
+    '''
+    Earth's shape (without water): Harmonic shape model of the Earth without
+    ocean water masses. This model provides radii of the terrain and ice.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Hirt, C., Kuhn, M., Featherstone, W.E., Goettl, F. (2012). Topographic/
+    isostatic evaluation of new-generation GOCE gravity field models, Journal
+    of Geophysical Research: Solid Earth, B05407, doi:10.1029/2011JB008878.
+    '''
+    fname = _retrieve(
+        url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.shape_bathy.SHCto2160.zip",  # noqa: E501
+        known_hash="sha256:ee03c7addf13f60efd3c928f166f83f5a9f17991c9dd74a88c6c8d9ede8bb15e",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHCoeffs.from_file(fname, lmax=lmax)
+
+
+def shape_bathy_bed(lmax=2160):
+    '''
+    Earth's shape (without water and ice): Harmonic shape model of the Earth
+    without icesheets and without ocean water masses. This model provides radii
+    of the terrain over land, of the sea bed over the oceans and inland lakes
+    and of bedrock heights over Antarctica and Greenland.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Hirt, C., Kuhn, M., Featherstone, W.E., Goettl, F. (2012). Topographic/
+    isostatic evaluation of new-generation GOCE gravity field models, Journal
+    of Geophysical Research: Solid Earth, B05407, doi:10.1029/2011JB008878.
+    '''
+    fname = _retrieve(
+        url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.shape_bathy_bed.SHCto2160.zip",  # noqa: E501
+        known_hash="sha256:66ffd58246566b4f62cc1f71145388057a4c2a1a8142f55e089e26a0b2a22d57",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHCoeffs.from_file(fname, lmax=lmax)
+
+
+def shape_RET(lmax=2160):
+    '''
+    Earth's rock-equivalent topography as shape model: Harmonic shape model of
+    Earth's rock-equivalent topography.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Hirt, C., Kuhn, M., Featherstone, W.E., Goettl, F. (2012). Topographic/
+    isostatic evaluation of new-generation GOCE gravity field models, Journal
+    of Geophysical Research: Solid Earth, B05407, doi:10.1029/2011JB008878.
+    '''
+    fname = _retrieve(
+        url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.shape_RET2012.SHCto2160.zip",  # noqa: E501
+        known_hash="sha256:16c769df9d2c790fb62d1a1e73fd6070c5b5b663c2bd7f68fd21ad4aa8c96a2b",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHCoeffs.from_file(fname, lmax=lmax)
+
+
+def topo_air(lmax=2160):
+    '''
+    Earth's surface (with water): Harmonic model of the interface between
+    Earth and its atmosphere, providing heights above mean sea level of the
+    terrain and ice over land and zero heights over the oceans.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Hirt, C., Kuhn, M., Featherstone, W.E., Goettl, F. (2012). Topographic/
+    isostatic evaluation of new-generation GOCE gravity field models, Journal
+    of Geophysical Research: Solid Earth, B05407, doi:10.1029/2011JB008878.
+    '''
+    fname = _retrieve(
+        url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.topo_air.SHCto2160.zip",  # noqa: E501
+        known_hash="sha256:7b68053ba74246f1a755fcce05266a58ab96529b1e48309b98a0e9ba49b4ba3f",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHCoeffs.from_file(fname, lmax=lmax)
+
+
+def topo_bathy(lmax=2160):
+    '''
+    Earth's surface (without water): Harmonic model of the Earth's topography
+    without ocean water masses. This model provides heights of the terrain and
+    of ice over land and bathymetric depths over the oceans, Caspian Sea and
+    major inland lakes (Superior, Michigan, Huron, Erie, Ontario and Baikal).
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Hirt, C., Kuhn, M., Featherstone, W.E., Goettl, F. (2012). Topographic/
+    isostatic evaluation of new-generation GOCE gravity field models, Journal
+    of Geophysical Research: Solid Earth, B05407, doi:10.1029/2011JB008878.
+    '''
+    fname = _retrieve(
+        url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.topo_bathy.SHCto2160.zip",  # noqa: E501
+        known_hash="sha256:997a16f85dafbfd1a0ee2339f503470acea6c8cb8eecdf5f2e057904a97f9718",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHCoeffs.from_file(fname, lmax=lmax)
+
+
+def topo_bathy_bed(lmax=2160):
+    '''
+    Earth's surface (without water and ice): Harmonic model of the Earth's
+    topography without ice sheets and without ocean water masses. This model
+    provides heights of the terrain over land, bathymetric depths over the
+    oceans, Caspian Sea and major inland lakes, and bedrock heights over
+    Antarctica and Greenland.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Hirt, C., Kuhn, M., Featherstone, W.E., Goettl, F. (2012). Topographic/
+    isostatic evaluation of new-generation GOCE gravity field models, Journal
+    of Geophysical Research: Solid Earth, B05407, doi:10.1029/2011JB008878.
+    '''
+    fname = _retrieve(
+        url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.topo_bathy_bed.SHCto2160.zip",  # noqa: E501
+        known_hash="sha256:f8b0535a76de11de767d0ebb6c032f5983ac48ad29d1750b0d22e15a627f88e1",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHCoeffs.from_file(fname, lmax=lmax)
+
+
+def RET(lmax=2160):
+    '''
+    Earth's rock-equivalent topography: Harmonic model of Earth's
+    rock-equivalent topography.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Hirt, C., Kuhn, M., Featherstone, W.E., Goettl, F. (2012). Topographic/
+    isostatic evaluation of new-generation GOCE gravity field models, Journal
+    of Geophysical Research: Solid Earth, B05407, doi:10.1029/2011JB008878.
+    '''
+    fname = _retrieve(
+        url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.RET2012.SHCto2160.zip",  # noqa: E501
+        known_hash="sha256:36b3204d86fa01fa9e8f693e2df8e91905b67619a0192cc0c269be21a7ba5799",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHCoeffs.from_file(fname, lmax=lmax)
+
+
+__all__ = ['shape_air', 'shape_bathy', 'shape_bathy_bed', 'shape_RET',
+           'topo_air', 'topo_bathy', 'topo_bathy_bed', 'RET']

--- a/pyshtools/datasets/Earth/Earth2012/__init__.py
+++ b/pyshtools/datasets/Earth/Earth2012/__init__.py
@@ -1,15 +1,16 @@
 '''
-Earth2012: Shape and topography of Earth expanded to degree and order 2160.
+Earth2012: Shape and topography (with respect to mean sea level) of Earth
+expanded to degree and order 2160.
 
 shape_air       :  Earth's shape (with water)
 shape_bathy     :  Earth's shape (without water)
 shape_bathy_bed :  Earth's shape (without water and ice)
-shape_RET       :  Earth's rock-equivalent topography as shape model
+shape_ret       :  Earth's rock-equivalent topography as shape model
 
 topo_air        :  Earth's surface (with water)
 topo_bathy      :  Earth's surface (without water)
 topo_bathy_bed  :  Earth's surface (without water and ice)
-RET             :  Earth's rock-equivalent topography
+ret             :  Earth's rock-equivalent topography
 
 Reference
 ---------
@@ -100,7 +101,7 @@ def shape_bathy_bed(lmax=2160):
     return _SHCoeffs.from_file(fname, lmax=lmax)
 
 
-def shape_RET(lmax=2160):
+def shape_ret(lmax=2160):
     '''
     Earth's rock-equivalent topography as shape model: Harmonic shape model of
     Earth's rock-equivalent topography.
@@ -206,7 +207,7 @@ def topo_bathy_bed(lmax=2160):
     return _SHCoeffs.from_file(fname, lmax=lmax)
 
 
-def RET(lmax=2160):
+def ret(lmax=2160):
     '''
     Earth's rock-equivalent topography: Harmonic model of Earth's
     rock-equivalent topography.
@@ -231,5 +232,5 @@ def RET(lmax=2160):
     return _SHCoeffs.from_file(fname, lmax=lmax)
 
 
-__all__ = ['shape_air', 'shape_bathy', 'shape_bathy_bed', 'shape_RET',
-           'topo_air', 'topo_bathy', 'topo_bathy_bed', 'RET']
+__all__ = ['shape_air', 'shape_bathy', 'shape_bathy_bed', 'shape_ret',
+           'topo_air', 'topo_bathy', 'topo_bathy_bed', 'ret']

--- a/pyshtools/datasets/Earth/Earth2012/__init__.py
+++ b/pyshtools/datasets/Earth/Earth2012/__init__.py
@@ -15,8 +15,8 @@ ret             :  Earth's rock-equivalent topography
 Reference
 ---------
 Hirt, C., Kuhn, M., Featherstone, W.E., Goettl, F. (2012). Topographic/
-isostatic evaluation of new-generation GOCE gravity field models, Journal of
-Geophysical Research: Solid Earth, B05407, doi:10.1029/2011JB008878.
+    isostatic evaluation of new-generation GOCE gravity field models, Journal
+    of Geophysical Research: Solid Earth, B05407, doi:10.1029/2011JB008878.
 '''
 from pooch import os_cache as _os_cache
 from pooch import retrieve as _retrieve
@@ -37,8 +37,9 @@ def shape_air(lmax=2160):
     Reference
     ---------
     Hirt, C., Kuhn, M., Featherstone, W.E., Goettl, F. (2012). Topographic/
-    isostatic evaluation of new-generation GOCE gravity field models, Journal
-    of Geophysical Research: Solid Earth, B05407, doi:10.1029/2011JB008878.
+        isostatic evaluation of new-generation GOCE gravity field models,
+        Journal of Geophysical Research: Solid Earth, B05407,
+        doi:10.1029/2011JB008878.
     '''
     fname = _retrieve(
         url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.shape_air.SHCto2160.zip",  # noqa: E501
@@ -62,8 +63,9 @@ def shape_bathy(lmax=2160):
     Reference
     ---------
     Hirt, C., Kuhn, M., Featherstone, W.E., Goettl, F. (2012). Topographic/
-    isostatic evaluation of new-generation GOCE gravity field models, Journal
-    of Geophysical Research: Solid Earth, B05407, doi:10.1029/2011JB008878.
+        isostatic evaluation of new-generation GOCE gravity field models,
+        Journal of Geophysical Research: Solid Earth, B05407,
+        doi:10.1029/2011JB008878.
     '''
     fname = _retrieve(
         url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.shape_bathy.SHCto2160.zip",  # noqa: E501
@@ -89,8 +91,9 @@ def shape_bathy_bed(lmax=2160):
     Reference
     ---------
     Hirt, C., Kuhn, M., Featherstone, W.E., Goettl, F. (2012). Topographic/
-    isostatic evaluation of new-generation GOCE gravity field models, Journal
-    of Geophysical Research: Solid Earth, B05407, doi:10.1029/2011JB008878.
+        isostatic evaluation of new-generation GOCE gravity field models,
+        Journal of Geophysical Research: Solid Earth, B05407,
+        doi:10.1029/2011JB008878.
     '''
     fname = _retrieve(
         url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.shape_bathy_bed.SHCto2160.zip",  # noqa: E501
@@ -114,8 +117,9 @@ def shape_ret(lmax=2160):
     Reference
     ---------
     Hirt, C., Kuhn, M., Featherstone, W.E., Goettl, F. (2012). Topographic/
-    isostatic evaluation of new-generation GOCE gravity field models, Journal
-    of Geophysical Research: Solid Earth, B05407, doi:10.1029/2011JB008878.
+        isostatic evaluation of new-generation GOCE gravity field models,
+        Journal of Geophysical Research: Solid Earth, B05407,
+        doi:10.1029/2011JB008878.
     '''
     fname = _retrieve(
         url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.shape_RET2012.SHCto2160.zip",  # noqa: E501
@@ -140,8 +144,9 @@ def topo_air(lmax=2160):
     Reference
     ---------
     Hirt, C., Kuhn, M., Featherstone, W.E., Goettl, F. (2012). Topographic/
-    isostatic evaluation of new-generation GOCE gravity field models, Journal
-    of Geophysical Research: Solid Earth, B05407, doi:10.1029/2011JB008878.
+        isostatic evaluation of new-generation GOCE gravity field models,
+        Journal of Geophysical Research: Solid Earth, B05407,
+        doi:10.1029/2011JB008878.
     '''
     fname = _retrieve(
         url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.topo_air.SHCto2160.zip",  # noqa: E501
@@ -167,8 +172,9 @@ def topo_bathy(lmax=2160):
     Reference
     ---------
     Hirt, C., Kuhn, M., Featherstone, W.E., Goettl, F. (2012). Topographic/
-    isostatic evaluation of new-generation GOCE gravity field models, Journal
-    of Geophysical Research: Solid Earth, B05407, doi:10.1029/2011JB008878.
+        isostatic evaluation of new-generation GOCE gravity field models,
+        Journal of Geophysical Research: Solid Earth, B05407,
+        doi:10.1029/2011JB008878.
     '''
     fname = _retrieve(
         url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.topo_bathy.SHCto2160.zip",  # noqa: E501
@@ -195,8 +201,9 @@ def topo_bathy_bed(lmax=2160):
     Reference
     ---------
     Hirt, C., Kuhn, M., Featherstone, W.E., Goettl, F. (2012). Topographic/
-    isostatic evaluation of new-generation GOCE gravity field models, Journal
-    of Geophysical Research: Solid Earth, B05407, doi:10.1029/2011JB008878.
+        isostatic evaluation of new-generation GOCE gravity field models,
+        Journal of Geophysical Research: Solid Earth, B05407,
+        doi:10.1029/2011JB008878.
     '''
     fname = _retrieve(
         url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.topo_bathy_bed.SHCto2160.zip",  # noqa: E501
@@ -220,8 +227,9 @@ def ret(lmax=2160):
     Reference
     ---------
     Hirt, C., Kuhn, M., Featherstone, W.E., Goettl, F. (2012). Topographic/
-    isostatic evaluation of new-generation GOCE gravity field models, Journal
-    of Geophysical Research: Solid Earth, B05407, doi:10.1029/2011JB008878.
+        isostatic evaluation of new-generation GOCE gravity field models,
+        Journal of Geophysical Research: Solid Earth, B05407,
+        doi:10.1029/2011JB008878.
     '''
     fname = _retrieve(
         url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.RET2012.SHCto2160.zip",  # noqa: E501

--- a/pyshtools/datasets/Earth/Earth2014/__init__.py
+++ b/pyshtools/datasets/Earth/Earth2014/__init__.py
@@ -1,0 +1,155 @@
+'''
+Earth2014: Topography of Earth with respect to mean sea level, expanded to
+degree and order 2160.
+
+surface   :  Earth's physical surface (including water and ice masses)
+bedrock   :  Earth's bedrock (excluding water and ice masses)
+tbi       :  Topography of Earth's bedrock and ice masses (excluding water)
+ret       :  Earth's rock-equivalent topography
+ice       :  Thickness of Earth's ice sheets
+
+Reference
+---------
+Hirt, C., Rexer, M. (2015). Earth2014: 1 arc-min shape, topography, bedrock
+and ice-sheet models - available as gridded data and degree-10,800 spherical
+harmonics, International Journal of Applied Earth Observation and
+Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
+'''
+from pooch import os_cache as _os_cache
+from pooch import retrieve as _retrieve
+from pooch import HTTPDownloader as _HTTPDownloader
+from ....shclasses import SHCoeffs as _SHCoeffs
+
+
+def surface(lmax=2160):
+    '''
+    Earth's physical surface: Harmonic model of the interface between the
+    atmosphere and Earth's surface (including water and ice).
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Hirt, C., Rexer, M. (2015). Earth2014: 1 arc-min shape, topography, bedrock
+    and ice-sheet models - available as gridded data and degree-10,800
+    spherical harmonics, International Journal of Applied Earth Observation and
+    Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
+    '''
+    fname = _retrieve(
+        url="http://ddfe.curtin.edu.au/gravitymodels/Earth2014/data_5min/shcs_to2160/Earth2014.SUR2014.degree2160.bshc",  # noqa: E501
+        known_hash="sha256:5694260d135c17427270ed18d48af23f4788e5fbc1dfb9dcb19f1cf9b401c9ce",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHCoeffs.from_file(fname, lmax=lmax, format='bshc')
+
+
+def bedrock(lmax=2160):
+    '''
+    Earth's bedrock: Harmonic model of the surface relief, excluding water
+    and ice masses.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Hirt, C., Rexer, M. (2015). Earth2014: 1 arc-min shape, topography, bedrock
+    and ice-sheet models - available as gridded data and degree-10,800
+    spherical harmonics, International Journal of Applied Earth Observation and
+    Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
+    '''
+    fname = _retrieve(
+        url="http://ddfe.curtin.edu.au/gravitymodels/Earth2014/data_5min/shcs_to2160/Earth2014.BED2014.degree2160.bshc",  # noqa: E501
+        known_hash="sha256:146dcc80f17d201352d391aa90f487f5ed16006a6a3966add2d023b998727af7",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHCoeffs.from_file(fname, lmax=lmax, format='bshc')
+
+
+def tbi(lmax=2160):
+    '''
+    Topography of Earth's bedrock and ice: Harmonic model of the surface
+    relief, excluding water masses.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Hirt, C., Rexer, M. (2015). Earth2014: 1 arc-min shape, topography, bedrock
+    and ice-sheet models - available as gridded data and degree-10,800
+    spherical harmonics, International Journal of Applied Earth Observation and
+    Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
+    '''
+    fname = _retrieve(
+        url="http://ddfe.curtin.edu.au/gravitymodels/Earth2014/data_5min/shcs_to2160/Earth2014.TBI2014.degree2160.bshc",  # noqa: E501
+        known_hash="sha256:84a72ef25fe26fd746d2c6988c01840a12e9e414ee266e9357acb81faaaa6d5f",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHCoeffs.from_file(fname, lmax=lmax, format='bshc')
+
+
+def ret(lmax=2160):
+    '''
+    Earth's rock-equivalent topography: Harmonic model of Earth's rock
+    equivalent topography, where ice and water masses are condensed to layers
+    of rock using a density of 2670 kg/m3.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Hirt, C., Rexer, M. (2015). Earth2014: 1 arc-min shape, topography, bedrock
+    and ice-sheet models - available as gridded data and degree-10,800
+    spherical harmonics, International Journal of Applied Earth Observation and
+    Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
+    '''
+    fname = _retrieve(
+        url="http://ddfe.curtin.edu.au/gravitymodels/Earth2014/data_5min/shcs_to2160/Earth2014.RET2014.degree2160.bshc",  # noqa: E501
+        known_hash="sha256:1fa87749532811614c00e9723dae1aa312e5511570d101bccb74bc40cb7dd5d1",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHCoeffs.from_file(fname, lmax=lmax, format='bshc')
+
+
+def ice(lmax=2160):
+    '''
+    Thickness of Earth's ice sheets: Harmonic model of the thickness of
+    Earth's ice masses.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Hirt, C., Rexer, M. (2015). Earth2014: 1 arc-min shape, topography, bedrock
+    and ice-sheet models - available as gridded data and degree-10,800
+    spherical harmonics, International Journal of Applied Earth Observation and
+    Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
+    '''
+    fname = _retrieve(
+        url="http://ddfe.curtin.edu.au/gravitymodels/Earth2014/data_5min/shcs_to2160/Earth2014.ICE2014.degree2160.bshc",  # noqa: E501
+        known_hash="sha256:04cd185cc668eba6f9bd1db527c4985703cce8d1a9fb993509e625e2bbecc78e",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHCoeffs.from_file(fname, lmax=lmax, format='bshc')
+
+
+__all__ = ['surface', 'bedrock', 'tbi', 'ret', 'ice']

--- a/pyshtools/datasets/Earth/Earth2014/__init__.py
+++ b/pyshtools/datasets/Earth/Earth2014/__init__.py
@@ -11,9 +11,9 @@ ice       :  Thickness of Earth's ice sheets
 Reference
 ---------
 Hirt, C., Rexer, M. (2015). Earth2014: 1 arc-min shape, topography, bedrock
-and ice-sheet models - available as gridded data and degree-10,800 spherical
-harmonics, International Journal of Applied Earth Observation and
-Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
+    and ice-sheet models - available as gridded data and degree-10,800
+    spherical harmonics, International Journal of Applied Earth Observation and
+    Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
 '''
 from pooch import os_cache as _os_cache
 from pooch import retrieve as _retrieve
@@ -34,9 +34,9 @@ def surface(lmax=2160):
     Reference
     ---------
     Hirt, C., Rexer, M. (2015). Earth2014: 1 arc-min shape, topography, bedrock
-    and ice-sheet models - available as gridded data and degree-10,800
-    spherical harmonics, International Journal of Applied Earth Observation and
-    Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
+        and ice-sheet models - available as gridded data and degree-10,800
+        spherical harmonics, International Journal of Applied Earth Observation
+        and Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
     '''
     fname = _retrieve(
         url="http://ddfe.curtin.edu.au/gravitymodels/Earth2014/data_5min/shcs_to2160/Earth2014.SUR2014.degree2160.bshc",  # noqa: E501
@@ -60,9 +60,9 @@ def bedrock(lmax=2160):
     Reference
     ---------
     Hirt, C., Rexer, M. (2015). Earth2014: 1 arc-min shape, topography, bedrock
-    and ice-sheet models - available as gridded data and degree-10,800
-    spherical harmonics, International Journal of Applied Earth Observation and
-    Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
+        and ice-sheet models - available as gridded data and degree-10,800
+        spherical harmonics, International Journal of Applied Earth Observation
+        and Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
     '''
     fname = _retrieve(
         url="http://ddfe.curtin.edu.au/gravitymodels/Earth2014/data_5min/shcs_to2160/Earth2014.BED2014.degree2160.bshc",  # noqa: E501
@@ -86,9 +86,9 @@ def tbi(lmax=2160):
     Reference
     ---------
     Hirt, C., Rexer, M. (2015). Earth2014: 1 arc-min shape, topography, bedrock
-    and ice-sheet models - available as gridded data and degree-10,800
-    spherical harmonics, International Journal of Applied Earth Observation and
-    Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
+        and ice-sheet models - available as gridded data and degree-10,800
+        spherical harmonics, International Journal of Applied Earth Observation
+        and Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
     '''
     fname = _retrieve(
         url="http://ddfe.curtin.edu.au/gravitymodels/Earth2014/data_5min/shcs_to2160/Earth2014.TBI2014.degree2160.bshc",  # noqa: E501
@@ -113,9 +113,9 @@ def ret(lmax=2160):
     Reference
     ---------
     Hirt, C., Rexer, M. (2015). Earth2014: 1 arc-min shape, topography, bedrock
-    and ice-sheet models - available as gridded data and degree-10,800
-    spherical harmonics, International Journal of Applied Earth Observation and
-    Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
+        and ice-sheet models - available as gridded data and degree-10,800
+        spherical harmonics, International Journal of Applied Earth Observation
+        and Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
     '''
     fname = _retrieve(
         url="http://ddfe.curtin.edu.au/gravitymodels/Earth2014/data_5min/shcs_to2160/Earth2014.RET2014.degree2160.bshc",  # noqa: E501
@@ -139,9 +139,9 @@ def ice(lmax=2160):
     Reference
     ---------
     Hirt, C., Rexer, M. (2015). Earth2014: 1 arc-min shape, topography, bedrock
-    and ice-sheet models - available as gridded data and degree-10,800
-    spherical harmonics, International Journal of Applied Earth Observation and
-    Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
+        and ice-sheet models - available as gridded data and degree-10,800
+        spherical harmonics, International Journal of Applied Earth Observation
+        and Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
     '''
     fname = _retrieve(
         url="http://ddfe.curtin.edu.au/gravitymodels/Earth2014/data_5min/shcs_to2160/Earth2014.ICE2014.degree2160.bshc",  # noqa: E501

--- a/pyshtools/datasets/Earth/__init__.py
+++ b/pyshtools/datasets/Earth/__init__.py
@@ -1,0 +1,11 @@
+'''
+Datasets related to the planet Earth.
+
+Topography
+----------
+Earth2012
+'''
+from . import Earth2012
+
+
+__all__ = ['Earth2012']

--- a/pyshtools/datasets/Earth/__init__.py
+++ b/pyshtools/datasets/Earth/__init__.py
@@ -3,9 +3,11 @@ Datasets related to the planet Earth.
 
 Topography
 ----------
-Earth2012
+Earth2012     : Hirt et al. (2012)
+Earth2014     : Hirt et al. (2014)
 '''
 from . import Earth2012
+from . import Earth2014
 
 
-__all__ = ['Earth2012']
+__all__ = ['Earth2012', 'Earth2014']

--- a/pyshtools/datasets/Earth/__init__.py
+++ b/pyshtools/datasets/Earth/__init__.py
@@ -8,17 +8,22 @@ Earth2014                  :  Hirt and Rexer (2015)
 
 Gravity
 -------
-EGM2008                    :  Pavlis et al. (2012); degree 2190, combined
-EIGEN_6C4                  :  Förste et al. (2014); degree 2190, combined
-GGM05C                     :  Ries et al. (2016); degree 360, combined
+EGM2008                    :  Pavlis et al. (2012); degree 2190
+EIGEN_6C4                  :  Förste et al. (2014); degree 2190
+GGM05C                     :  Ries et al. (2016); degree 360
 GOCO06S                    :  Kvas et al. (2019); degree 300, satellite only
 EIGEN_GRGS_RL04_MEAN_FIELD :  Lemoine et al. (2019); degree 300, satellite only
-XGM2019E                   :  Zingerle et al. (2019); degree 2190, combined
+XGM2019E                   :  Zingerle et al. (2019); degree 2190
+
+Magnetic field
+--------------
+IGRF_13                    :  Thébault et al. (2015)
 '''
 from pooch import os_cache as _os_cache
 from pooch import retrieve as _retrieve
 from pooch import HTTPDownloader as _HTTPDownloader
 from ...shclasses import SHGravCoeffs as _SHGravCoeffs
+from ...shclasses import SHMagCoeffs as _SHMagCoeffs
 from ...constant.Earth import omega_egm2008 as _omega
 
 from . import Earth2012
@@ -202,5 +207,38 @@ def XGM2019E(lmax=2190):
                                    errors='formal', omega=_omega.value)
 
 
+def IGRF_13(lmax=13, year=2020.):
+    '''
+    IGRF-13 is a degree 13 time variable model of the Earth's main magnetic
+    field that is valid between 1900 and 2020. Coefficients are provided in 5
+    year intervals, and for a given year, the values of the coefficients are
+    interpolated linearly between adjacent entries. For years between 2020 and
+    2025, the coefficients are extrapolated using the provided secular
+    variation.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+    year : float, optional, default = 2020.
+        The year to compute the coefficients.
+
+    Reference
+    ---------
+    Thébault, E., and 47 coauthors (2015). International Geomagnetic Reference
+        Field: the 12th generation, Earth, Planets and Space, 67, 79,
+        doi:10.1186/s40623-015-0228-9.
+    '''
+    fname = _retrieve(
+        url="https://www.ngdc.noaa.gov/IAGA/vmod/coeffs/igrf13coeffs.txt",
+        known_hash="sha256:460b8d8beb9b4df84febe4f0b639f0dd54dccfe8ff0970616287b015fa721425",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHMagCoeffs.from_file(fname, format='igrf', r0=6371.2e3,
+                                  lmax=lmax, year=year)
+
+
 __all__ = ['Earth2012', 'Earth2014', 'EGM2008', 'EIGEN_6C4',
-           'GGM05C', 'GOCO06S', 'EIGEN_GRGS_RL04_MEAN_FIELD', 'XGM2019E']
+           'GGM05C', 'GOCO06S', 'EIGEN_GRGS_RL04_MEAN_FIELD', 'XGM2019E',
+           'IGRF_13']

--- a/pyshtools/datasets/Earth/__init__.py
+++ b/pyshtools/datasets/Earth/__init__.py
@@ -3,11 +3,204 @@ Datasets related to the planet Earth.
 
 Topography
 ----------
-Earth2012     : Hirt et al. (2012)
-Earth2014     : Hirt et al. (2014)
+Earth2012                  :  Hirt et al. (2012)
+Earth2014                  :  Hirt and Rexer (2015)
+
+Gravity
+-------
+EGM2008                    :  Pavlis et al. (2012); degree 2190, combined
+EIGEN_6C4                  :  Förste et al. (2014); degree 2190, combined
+GGM05C                     :  Ries et al. (2016); degree 360, combined
+GOCO06S                    :  Kvas et al. (2019); degree 300, satellite only
+EIGEN_GRGS_RL04_MEAN_FIELD :  Lemoine et al. (2019); degree 300, satellite only
+XGM2019E                   :  Zingerle et al. (2019); degree 2190, combined
 '''
+from pooch import os_cache as _os_cache
+from pooch import retrieve as _retrieve
+from pooch import HTTPDownloader as _HTTPDownloader
+from ...shclasses import SHGravCoeffs as _SHGravCoeffs
+from ...constant.Earth import omega_egm2008 as _omega
+
 from . import Earth2012
 from . import Earth2014
 
 
-__all__ = ['Earth2012', 'Earth2014']
+def EGM2008(lmax=2190):
+    '''
+    EGM2008 is a degree 2190 model of the Earth's gravity field in a
+    tide-free system. This model is based on data from altimetry, ground-based
+    measurements, and the satellite GRACE. The error coefficients are
+    calibrated.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Pavlis, N. K., Holmes, S. A., Kenyon, S. C., Factor, J. K. (2012). The
+        development and evaluation of the Earth Gravitational Model 2008
+        (EGM2008), Journal of Geophysical Research: Solid Earth, 117, B04406,
+        doi:10.1029/2011JB008916.
+    '''
+    fname = _retrieve(
+        url="http://icgem.gfz-potsdam.de/getmodel/gfc/c50128797a9cb62e936337c890e4425f03f0461d7329b09a8cc8561504465340/EGM2008.gfc",  # noqa: E501
+        known_hash="sha256:ab5b524da073e63b5bdceb7ca47a0de07a26dd44a1c5798f39fc98dc80af70fd",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, format='icgem',
+                                   errors='calibrated', omega=_omega.value)
+
+
+def EIGEN_6C4(lmax=2190):
+    '''
+    EIGEN_6C4 is a degree 2190 model of the Earth's gravity field in a
+    tide-free system. This model is based on data from altimetry, ground-based
+    measurements, and the satellites GOCE, GRACE, and LAGEOS. The error
+    coefficients are formal.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Förste, C., Bruinsma, S. L., Abrikosov, O., Lemoine, J.-M., Marty, J. C.,
+        Flechtner, F., Balmino, G., Barthelmes, F., Biancale, R. (2014).
+        EIGEN-6C4 The latest combined global gravity field model including GOCE
+        data up to degree and order 2190 of GFZ Potsdam and GRGS Toulouse, GFZ
+        Data Services, http://doi.org/10.5880/icgem.2015.1.
+    '''
+    fname = _retrieve(
+        url="http://icgem.gfz-potsdam.de/getmodel/gfc/7fd8fe44aa1518cd79ca84300aef4b41ddb2364aef9e82b7cdaabdb60a9053f1/EIGEN-6C4.gfc",  # noqa: E501
+        known_hash="sha256:2ac274a66a25fb25bdddcec7074669867939345ad003bbc1ece3967450d48dc1",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, format='icgem',
+                                   errors='formal', omega=_omega.value,
+                                   encoding='iso-8859-1')
+
+
+def GGM05C(lmax=360):
+    '''
+    GGM05C is a degree 360 model of the Earth's gravity field in a zero-tide
+    system. This model is based on data from altimetry, ground-based
+    measurements, and the satellites GOCE and GRACE. The error coefficients are
+    calibrated.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Ries, J., Bettadpur, S., Eanes, R., Kang, Z., Ko, U., McCullough, C.,
+        Nagel, P., Pie, N., Poole, S., Richter, T., Save, H., Tapley, B.
+        (2016). The Combined Gravity Model GGM05C, GFZ Data Services,
+        http://doi.org/10.5880/icgem.2016.002.
+    '''
+    fname = _retrieve(
+        url="http://icgem.gfz-potsdam.de/getmodel/gfc/778a683780a5b0ad3163f4772b97b9075a0a13c389d2bd8ea3f891b64cfa383d/GGM05C.gfc",  # noqa: E501
+        known_hash="sha256:efb1781e748969dab2721f45365cd060b5963ffe4fd497006cc786f9e5241bf2",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, format='icgem',
+                                   errors='calibrated', omega=_omega.value)
+
+
+def GOCO06S(lmax=300):
+    '''
+    GOCO06S is a degree 300 model of the Earth's gravity field in a zero-tide
+    system. This model is based solely on satellite data. The error
+    coefficients are formal.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Kvas, A., Mayer-Gürr, T., Krauss, S., Brockmann, J. M., Schubert, T.,
+        Schuh, W.-D., Pail, R., Gruber, T., Jäggi, A., Meyer, U. (2019).
+        The satellite-only gravity field model GOCO06s, GFZ Data Services,
+        http://doi.org/10.5880/ICGEM.2019.002.
+    '''
+    fname = _retrieve(
+        url="http://icgem.gfz-potsdam.de/getmodel/gfc/32ec2884630a02670476f752d2a2bf1c395d8c8d6d768090ed95b4f04b0d5863/GOCO06s.gfc",  # noqa: E501
+        known_hash="sha256:351d9d20b84cd2c0f52ce77146b1e3b774f408200b579ffaf98593cf3d271819",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, format='icgem',
+                                   errors='formal', omega=_omega.value)
+
+
+def EIGEN_GRGS_RL04_MEAN_FIELD(epoch=None, lmax=300):
+    '''
+    EIGEN_GRGS_RL04_MEAN_FIELD is a degree 300 model of the Earth's gravity
+    field in a tide-free system. This model is based solely on satellite
+    data. The error coefficients are formal.
+
+    Parameters
+    ----------
+    epoch : str or float
+        The epoch time to calculate time-variable coefficients in YYYYMMDD.DD
+        format.
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Lemoine, J.-M., Bourgogne, S., Biancale, R., Reinquin, F. (2019). The new
+        time-variable gravity field model for POD of altimetric satellites
+        based on GRACE+SLR RL04 from CNES/GRGS, IDS Workshop, 24-29 September,
+        Ponta Delgada, Portugal.
+    '''
+    fname = _retrieve(
+        url="http://icgem.gfz-potsdam.de/getmodel/gfc/96e984f23a31505411d943341767e9ff082ad2c77fbbdcba1be2e393cf35110a/EIGEN-GRGS.RL04.MEAN-FIELD.gfc",  # noqa: E501
+        known_hash="sha256:ea5d99d84da42d0eedccb381c282604a1a42fd64d1f9e25bba796b7e8838732f",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, format='icgem',
+                                   errors='formal', omega=_omega.value,
+                                   epoch=epoch)
+
+
+def XGM2019E(lmax=2190):
+    '''
+    XGM2019E is a degree 2190 experimental model of the Earth's gravity field
+    in a zero-tide system. This model is based on data from altimetry,
+    ground-based measurements, topography, and satellites. The error
+    coefficients are formal.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Zingerle, P., Pail, R., Gruber, T., Oikonomidou, X. (2019). The
+        experimental gravity field model XGM2019e, GFZ Data Services,
+        http://doi.org/10.5880/ICGEM.2019.007.
+    '''
+    fname = _retrieve(
+        url="http://icgem.gfz-potsdam.de/getmodel/gfc/eeb03971cf6e533e6eeb6b010336463286dcda0846684248d5530acf8e800055/XGM2019e_2159.gfc",  # noqa: E501
+        known_hash="sha256:ee24f7cf68f45b44cdbf3ccbf57e7382c7667869356061419f00f2ca951861e4",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, format='icgem',
+                                   errors='formal', omega=_omega.value)
+
+
+__all__ = ['Earth2012', 'Earth2014', 'EGM2008', 'EIGEN_6C4',
+           'GGM05C', 'GOCO06S', 'EIGEN_GRGS_RL04_MEAN_FIELD', 'XGM2019E']

--- a/pyshtools/datasets/Mars.py
+++ b/pyshtools/datasets/Mars.py
@@ -111,28 +111,12 @@ def Morschhauser2014(lmax=110, nt=True):
         url="https://zenodo.org/record/3876495/files/Morschhauser2014.txt.gz?download=1",  # noqa: E501
         known_hash="sha256:a86200b3147a24447ff8bba88ec6047329823275813a9f5e9505bb611e3e86e0",  # noqa: E501
         downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
         processor=_Decompress(),
     )
-
     r0 = 3393.5e3
-    lmax = 110
-
-    with open(fname, 'r') as f:
-        lines = f.readlines()
-        coeffs = _np.zeros([2, lmax+1, lmax+1])
-
-        for x in lines[3:]:
-            degree = int(x.split()[0])
-            order = int(x.split()[1])
-            d = float(x.split()[2])
-
-            if degree <= lmax:
-                if order >= 0:
-                    coeffs[0, degree, order] = d
-                else:
-                    coeffs[1, degree, abs(order)] = d
-
-    temp = _SHMagCoeffs.from_array(coeffs, r0=r0)
+    temp = _SHMagCoeffs.from_file(fname, r0=r0, skip=3, header=False,
+                                  format='dov')
 
     if nt:
         return temp
@@ -162,6 +146,7 @@ def GMM3(lmax=120):
         url="https://pds-geosciences.wustl.edu/mro/mro-m-rss-5-sdp-v1/mrors_1xxx/data/shadr/gmm3_120_sha.tab",  # noqa: E501
         known_hash="sha256:eb4913b1afb6682406e6a9dad5be7918a162fa8462473c9a2e7aae258d4c2c9c",  # noqa: E501
         downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
                                    r0_index=0, gm_index=1, errors=True)
@@ -190,6 +175,7 @@ def GMM3_RM1_1E0(lmax=150):
         url="https://core2.gsfc.nasa.gov/PGDA/data/MarsDensityRM1/sha.gmm3_l150_rm1_lambda_1",  # noqa: E501
         known_hash="sha256:b309917362bd2014df42a62cb19ea321ee8db97997b0688eda2774deb46ef538",  # noqa: E501
         downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='m',
                                    r0_index=1, gm_index=0, errors=False)
@@ -216,6 +202,7 @@ def MRO120D(lmax=120):
         url="https://pds-geosciences.wustl.edu/mro/mro-m-rss-5-sdp-v1/mrors_1xxx/data/shadr/jgmro_120d_sha.tab",  # noqa: E501
         known_hash="sha256:00c3a2fada7bdfb8022962752b1226be1de21ea469f9e88af5d8dc47d23883bd",  # noqa: E501
         downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
                                    r0_index=0, gm_index=1, errors=True)

--- a/pyshtools/datasets/Mars.py
+++ b/pyshtools/datasets/Mars.py
@@ -1,0 +1,225 @@
+'''
+Datasets related to the planet Mars.
+
+Topography
+----------
+MarsTopo2600     :  Wieczorek (2015)
+
+Gravity
+-------
+GMM3             :  Genova et al. (2016)
+GMM3_RM1_1E0     :  Goossens et al. (2017)
+MRO120D          :  Konopliv et al. (2016)
+
+Magnetic field
+--------------
+Langlais2019     :  Langlais et al. (2019)
+Morschhauser2014 :  Morschhauser et al. (2014)
+'''
+import numpy as _np
+from pooch import os_cache as _os_cache
+from pooch import retrieve as _retrieve
+from pooch import HTTPDownloader as _HTTPDownloader
+from ..shclasses import SHCoeffs as _SHCoeffs
+from ..shclasses import SHGravCoeffs as _SHGravCoeffs
+from ..shclasses import SHMagCoeffs as _SHMagCoeffs
+from pooch import Decompress as _Decompress
+
+
+def MarsTopo2600(lmax=2600):
+    '''
+    MarsTopo2600 is a 2600 degree and order spherical harmonic model of the
+    shape of the planet Mars. The coefficients are in units of meters.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Wieczorek, M.A. (2015). Gravity and Topography of the Terrestrial Planets,
+        Treatise on Geophysics, 2nd edition, Oxford, 153-193,
+        doi:10.1016/B978-0-444-53802-4.00169-X.
+    '''
+    fname = _retrieve(
+        url="https://zenodo.org/record/3870922/files/MarsTopo2600.shape.gz",
+        known_hash="sha256:8882a9ee7ee405d971b752028409f69bd934ba5411f1c64eaacd149e3b8642af",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHCoeffs.from_file(fname, lmax=lmax)
+
+
+def Langlais2019(lmax=134, nt=True):
+    '''
+    Langlais2019 is a 134 degree and order spherical harmonic model of the
+    magnetic potential of Mars. This model makes use of data from MGS MAG,
+    MGS ER and MAVEN MAG. By default, the coefficients will be output in
+    units of nT.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+    nt : bool, optional, default = True
+        If true, the returned coefficients will be in units of nT. If false,
+        the coefficients will have units of Teslas.
+
+    References
+    ----------
+    Langlais, B., Thébault, E., Houliez, A., Purucker, M.E., Lillis, R.J.
+        (2019). A new model of the crustal magnetic field of Mars using MGS
+        and MAVEN. Journal of Geophysical Research: Planets, 124, 1542-1569,
+        doi:10.1029/2018JE005854.
+    '''
+    fname = _retrieve(
+        url="https://zenodo.org/record/3876714/files/Langlais2019.sh.gz?download=1",  # noqa: E501
+        known_hash="sha256:3cad9e268f0673be1702f1df504a4cbcb8dba4480c7b3f629921911488fe247b",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    temp = _SHMagCoeffs.from_file(fname, lmax=lmax, skip=4, r0=3393.5e3,
+                                  header=False)
+    if nt:
+        return temp
+    else:
+        return temp / 1.e9
+
+
+def Morschhauser2014(lmax=110, nt=True):
+    '''
+    Morschhauser2014 is a 110 degree and order spherical harmonic model of the
+    magnetic potential of Mars. By default, the coefficients will be output in
+    units of nT.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+    nt : bool, optional, default = True
+        If true, the returned coefficients will be in units of nT. If false,
+        the coefficients will have units of Teslas.
+
+    References
+    ----------
+    Morschhauser, A., Lesur, V., Grott, M. (2014). A spherical harmonic model
+        of the lithospheric magnetic ﬁeld of Mars, Journal of Geophysical
+        Research: Planets, 119, 1162-1188, doi:10.1002/2013JE004555.
+    '''
+    fname = _retrieve(
+        url="https://zenodo.org/record/3876495/files/Morschhauser2014.txt.gz?download=1",  # noqa: E501
+        known_hash="sha256:a86200b3147a24447ff8bba88ec6047329823275813a9f5e9505bb611e3e86e0",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        processor=_Decompress(),
+    )
+
+    r0 = 3393.5e3
+    lmax = 110
+
+    with open(fname, 'r') as f:
+        lines = f.readlines()
+        coeffs = _np.zeros([2, lmax+1, lmax+1])
+
+        for x in lines[3:]:
+            degree = int(x.split()[0])
+            order = int(x.split()[1])
+            d = float(x.split()[2])
+
+            if degree <= lmax:
+                if order >= 0:
+                    coeffs[0, degree, order] = d
+                else:
+                    coeffs[1, degree, abs(order)] = d
+
+    temp = _SHMagCoeffs.from_array(coeffs, r0=r0)
+
+    if nt:
+        return temp
+    else:
+        return temp / 1.e9
+
+
+def GMM3(lmax=120):
+    '''
+    GMM3 is a GSFC 120 degree and order spherical harmonic model of the
+    gravitational potential of Mars. This model applies a Kaula constraint for
+    degrees greater than 90.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Genova, A., Goossens, S., Lemoine, F.G., Mazarico, E., Neumann, G.A.,
+        Smith, D.E., Zuber, M.T. (2016). Seasonal and static gravity field of
+        Mars from MGS, Mars Odyssey and MRO radio science, Icarus, 272,
+        228-245, doi:10.1016/j.icarus.2016.02.050.
+    '''
+    fname = _retrieve(
+        url="https://pds-geosciences.wustl.edu/mro/mro-m-rss-5-sdp-v1/mrors_1xxx/data/shadr/gmm3_120_sha.tab",  # noqa: E501
+        known_hash="sha256:eb4913b1afb6682406e6a9dad5be7918a162fa8462473c9a2e7aae258d4c2c9c",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
+                                   r0_index=0, gm_index=1, errors=True)
+
+
+def GMM3_RM1_1E0(lmax=150):
+    '''
+    GMM3_RM1_1E0 is a GSFC 150 degree and order spherical harmonic model of the
+    gravitational potential of Mars. This model uses the same data as GMM3, but
+    with a rank-minus-1 constraint based on gravity from surface topography for
+    degrees greater than 50 with a value of lambda equal to 1.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Goossens, S., Sabaka, T.J., Genova, A, Mazarico, E., Nicholas, J.B.,
+        Neumann, G.A. (2017), Evidence for a low bulk crustal density for Mars
+        from gravity and topography, Geophysical Research Letters, 44,
+        7686-7694, doi:10.1002/2017GL074172.
+    '''
+    fname = _retrieve(
+        url="https://core2.gsfc.nasa.gov/PGDA/data/MarsDensityRM1/sha.gmm3_l150_rm1_lambda_1",  # noqa: E501
+        known_hash="sha256:b309917362bd2014df42a62cb19ea321ee8db97997b0688eda2774deb46ef538",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='m',
+                                   r0_index=1, gm_index=0, errors=False)
+
+
+def MRO120D(lmax=120):
+    '''
+    MRO120D is a JPL 120 degree and order spherical harmonic model of the
+    gravitational potential of Mars. This model applies a Kaula constraint for
+    degrees greater than 80.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Konopliv, A.S., Park, R.S., Folkner, W.M. (2016). An improved JPL Mars
+        gravity field and orientation from Mars orbiter and lander tracking
+        data. Icarus, 274, 253-260, doi:10.1016/j.icarus.2016.02.052.
+    '''
+    fname = _retrieve(
+        url="https://pds-geosciences.wustl.edu/mro/mro-m-rss-5-sdp-v1/mrors_1xxx/data/shadr/jgmro_120d_sha.tab",  # noqa: E501
+        known_hash="sha256:00c3a2fada7bdfb8022962752b1226be1de21ea469f9e88af5d8dc47d23883bd",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
+                                   r0_index=0, gm_index=1, errors=True)
+
+
+__all__ = ['MarsTopo2600', 'Langlais2019', 'Morschhauser2014', 'GMM3',
+           'GMM3_RM1_1E0', 'MRO120D']

--- a/pyshtools/datasets/Mars.py
+++ b/pyshtools/datasets/Mars.py
@@ -16,7 +16,6 @@ Magnetic field
 Langlais2019     :  Langlais et al. (2019)
 Morschhauser2014 :  Morschhauser et al. (2014)
 '''
-import numpy as _np
 from pooch import os_cache as _os_cache
 from pooch import retrieve as _retrieve
 from pooch import HTTPDownloader as _HTTPDownloader
@@ -49,79 +48,6 @@ def MarsTopo2600(lmax=2600):
         path=_os_cache('pyshtools'),
     )
     return _SHCoeffs.from_file(fname, lmax=lmax)
-
-
-def Langlais2019(lmax=134, nt=True):
-    '''
-    Langlais2019 is a 134 degree and order spherical harmonic model of the
-    magnetic potential of Mars. This model makes use of data from MGS MAG,
-    MGS ER and MAVEN MAG. By default, the coefficients will be output in
-    units of nT.
-
-    Parameters
-    ----------
-    lmax : int, optional
-        The maximum spherical harmonic degree to return.
-    nt : bool, optional, default = True
-        If true, the returned coefficients will be in units of nT. If false,
-        the coefficients will have units of Teslas.
-
-    References
-    ----------
-    Langlais, B., Thébault, E., Houliez, A., Purucker, M.E., Lillis, R.J.
-        (2019). A new model of the crustal magnetic field of Mars using MGS
-        and MAVEN. Journal of Geophysical Research: Planets, 124, 1542-1569,
-        doi:10.1029/2018JE005854.
-    '''
-    fname = _retrieve(
-        url="https://zenodo.org/record/3876714/files/Langlais2019.sh.gz?download=1",  # noqa: E501
-        known_hash="sha256:3cad9e268f0673be1702f1df504a4cbcb8dba4480c7b3f629921911488fe247b",  # noqa: E501
-        downloader=_HTTPDownloader(progressbar=True),
-        path=_os_cache('pyshtools'),
-    )
-    temp = _SHMagCoeffs.from_file(fname, lmax=lmax, skip=4, r0=3393.5e3,
-                                  header=False)
-    if nt:
-        return temp
-    else:
-        return temp / 1.e9
-
-
-def Morschhauser2014(lmax=110, nt=True):
-    '''
-    Morschhauser2014 is a 110 degree and order spherical harmonic model of the
-    magnetic potential of Mars. By default, the coefficients will be output in
-    units of nT.
-
-    Parameters
-    ----------
-    lmax : int, optional
-        The maximum spherical harmonic degree to return.
-    nt : bool, optional, default = True
-        If true, the returned coefficients will be in units of nT. If false,
-        the coefficients will have units of Teslas.
-
-    References
-    ----------
-    Morschhauser, A., Lesur, V., Grott, M. (2014). A spherical harmonic model
-        of the lithospheric magnetic ﬁeld of Mars, Journal of Geophysical
-        Research: Planets, 119, 1162-1188, doi:10.1002/2013JE004555.
-    '''
-    fname = _retrieve(
-        url="https://zenodo.org/record/3876495/files/Morschhauser2014.txt.gz?download=1",  # noqa: E501
-        known_hash="sha256:a86200b3147a24447ff8bba88ec6047329823275813a9f5e9505bb611e3e86e0",  # noqa: E501
-        downloader=_HTTPDownloader(progressbar=True),
-        path=_os_cache('pyshtools'),
-        processor=_Decompress(),
-    )
-    r0 = 3393.5e3
-    temp = _SHMagCoeffs.from_file(fname, r0=r0, skip=3, header=False,
-                                  format='dov')
-
-    if nt:
-        return temp
-    else:
-        return temp / 1.e9
 
 
 def GMM3(lmax=120):
@@ -208,5 +134,76 @@ def MRO120D(lmax=120):
                                    r0_index=0, gm_index=1, errors=True)
 
 
-__all__ = ['MarsTopo2600', 'Langlais2019', 'Morschhauser2014', 'GMM3',
-           'GMM3_RM1_1E0', 'MRO120D']
+def Langlais2019(lmax=134, nt=True):
+    '''
+    Langlais2019 is a 134 degree and order spherical harmonic model of the
+    magnetic potential of Mars. This model makes use of data from MGS MAG,
+    MGS ER and MAVEN MAG. By default, the coefficients will be output in
+    units of nT.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+    nt : bool, optional, default = True
+        If true, the returned coefficients will be in units of nT. If false,
+        the coefficients will have units of Teslas.
+
+    References
+    ----------
+    Langlais, B., Thébault, E., Houliez, A., Purucker, M.E., Lillis, R.J.
+        (2019). A new model of the crustal magnetic field of Mars using MGS
+        and MAVEN. Journal of Geophysical Research: Planets, 124, 1542-1569,
+        doi:10.1029/2018JE005854.
+    '''
+    fname = _retrieve(
+        url="https://zenodo.org/record/3876714/files/Langlais2019.sh.gz?download=1",  # noqa: E501
+        known_hash="sha256:3cad9e268f0673be1702f1df504a4cbcb8dba4480c7b3f629921911488fe247b",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    temp = _SHMagCoeffs.from_file(fname, lmax=lmax, skip=4, r0=3393.5e3,
+                                  header=False)
+    if nt:
+        return temp
+    else:
+        return temp / 1.e9
+
+
+def Morschhauser2014(lmax=110, nt=True):
+    '''
+    Morschhauser2014 is a 110 degree and order spherical harmonic model of the
+    magnetic potential of Mars. By default, the coefficients will be output in
+    units of nT.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+    nt : bool, optional, default = True
+        If true, the returned coefficients will be in units of nT. If false,
+        the coefficients will have units of Teslas.
+
+    References
+    ----------
+    Morschhauser, A., Lesur, V., Grott, M. (2014). A spherical harmonic model
+        of the lithospheric magnetic ﬁeld of Mars, Journal of Geophysical
+        Research: Planets, 119, 1162-1188, doi:10.1002/2013JE004555.
+    '''
+    fname = _retrieve(
+        url="https://zenodo.org/record/3876495/files/Morschhauser2014.txt.gz?download=1",  # noqa: E501
+        known_hash="sha256:a86200b3147a24447ff8bba88ec6047329823275813a9f5e9505bb611e3e86e0",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+        processor=_Decompress(),
+    )
+    temp = _SHMagCoeffs.from_file(fname, r0=3393.5e3, skip=3, header=False,
+                                  format='dov')
+    if nt:
+        return temp
+    else:
+        return temp / 1.e9
+
+
+__all__ = ['MarsTopo2600', 'GMM3', 'GMM3_RM1_1E0', 'MRO120D', 'Langlais2019',
+           'Morschhauser2014']

--- a/pyshtools/datasets/Mercury.py
+++ b/pyshtools/datasets/Mercury.py
@@ -1,0 +1,164 @@
+'''
+Datasets related to the planet Mercury.
+
+Topography
+----------
+GTMES150           :  Topography constructed using laser altimeter and
+                      occultation data.
+
+Gravity
+-------
+JGMESS160A         :  Konolpiv et al. (2020)
+JGMESS160A_ACCEL   :  Konolpiv et al. (2020)
+JGMESS160A_TOPOSIG :  Konolpiv et al. (2020)
+GGMES100V08        :  Genova et al. (2019)
+'''
+from pooch import os_cache as _os_cache
+from pooch import retrieve as _retrieve
+from pooch import HTTPDownloader as _HTTPDownloader
+from ..shclasses import SHCoeffs as _SHCoeffs
+from ..shclasses import SHGravCoeffs as _SHGravCoeffs
+
+
+def GTMES150(lmax=150):
+    '''
+    GTMES150 is a GSFC 150 degree and order spherical harmonic model of the
+    shape of the planet Mercury. This model is based on 26 million laser
+    altimeter measurements and 557 radio occultations. The coefficients are in
+    units of meters. Errors for the coefficients are given in the original
+    file, but are not output in this dataset.
+
+    Documentation for this model can be found on the PDS web site at
+    https://pds-geosciences.wustl.edu/
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+    '''
+    fname = _retrieve(
+        url="https://pds-geosciences.wustl.edu/messenger/mess-h-rss_mla-5-sdp-v1/messrs_1001/data/shadr/gtmes_150v05_sha.tab",  # noqa: E501
+        known_hash="sha256:c49d07c14b09c1b1ed1b4bfc4b42d2ff058875f5e949b50128b83ffa94c659b3",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHCoeffs.from_file(fname, lmax=lmax, header=True) * 1000.
+
+
+def JGMESS160A(lmax=160):
+    '''
+    JGMESS160A is a JPL 160 degree and order spherical harmonic model of the
+    gravitational potential of Mercury. This model applies a Kaula law
+    constraint to all degrees.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Konopliv, A.S., Park, R.S., Ermakov, A.I. (2020). The Mercury gravity
+        field, orientation, Love number, and ephemeris from the MESSENGER
+        radiometric tracking data, Icarus, 335, 253-260,
+        doi:10.1016/j.icarus.2019.07.020.
+    '''
+    fname = _retrieve(
+        url="https://pds-geosciences.wustl.edu/messenger/mess-h-rss_mla-5-sdp-v1/messrs_1001/data/shadr/jgmess_160a_sha.tab",  # noqa: E501
+        known_hash="sha256:14fa0129c4b5ef655e08a883a05a476a836a806349da607f84b3c2b2e3d899ca",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
+                                   errors=True)
+
+
+def JGMESS160A_ACCEL(lmax=160):
+    '''
+    JGMESS160A_ACCEL is a JPL 160 degree and order spherical harmonic model of
+    the gravitational potential of Mercury. This model applies a surface
+    acceleration constraint that is based on the degree strength given by the
+    coefficient covariance.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Konopliv, A.S., Park, R.S., Ermakov, A.I. (2020). The Mercury gravity
+        field, orientation, Love number, and ephemeris from the MESSENGER
+        radiometric tracking data, Icarus, 335, 253-260,
+        doi:10.1016/j.icarus.2019.07.020.
+    '''
+    fname = _retrieve(
+        url="https://pds-geosciences.wustl.edu/messenger/mess-h-rss_mla-5-sdp-v1/messrs_1001/data/shadr/jgmess_160a_accel_sha.tab",  # noqa: E501
+        known_hash="sha256:a0f99553fcea3d7d0c1395c89d8516f4e53e9e39893a2b82541ca1520b291423",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
+                                   errors=True)
+
+
+def JGMESS160A_TOPOSIG(lmax=160):
+    '''
+    JGMESS160A_TOPOSIG is a JPL 160 degree and order spherical harmonic model
+    of the gravitational potential of Mercury. This model applies a constraint
+    similar to the Kaula constraint except that the uncertainty is given by the
+    corresponding magnitude of the gravity derived from topography coefficient.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Konopliv, A.S., Park, R.S., Ermakov, A.I. (2020). The Mercury gravity
+        field, orientation, Love number, and ephemeris from the MESSENGER
+        radiometric tracking data, Icarus, 335, 253-260,
+        doi:10.1016/j.icarus.2019.07.020.
+    '''
+    fname = _retrieve(
+        url="https://pds-geosciences.wustl.edu/messenger/mess-h-rss_mla-5-sdp-v1/messrs_1001/data/shadr/jgmess_160a_toposig_sha.tab",  # noqa: E501
+        known_hash="sha256:ad6d77e55968b9ddaea9cde03cb00ad6b630c81e8509e413e5b5b11213b3d848",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
+                                   errors=True)
+
+
+def GGMES100V08(lmax=100):
+    '''
+    GGMES100V08 is a GSFC 100 degree and order spherical harmonic model of
+    the gravitational potential of Mercury. This model applies a Kaula
+    constraint to all degrees.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Genova, A., Goossens, S., Mazarico, E., Lemoine, F.G., Neumann, G.A.,
+        Kuang, W., Sabaka, T.J., Hauck, S.A. II, Smith, D.E., Solomon S.C.,
+        Zuber, M.T. (2019). Geodetic evidence that Mercury has a solid inner
+        core. Geophysical Research Letters, 46, 3625-3633,
+        doi:10.1029/2018GL081135.
+    '''
+    fname = _retrieve(
+        url="https://pds-geosciences.wustl.edu/messenger/mess-h-rss_mla-5-sdp-v1/messrs_1001/data/shadr/ggmes_100v08_sha.tab",  # noqa: E501
+        known_hash="sha256:f81b33663ced0c6e05c775aa2d8c6c8eb99c41a20d4063d240fed536e45058fd",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
+                                   errors=True)
+
+
+__all__ = ['GTMES150', 'JGMESS160A', 'JGMESS160A_ACCEL', 'JGMESS160A_TOPOSIG',
+           'GGMES100V08']

--- a/pyshtools/datasets/Moon.py
+++ b/pyshtools/datasets/Moon.py
@@ -1,0 +1,243 @@
+'''
+Datasets related to Earth's Moon.
+
+Topography
+----------
+MoonTopo2600p     :  Wieczorek (2015)
+
+Gravity
+-------
+GRGM900C          :  Lemoine et al. (2014)
+GRGM1200B         :  Goossens et al. (2020)
+GRGM1200B_RM1_1E0 :  Goossens et al. (2020)
+GL0900D           :  Konopliv et al. (2014)
+GL1500E           :  Konopliv et al. (2014)
+
+Magnetic field
+--------------
+T2015_449         :  Wieczorek (2018), using data from Tsunakawa et al. (2015)
+'''
+from pooch import os_cache as _os_cache
+from pooch import retrieve as _retrieve
+from pooch import HTTPDownloader as _HTTPDownloader
+from ..shclasses import SHCoeffs as _SHCoeffs
+from ..shclasses import SHGravCoeffs as _SHGravCoeffs
+from ..shclasses import SHMagCoeffs as _SHMagCoeffs
+
+
+def MoonTopo2600p(lmax=2600):
+    '''
+    MoonTopo2600p is a 2600 degree and order spherical harmonic model of the
+    shape of Earth's Moon in a principal axis coordinate system. The
+    coefficients are in units of meters.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Wieczorek, M.A. (2015). Gravity and Topography of the Terrestrial Planets,
+        Treatise on Geophysics, 2nd edition, Oxford, 153-193,
+        doi:10.1016/B978-0-444-53802-4.00169-X.
+    '''
+    fname = _retrieve(
+        url="https://zenodo.org/record/3870924/files/MoonTopo2600p.shape.gz",
+        known_hash="sha256:193146df894e2fef796df9d6142c78fae6fa5c183fd79d3f79eeb356602af69a",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHCoeffs.from_file(fname, lmax=lmax)
+
+
+def T2015_449(lmax=449, nt=True):
+    '''
+    T2015_449 is a 449 degree and order spherical harmonic model of the
+    magnetic potential of the Moon. This model was used in Wieczorek (2018) and
+    is a spherical harmonic expansion of the global magnetic field model of
+    Tsunakawa et al. (2015). By default, the coefficients will be output in
+    units of nT.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+    nt : bool, optional, default = True
+        If true, the returned coefficients will be in units of nT. If false,
+        the coefficients will have units of Teslas.
+
+    References
+    ----------
+    Tsunakawa, H., Takahashi, F., Shimizu, H., Shibuya, H., Matsushima, M.
+        (2015). Surface vector mapping of magnetic anomalies over the Moon
+        using Kaguya and Lunar Prospector observations, Journal of Geophysical
+        Research Planets, 120, 1160-1185, doi:10.1002/2014JE004785.
+    Wieczorek, M.A. (2018). Strength, depth, and geometry of magnetic sources
+        in the crust of the Moon from localized power spectrum analysis,
+        Journal of Geophysical Research Planets, 123, 291-316,
+        doi:10.1002/2017JE005418.
+    '''
+    fname = _retrieve(
+        url="https://zenodo.org/record/3873648/files/T2015_449.sh.gz",
+        known_hash="sha256:4db0b77b3863f38d6fb6e62c5c1116bf7123b77c5aad65df7dae598714edd655",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    temp = _SHMagCoeffs.from_file(fname, lmax=lmax, header=True)
+    if nt:
+        return temp * 1.e9
+    else:
+        return temp
+
+
+def GRGM900C(lmax=900):
+    '''
+    GRGM900C is a GSFC 900 degree and order spherical harmonic model of the
+    gravitational potential of the Moon. This model applies a Kaula constraint
+    for degrees greater than 600.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Lemoine, F.G., Goossens, S., Sabaka, T.J., Nicholas, J.B., Mazarico, E.,
+        Rowlands, D.D., Loomis, B.D., Chinn, D.S., Neumann, G.A., Smith, D.E.,
+        Zuber, M.T. (2014) GRGM900C: A degree 900 lunar gravity model from
+        GRAIL primary and extended mission data, Geophysical Research Letters,
+        41, 3382-3389, doi:10.1002/2014GL060027.
+    '''
+    fname = _retrieve(
+        url="https://pds-geosciences.wustl.edu/grail/grail-l-lgrs-5-rdr-v1/grail_1001/shadr/gggrx_0900c_sha.tab",  # noqa: E501
+        known_hash="sha256:dab6ab06e0d3d7cbc594ea4bd03151a65534ed5fdf4f147ae38662428c04454e",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
+                                   errors=True)
+
+
+def GRGM1200B(lmax=1200):
+    '''
+    GRGM1200B is a GSFC 1200 degree and order spherical harmonic model of the
+    gravitational potential of the Moon. This model applies a Kaula constraint
+    for degrees greater than 600.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Goossens, S., Sabaka, T.J., Wieczorek, M.A., Neumann, G.A., Mazarico, E.,
+        Lemoine, F.G., Nicholas, J.B., Smith. D.E., Zuber M.T. (2020).
+        High-resolution gravity field models from GRAIL data and implications
+        for models of the density structure of the Moon's crust. Journal of
+        Geophysical Research Planets, 125, e2019JE006086,
+        doi:10.1029/2019JE006086.
+    '''
+    fname = _retrieve(
+        url="https://core2.gsfc.nasa.gov/PGDA/data/MoonRM1/sha.grgm1200b_sigma",  # noqa: E501
+        known_hash="sha256:f08a988b43f3eaa5a2089045a9b7e41e02f16542c7912b87ea34366fafa39bc5",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='m',
+                                   r0_index=1, gm_index=0, errors=True)
+
+
+def GRGM1200B_RM1_1E0(lmax=1200):
+    '''
+    GRGM1200B_RM1_1E0 is a GSFC 1200 degree and order spherical harmonic model
+    of the gravitational potential of the Moon. This model uses a rank-minus-1
+    constraint based on gravity from surface topography for degrees greater
+    than 600 with a value of lambda equal to 1.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Goossens, S., Sabaka, T.J., Wieczorek, M.A., Neumann, G.A., Mazarico, E.,
+        Lemoine, F.G., Nicholas, J.B., Smith. D.E., Zuber M.T. (2020).
+        High-resolution gravity field models from GRAIL data and implications
+        for models of the density structure of the Moon's crust. Journal of
+        Geophysical Research Planets, 125, e2019JE006086,
+        doi:10.1029/2019JE006086.
+    '''
+    fname = _retrieve(
+        url="https://core2.gsfc.nasa.gov/PGDA/data/MoonRM1/sha.grgm1200b_rm1_1e0_sigma",  # noqa: E501
+        known_hash="sha256:d42536cc716f5da8e067aa79a253c310e9d53d1d3b3ae7b43fa4517654d20d35",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='m',
+                                   r0_index=1, gm_index=0, errors=True)
+
+
+def GL0900D(lmax=900):
+    '''
+    GL0900D is a JPL 900 degree and order spherical harmonic model of
+    the gravitational potential of the Moon. This model applies a Kaula
+    constraint for degrees greater than 700.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Konopliv, A.S., Park, R.S., Yuan, D.-N., Asmar, S.W., Watkins, M.M.,
+        Williams, J.G., Fahnestock, E., Kruizinga, G., Paik, M., Strekalov, D.,
+        Harvey, N., Smith, D.E., Zuber, M.T. (2014). High-resolution lunar
+        gravity fields from the GRAIL Primary and Extended Missions,
+        Geophysical Research Letters, 41, 1452-1458, doi:10.1002/2013GL059066.
+    '''
+    fname = _retrieve(
+        url="https://pds-geosciences.wustl.edu/grail/grail-l-lgrs-5-rdr-v1/grail_1001/shadr/jggrx_0900d_sha.tab",  # noqa: E501
+        known_hash="sha256:0ead4e6260729c53fe29dcc6d954d473e87eb3ae1f4d932496a1417fd62fcdc6",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
+                                   errors=True)
+
+
+def GL1500E(lmax=1500):
+    '''
+    GL1500E is a JPL 1500 degree and order spherical harmonic model of
+    the gravitational potential of the Moon. This model applies a Kaula
+    constraint for degrees greater than 700.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Konopliv, A.S., Park, R.S., Yuan, D.-N., Asmar, S.W., Watkins, M.M.,
+        Williams, J.G., Fahnestock, E., Kruizinga, G., Paik, M., Strekalov, D.,
+        Harvey, N., Smith, D.E., Zuber, M.T. (2014). High-resolution lunar
+        gravity fields from the GRAIL Primary and Extended Missions,
+        Geophysical Research Letters, 41, 1452-1458, doi:10.1002/2013GL059066.
+    '''
+    fname = _retrieve(
+        url="https://pds-geosciences.wustl.edu/grail/grail-l-lgrs-5-rdr-v1/grail_1001/shadr/jggrx_1500e_sha.tab",  # noqa: E501
+        known_hash="sha256:93a7467b9241f6f94c131126c87fd3b81cfc3d223c474ee3444bf162b7c97f5a",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
+                                   errors=True)
+
+
+__all__ = ['MoonTopo2600p', 'T2015_449', 'GRGM900C', 'GRGM1200B',
+           'GRGM1200B_RM1_1E0', 'GL0900D', 'GL1500E']

--- a/pyshtools/datasets/Venus.py
+++ b/pyshtools/datasets/Venus.py
@@ -1,0 +1,70 @@
+'''
+Datasets related to the planet Venus.
+
+Topography
+----------
+VenusTopo719 :  Wieczorek (2015)
+
+Gravity
+-------
+MGNP180U     :  Konopliv et al. (1999)
+'''
+from pooch import os_cache as _os_cache
+from pooch import retrieve as _retrieve
+from pooch import HTTPDownloader as _HTTPDownloader
+from ..shclasses import SHCoeffs as _SHCoeffs
+from ..shclasses import SHGravCoeffs as _SHGravCoeffs
+
+
+def VenusTopo719(lmax=719):
+    '''
+    VenusTopo719 is a 719 degree and order spherical harmonic model of the
+    shape of the planet Venus. The coefficients are in units of meters.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Wieczorek, M.A. (2015). Gravity and Topography of the Terrestrial Planets,
+        Treatise on Geophysics, 2nd edition, Oxford, 153-193,
+        doi:10.1016/B978-0-444-53802-4.00169-X.
+    '''
+    fname = _retrieve(
+        url="https://zenodo.org/record/3870926/files/VenusTopo719.shape.gz",
+        known_hash="sha256:9fcb04fb21eb7090df68e42458f6d7495a27ff62687b46534057ed608786cf3b",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHCoeffs.from_file(fname, lmax=lmax)
+
+
+def MGNP180U(lmax=180):
+    '''
+    MGNP180U is a JPL 180 degree and order spherical harmonic model of the
+    gravitational potential of Venus.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Konopliv, A.S., Banerdt, W.B., Sjogren, W.L. (1999). Venus gravity: 180th
+        degree and order model, Icarus, 139, 3-18, doi:10.1006/icar.1999.6086.
+    '''
+    fname = _retrieve(
+        url="https://pds-geosciences.wustl.edu/mgn/mgn-v-rss-5-gravity-l2-v1/mg_5201/gravity/shgj180u.a01",  # noqa: E501
+        known_hash="sha256:d59e2bb90c104ca1157681454a4c016ed4d1cb0e496861b1d3b35829403cf53b",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, skip=236, header=True,
+                                   r0_index=1, gm_index=2, header_units='km',
+                                   errors=True)
+
+
+__all__ = ['VenusTopo719', 'MGNP180U']

--- a/pyshtools/datasets/Vesta.py
+++ b/pyshtools/datasets/Vesta.py
@@ -1,0 +1,43 @@
+'''
+Datasets related to the asteroid (4) Vesta.
+
+Gravity
+-------
+VESTA20H :  Konopliv et al. (2014)
+'''
+from pooch import os_cache as _os_cache
+from pooch import retrieve as _retrieve
+from pooch import HTTPDownloader as _HTTPDownloader
+from ..shclasses import SHGravCoeffs as _SHGravCoeffs
+
+
+def VESTA20H(lmax=20):
+    '''
+    VESTA20H is a JPL 20 degree and order spherical harmonic model of the
+    gravitational potential of (4) Vesta.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Konopliv, A.S., Asmar, S.W., Park, R.S., Bills, B.G., Centinello, F.,
+        Chamberlin, A.B., Ermakov, A., Gaskell, R.W., Rambaux, N.,
+        Raymond, C.A., Russell, C.T., Smith, D.E., Tricarico, P., Zuber, M.T.
+        (2014). The Vesta gravity field, spin pole and rotation period,
+        landmark positions, and ephemeris from the Dawn tracking and optical
+        data. Icarus, 240, 103-117, doi:10.1016/j.icarus.2013.09.005.
+    '''
+    fname = _retrieve(
+        url="https://sbnarchive.psi.edu/pds3/dawn/grav/DWNVGRS_2/DATA/SHADR/JGDWN_VES20H_SHA.TAB",  # noqa: E501
+        known_hash="sha256:389bb30882b43b36877e9ff8bf54c55a210d7ba98cab88e9c4a1fa83ad8484b7",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
+                                   r0_index=0, gm_index=1, errors=True)
+
+
+__all__ = ['VESTA20H']

--- a/pyshtools/datasets/__init__.py
+++ b/pyshtools/datasets/__init__.py
@@ -1,0 +1,27 @@
+"""
+pyshtools datasets.
+
+To load a dataset, call the relevant method as in this example:
+
+    hlm = pysh.datasets.Venus.VenusTopo719()
+
+When accessing a pyshtools dataset, the file will first be downloaded from the
+orginal source and stored in the user's cache directory (if it had not been
+done previously). The file hash will be verified to ensure that it has not been
+modified, and the file will then be used to instantiate and return an SHCoeffs,
+SHGravCoeffs or SHMagCoeffs class instance.
+
+For datasets of spherical harmonic coefficients, the coefficients can be read
+up to a maximum specified degree by providing the optional variable lmax. For
+magnetic field data, the coefficients can be returned in Tesla or nT by
+use of the variable nt.
+"""
+from . import Mercury
+from . import Venus
+from . import Moon
+from . import Mars
+from . import Vesta
+from . import Ceres
+
+
+__all__ = ['Mercury', 'Venus', 'Moon', 'Mars', 'Vesta', 'Ceres']

--- a/pyshtools/datasets/__init__.py
+++ b/pyshtools/datasets/__init__.py
@@ -18,10 +18,11 @@ use of the variable nt.
 """
 from . import Mercury
 from . import Venus
+from . import Earth
 from . import Moon
 from . import Mars
 from . import Vesta
 from . import Ceres
 
 
-__all__ = ['Mercury', 'Venus', 'Moon', 'Mars', 'Vesta', 'Ceres']
+__all__ = ['Mercury', 'Venus', 'Earth', 'Moon', 'Mars', 'Vesta', 'Ceres']

--- a/pyshtools/shclasses/shcoeffsgrid.py
+++ b/pyshtools/shclasses/shcoeffsgrid.py
@@ -441,7 +441,7 @@ class SHCoeffs(object):
             ends with '.gz' or '.zip', the file will be uncompressed before
             parsing.
         format : str, optional, default = 'shtools'
-            'shtools' format or binary numpy 'npy' format.
+            'shtools' for generic ascii files, or 'npy' for binary numpy files.
         lmax : int, optional, default = None
             The maximum spherical harmonic degree to read from 'shtools'
             formatted files. The default is to read the entire file.
@@ -463,13 +463,26 @@ class SHCoeffs(object):
 
         Notes
         -----
-        If format='shtools', spherical harmonic coefficients will be read from
-        a text file. The optional parameter `skip` specifies how many lines
-        should be skipped before attempting to parse the file, the optional
-        parameter `header` specifies whether to read a list of values from a
-        header line, and the optional parameter `lmax` specifies the maximum
-        degree to read from the file. All lines that do not start with 2
-        integers and that are less than 3 words long will be treated as
+        If format='shtools', the spherical harmonic coefficients will be read
+        from a text file using the function pyshtools.shio.shread().
+
+        If format='npy', the spherical harmonic coefficients will be read from
+        a binary numpy 'npy' using the function numpy.load().
+
+        For 'shtools' formatted files, if filename starts with 'http://',
+        'https://', or 'ftp://', the file will be treated as a URL. In this
+        case, the file will be downloaded in its entirety before it is parsed.
+        If the filename ends with '.gz' or '.zip', the file will be
+        automatically uncompressed before parsing. For zip files, archives with
+        only a single file are supported. Note that reading '.gz' and '.zip'
+        files will be extremely slow if lmax is not specified.
+
+        For 'shtools' formatted files, the optional parameter `skip` specifies
+        how many lines should be skipped before attempting to parse the file,
+        the optional parameter `header` specifies whether to read a list of
+        values from a header line, and the optional parameter `lmax` specifies
+        the maximum degree to read from the file. All lines that do not start
+        with 2 integers and that are less than 3 words long will be treated as
         comments and ignored. For this format, each line of the file must
         contain
 
@@ -477,19 +490,7 @@ class SHCoeffs(object):
 
         where l and m are the spherical harmonic degree and order,
         respectively. The terms coeffs[1, l, 0] can be neglected as they are
-        zero. For more information, see `shio.shread()`.
-
-        If filename starts with http://, https://, or ftp://, the file will be
-        treated as a URL. In this case, the file will be downloaded in its
-        entirety before it is parsed.
-
-        If the filename ends with '.gz' or '.zip', the file will be
-        automatically uncompressed before parsing. For zip files, archives with
-        only a single file are supported. Note that reading '.gz' and '.zip'
-        files will be extremely slow if lmax is not specified.
-
-        If format='npy', a binary numpy 'npy' file will be read using
-        numpy.load().
+        zero.
         """
         if type(normalization) != str:
             raise ValueError('normalization must be a string. '
@@ -516,9 +517,11 @@ class SHCoeffs(object):
                                                        skip=skip, header=True)
             else:
                 coeffs, lmaxout = _shread(fname, lmax=lmax, skip=skip)
+
         elif format.lower() == 'npy':
             coeffs = _np.load(fname, **kwargs)
             lmaxout = coeffs.shape[1] - 1
+
         else:
             raise NotImplementedError(
                 'format={:s} not implemented.'.format(repr(format)))
@@ -530,6 +533,7 @@ class SHCoeffs(object):
                            "85. Input value is {:d}.".format(lmaxout),
                            category=RuntimeWarning)
             lmaxout = 85
+            coeffs = coeffs[:, :lmaxout+1, :lmaxout+1]
 
         if _np.iscomplexobj(coeffs):
             kind = 'complex'

--- a/pyshtools/shclasses/shcoeffsgrid.py
+++ b/pyshtools/shclasses/shcoeffsgrid.py
@@ -438,7 +438,7 @@ class SHCoeffs(object):
             File name or URL containing the spherical harmonic coefficients.
             filename will be treated as a URL if it starts with 'http://',
             'https://', or 'ftp://'. For shtools formatted files, if filename
-            ends with '.gz', the file will be uncompressed using gzip before
+            ends with '.gz' or '.zip', the file will be uncompressed before
             parsing.
         format : str, optional, default = 'shtools'
             'shtools' format or binary numpy 'npy' format.
@@ -483,8 +483,10 @@ class SHCoeffs(object):
         treated as a URL. In this case, the file will be downloaded in its
         entirety before it is parsed.
 
-        If the filename ends with '.gz', the file will be automatically
-        uncompressed using gzip before parsing.
+        If the filename ends with '.gz' or '.zip', the file will be
+        automatically uncompressed before parsing. For zip files, archives with
+        only a single file are supported. Note that reading '.gz' and '.zip'
+        files will be extremely slow if lmax is not specified.
 
         If format='npy', a binary numpy 'npy' file will be read using
         numpy.load().

--- a/pyshtools/shclasses/shcoeffsgrid.py
+++ b/pyshtools/shclasses/shcoeffsgrid.py
@@ -473,17 +473,11 @@ class SHCoeffs(object):
 
         Notes
         -----
-        If format='shtools', the spherical harmonic coefficients will be read
-        from a text file using the function pyshtools.shio.shread().
-
-        If format='dov', the spherical harmonic coefficients will be read
-        from a text file using the function pyshtools.shio.read_dov().
-
-        If format='bshc', the real spherical harmonic coefficients will be read
-        from a binary file using the function pyshtools.shio.read_bshc().
-
-        If format='npy', the spherical harmonic coefficients will be read from
-        a binary numpy 'npy' using the function numpy.load().
+        Supported file formats:
+            'shtools' (see pyshtools.shio.shread)
+            'dov' (see pyshtools.shio.shread)
+            'bshc' (see pyshtools.shio.read_bshc)
+            'npy' (see numpy.load)
 
         For 'shtools', 'dov' or 'bshc' formatted files, if filename starts with
         'http://', 'https://', or 'ftp://', the file will be treated as a URL.
@@ -525,7 +519,7 @@ class SHCoeffs(object):
             else:
                 coeffs, lmaxout = _shread(fname, lmax=lmax, skip=skip)
 
-        if format.lower() == 'dov':
+        elif format.lower() == 'dov':
             if header:
                 if header2:
                     coeffs, lmaxout, header_list, header2_list = \

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -350,12 +350,16 @@ class SHGravCoeffs(object):
         Parameters
         ----------
         filename : str
-            Name of the file, including path.
+            File name or URL containing the spherical harmonic coefficients.
+            filename will be treated as a URL if it starts with 'http://',
+            'https://', or 'ftp://'. For shtools formatted files, if filename
+            ends with '.gz', the file will be uncompressed using gzip before
+            parsing.
         format : str, optional, default = 'shtools'
             'shtools' format or binary numpy 'npy' format.
         lmax : int, optional, default = None
             The maximum spherical harmonic degree to read from 'shtools'
-            formatted files.
+            formatted files. The default is to read the entire file.
         header : bool, optional, default = True
             If True, read a list of values from the header line of an 'shtools'
             formatted file.
@@ -424,9 +428,14 @@ class SHGravCoeffs(object):
         l, m, coeffs[0, l, m], coeffs[1, l, m], error[0, l, m], error[1, l, m]
 
         If the degree 0 term of the file is zero (or not specified), this will
-        be set to 1. If filename starts with http://, https://, or ftp://, the
-        file will be treated as a URL. In this case, the file will be
-        downloaded in its entirety before it is parsed.
+        be set to 1.
+
+        If filename starts with http://, https://, or ftp://, the file will be
+        treated as a URL. In this case, the file will be downloaded in its
+        entirety before it is parsed.
+
+        If the filename ends with '.gz', the file will be automatically
+        uncompressed using gzip before parsing.
 
         If format='npy', a binary numpy 'npy' file will be read using
         numpy.load().

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -352,8 +352,8 @@ class SHGravCoeffs(object):
         filename : str
             File name or URL containing the spherical harmonic coefficients.
             filename will be treated as a URL if it starts with 'http://',
-            'https://', or 'ftp://'. For shtools formatted files, if filename
-            ends with '.gz', the file will be uncompressed using gzip before
+            'https://', or 'ftp://'. For shtools formatted files, ff filename
+            ends with '.gz' or '.zip', the file will be uncompressed before
             parsing.
         format : str, optional, default = 'shtools'
             'shtools' format or binary numpy 'npy' format.
@@ -434,8 +434,10 @@ class SHGravCoeffs(object):
         treated as a URL. In this case, the file will be downloaded in its
         entirety before it is parsed.
 
-        If the filename ends with '.gz', the file will be automatically
-        uncompressed using gzip before parsing.
+        If the filename ends with '.gz' or '.zip', the file will be
+        automatically uncompressed before parsing. For zip files, archives with
+        only a single file are supported. Note that reading '.gz' and '.zip'
+        files will be extremely slow if lmax is not specified.
 
         If format='npy', a binary numpy 'npy' file will be read using
         numpy.load().

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -331,7 +331,7 @@ class SHGravCoeffs(object):
                   omega=None, lmax=None, normalization='4pi', skip=0,
                   header=True, errors=False, csphase=1, r0_index=0, gm_index=1,
                   omega_index=None, header_units='m', set_degree0=True,
-                  epoch=None, **kwargs):
+                  epoch=None, encoding=None, **kwargs):
         """
         Initialize the class with spherical harmonic coefficients from a file.
 
@@ -343,7 +343,7 @@ class SHGravCoeffs(object):
                                    header_units, set_degree0])
         x = SHGravCoeffs.from_file(filename, format='icgem', [lmax, omega,
                                    normalization, csphase, errors, set_degree0,
-                                   epoch])
+                                   epoch, encoding])
         x = SHGravCoeffs.from_file(filename, format='bshc', gm, r0, [lmax,
                                    omega, normalization, csphase, set_degree0])
         x = SHGravCoeffs.from_file(filename, format='npy', gm, r0, [lmax,
@@ -415,6 +415,9 @@ class SHGravCoeffs(object):
             files. Epoch is given by the format YYYYMMDD.DD, and if None the
             reference epoch t0 of the model will be used. Epoch is required for
             'icgem2.0' formatted files.
+        encoding : str, optional, default = None
+            Encoding of the input file for 'icgem' files. Try to use
+            'iso-8859-1' if the default (UTF-8) fails.
         **kwargs : keyword argument list, optional for format = 'npy'
             Keyword arguments of numpy.load() when format is 'npy'.
 
@@ -537,10 +540,12 @@ class SHGravCoeffs(object):
             if errors is False or errors is None:
                 coeffs, gm, r0 = _read_icgem_gfc(filename=fname,
                                                  errors=None, lmax=lmax,
-                                                 epoch=epoch)
+                                                 epoch=epoch,
+                                                 encoding=encoding)
             elif errors in valid_err:
                 coeffs, gm, r0, error_coeffs = _read_icgem_gfc(
-                    filename=fname, errors=errors, lmax=lmax, epoch=epoch)
+                    filename=fname, errors=errors, lmax=lmax, epoch=epoch,
+                    encoding=encoding)
             else:
                 raise ValueError('errors must be among: {}. '
                                  'Input value is {:s}.'

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -432,20 +432,12 @@ class SHGravCoeffs(object):
 
         Notes
         -----
-        If format='shtools', the spherical harmonic coefficients will be read
-        from a text file using the function pyshtools.shio.shread().
-
-        If format='dov', the spherical harmonic coefficients will be read
-        from a text file using the function pyshtools.shio.read_dov().
-
-        If format='icgem', the spherical harmonic coefficients will be read
-        from a text file using the function pyshtools.shio.icgem_read_gfc().
-
-        If format='bshc', the real spherical harmonic coefficients will be read
-        from a binary file using the function pyshtools.shio.read_bshc().
-
-        If format='npy', the spherical harmonic coefficients will be read from
-        a binary numpy 'npy' file using the function numpy.load().
+        Supported file formats:
+            'shtools' (see pyshtools.shio.shread)
+            'dov' (see pyshtools.shio.shread)
+            'icgem' (see pyshtools.shio.icgem_read_gfc)
+            'bshc' (see pyshtools.shio.read_bshc)
+            'npy' (see numpy.load)
 
         If the degree 0 term of the file is zero (or not specified), this will
         by default be set to 1.

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -20,6 +20,7 @@ from ..constant import G as _G
 from ..spectralanalysis import spectrum as _spectrum
 from ..shio import convert as _convert
 from ..shio import shread as _shread
+from ..shio import read_icgem_gfc as _read_icgem_gfc
 from ..shtools import CilmPlusRhoHDH as _CilmPlusRhoHDH
 from ..shtools import CilmPlusDH as _CilmPlusDH
 from ..shtools import MakeGravGridDH as _MakeGravGridDH
@@ -329,17 +330,19 @@ class SHGravCoeffs(object):
                   omega=None, lmax=None, normalization='4pi', skip=0,
                   header=True, errors=False, csphase=1, r0_index=0, gm_index=1,
                   omega_index=None, header_units='m', set_degree0=True,
-                  **kwargs):
+                  epoch=None, **kwargs):
         """
         Initialize the class with spherical harmonic coefficients from a file.
 
         Usage
         -----
-        x = SHGravCoeffs.from_file(filename, [format='shtools', gm, r0, omega,
-                                              lmax, normalization, csphase,
+        x = SHGravCoeffs.from_file(filename, [format='shtools' or 'icgem',
+                                              gm, r0, omega, lmax,
+                                              normalization, csphase,
                                               skip, header, errors, gm_index,
                                               r0_index, omega_index,
-                                              header_units, set_degree0])
+                                              header_units, set_degree0,
+                                              epoch])
         x = SHGravCoeffs.from_file(filename, format='npy', gm, r0,
                                    [omega, normalization, csphase, **kwargs])
 
@@ -352,20 +355,23 @@ class SHGravCoeffs(object):
         filename : str
             File name or URL containing the spherical harmonic coefficients.
             filename will be treated as a URL if it starts with 'http://',
-            'https://', or 'ftp://'. For shtools formatted files, ff filename
-            ends with '.gz' or '.zip', the file will be uncompressed before
-            parsing.
+            'https://', or 'ftp://'. For 'shtools' and 'icgem' formatted files,
+            if filename ends with '.gz' or '.zip' (or if the path contains
+            '/zip/'), the file will be uncompressed before parsing.
         format : str, optional, default = 'shtools'
-            'shtools' format or binary numpy 'npy' format.
+            'shtools' for generic ascii files, 'icgem' for ICGEM GFC formatted
+            files, or 'npy' for binary numpy files.
         lmax : int, optional, default = None
-            The maximum spherical harmonic degree to read from 'shtools'
-            formatted files. The default is to read the entire file.
+            The maximum spherical harmonic degree to read from 'shtools' or
+            'icgem' formatted files. The default is to read the entire file.
         header : bool, optional, default = True
             If True, read a list of values from the header line of an 'shtools'
             formatted file.
-        errors : bool, optional, default = False
-            If True, read errors from the file (for 'shtools' formatted files
-            only).
+        errors : bool or str, optional, default = False
+            For 'shtools' formatted files: if True, read and return the
+            spherical harmonic coefficients of the errors. For 'icgem'
+            formatted files, specify the type of error to return: 'calibrated'
+            or 'formal'.
         r0_index : int, optional, default = 0
             For shtools formatted files, if header is True, r0 will be set
             using the value from the header line with this index.
@@ -398,22 +404,47 @@ class SHGravCoeffs(object):
         skip : int, optional, default = 0
             Number of lines to skip at the beginning of the file when format is
             'shtools'.
+        epoch : str or float, optional, default = None
+            The epoch time to calculate time-variable coefficients for 'icgem'
+            files. Epoch is given by the format YYYYMMDD.DD, and if None the
+            reference epoch t0 of the model will be used. Epoch is required for
+            'icgem2.0' formatted files.
         **kwargs : keyword argument list, optional for format = 'npy'
             Keyword arguments of numpy.load() when format is 'npy'.
 
         Notes
         -----
-        If format='shtools', spherical harmonic coefficients will be read from
-        a text file. The optional parameter `skip` specifies how many lines
-        should be skipped before attempting to parse the file, the optional
-        parameter `header` specifies whether to read a list of values from a
-        header line, and the optional parameter `lmax` specifies the maximum
-        degree to read from the file. If a header line is read, r0_index,
-        gm_index, and omega_index, are used as the indices to set r0, gm, and
-        omega. If header_unit is specified as 'km', the values of r0 and gm
-        that are read from the header will be converted to meters.
+        If format='shtools', the spherical harmonic coefficients will be read
+        from a text file using the function pyshtools.shio.shread().
 
-        For shtools formatted files, all lines that do not start with 2
+        If format='icgem', the spherical harmonic coefficients will be read
+        from a text file using the function pyshtools.shio.icgem_read_gfc().
+
+        If format='npy', the spherical harmonic coefficients will be read from
+        a binary numpy 'npy' file using the function numpy.load().
+
+        If the degree 0 term of the file is zero (or not specified), this will
+        by default be set to 1.
+
+        For 'shtools' and 'icgem' formatted files, if filename starts with
+        'http://', 'https://', or 'ftp://', the file will be treated as a URL.
+        In this case, the file will be downloaded in its entirety before it is
+        parsed. If the filename ends with '.gz' or '.zip' (or if the path
+        contains '/zip/'), the file will be automatically uncompressed before
+        parsing. For zip files, archives with only a single file are supported.
+        Note that reading '.gz' and '.zip' files in 'shtools' format will be
+        extremely slow if lmax is not specified.
+
+        For 'shtools' formatted files, the optional parameter `skip` specifies
+        how many lines should be skipped before attempting to parse the file,
+        the optional parameter `header` specifies whether to read a list of
+        values from a header line, and the optional parameter `lmax` specifies
+        the maximum degree to read from the file. If a header line is read,
+        r0_index, gm_index, and omega_index, are used as the indices to set r0,
+        gm, and omega. If header_unit is specified as 'km', the values of r0
+        and gm that are read from the header will be converted to meters.
+
+        For 'shtools' formatted files, all lines that do not start with 2
         integers and that are less than 3 words long will be treated as
         comments and ignored. For this format, each line of the file must
         contain
@@ -422,27 +453,12 @@ class SHGravCoeffs(object):
 
         where l and m are the spherical harmonic degree and order,
         respectively. The terms coeffs[1, l, 0] can be neglected as they are
-        zero. For more information, see `shio.shread()`. If errors are read,
-        each line must contain:
+        zero. If errors are read, each line must contain:
 
         l, m, coeffs[0, l, m], coeffs[1, l, m], error[0, l, m], error[1, l, m]
-
-        If the degree 0 term of the file is zero (or not specified), this will
-        be set to 1.
-
-        If filename starts with http://, https://, or ftp://, the file will be
-        treated as a URL. In this case, the file will be downloaded in its
-        entirety before it is parsed.
-
-        If the filename ends with '.gz' or '.zip', the file will be
-        automatically uncompressed before parsing. For zip files, archives with
-        only a single file are supported. Note that reading '.gz' and '.zip'
-        files will be extremely slow if lmax is not specified.
-
-        If format='npy', a binary numpy 'npy' file will be read using
-        numpy.load().
         """
-        error = None
+        error_coeffs = None
+        header_list = None
 
         if type(normalization) != str:
             raise ValueError('normalization must be a string. '
@@ -462,11 +478,11 @@ class SHGravCoeffs(object):
                 .format(repr(csphase))
                 )
 
-        if header_units.lower() not in ('m', 'km'):
-            raise ValueError("header_units can be only 'm', or 'km'. Input "
-                             "value is {:s}.".format(repr(header_units)))
-
         if format == 'shtools':
+            if header_units.lower() not in ('m', 'km'):
+                raise ValueError("header_units can be only 'm', or 'km'. "
+                                 "Input value is {:s}."
+                                 .format(repr(header_units)))
             if r0_index is not None and r0 is not None:
                 raise ValueError('Can not specify both r0_index and r0.')
             if gm_index is not None and gm is not None:
@@ -477,18 +493,28 @@ class SHGravCoeffs(object):
                 raise ValueError('If header is False, r0 and gm must be '
                                  'specified.')
 
-        header_list = None
         if format.lower() == 'shtools':
             if header is True:
                 if errors is True:
-                    coeffs, error, lmaxout, header_list = _shread(
+                    coeffs, error_coeffs, lmaxout, header_list = _shread(
                         fname, lmax=lmax, skip=skip, header=True, error=True)
                 else:
                     coeffs, lmaxout, header_list = _shread(
                         fname, lmax=lmax, skip=skip, header=True)
+
+                if r0_index is not None:
+                    r0 = float(header_list[r0_index])
+                if gm_index is not None:
+                    gm = float(header_list[gm_index])
+                if omega_index is not None:
+                    omega = float(header_list[omega_index])
+                if header_units.lower() == 'km':
+                    r0 *= 1.e3
+                    gm *= 1.e9
+
             else:
                 if errors is True:
-                    coeffs, error, lmaxout = _shread(
+                    coeffs, error_coeffs, lmaxout = _shread(
                         fname, lmax=lmax, error=True, skip=skip)
                 else:
                     coeffs, lmaxout = _shread(fname, lmax=lmax, skip=skip)
@@ -499,6 +525,22 @@ class SHGravCoeffs(object):
                                  'specified.')
             coeffs = _np.load(fname, **kwargs)
             lmaxout = coeffs.shape[1] - 1
+
+        elif format.lower() == 'icgem':
+            valid_err = ('calibrated', 'formal')
+            if errors is False or errors is None:
+                coeffs, gm, r0 = _read_icgem_gfc(filename=fname,
+                                                 errors=None, lmax=lmax,
+                                                 epoch=epoch)
+            elif errors in valid_err:
+                coeffs, gm, r0, error_coeffs = _read_icgem_gfc(
+                    filename=fname, errors=errors, lmax=lmax, epoch=epoch)
+            else:
+                raise ValueError('errors must be among: {}. '
+                                 'Input value is {:s}.'
+                                 .format(valid_err, repr(errors)))
+            lmaxout = coeffs.shape[1] - 1
+
         else:
             raise NotImplementedError(
                 'format={:s} not implemented'.format(repr(format)))
@@ -513,23 +555,13 @@ class SHGravCoeffs(object):
                            "85. Input value is {:d}.".format(lmaxout),
                            category=RuntimeWarning)
             lmaxout = 85
+            coeffs = coeffs[:, :lmaxout+1, :lmaxout+1]
 
         if coeffs[0, 0, 0] == 0 and set_degree0:
             coeffs[0, 0, 0] = 1.0
 
-        if format.lower() == 'shtools' and header is True:
-            if r0_index is not None:
-                r0 = float(header_list[r0_index])
-            if gm_index is not None:
-                gm = float(header_list[gm_index])
-            if omega_index is not None:
-                omega = float(header_list[omega_index])
-            if header_units.lower() == 'km':
-                r0 *= 1.e3
-                gm *= 1.e9
-
         clm = SHGravRealCoeffs(coeffs, gm=gm, r0=r0, omega=omega,
-                               errors=error,
+                               errors=error_coeffs,
                                normalization=normalization.lower(),
                                csphase=csphase, header=header_list)
         return clm

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -384,6 +384,8 @@ class SHMagCoeffs(object):
         numpy.load().
         """
         error = None
+        if not header:
+            r0_index = None
 
         if type(normalization) != str:
             raise ValueError('normalization must be a string. '

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -303,12 +303,16 @@ class SHMagCoeffs(object):
         Parameters
         ----------
         filename : str
-            Name of the file, including path.
+            File name or URL containing the spherical harmonic coefficients.
+            filename will be treated as a URL if it starts with 'http://',
+            'https://', or 'ftp://'. For shtools formatted files, if filename
+            ends with '.gz', the file will be uncompressed using gzip before
+            parsing.
         format : str, optional, default = 'shtools'
             'shtools' format or binary numpy 'npy' format.
         lmax : int, optional, default = None
             The maximum spherical harmonic degree to read from 'shtools'
-            formatted files.
+            formatted files. The default is to read the entire file.
         header : bool, optional, default = True
             If True, read a list of values from the header line of an 'shtools'
             formatted file.
@@ -367,16 +371,17 @@ class SHMagCoeffs(object):
 
         l, m, coeffs[0, l, m], coeffs[1, l, m], error[0, l, m], error[1, l, m]
 
+        The coefficients read from the file are assumed to have units of nT.
+
         If filename starts with http://, https://, or ftp://, the file will be
         treated as a URL. In this case, the file will be downloaded in its
         entirety before it is parsed.
 
+        If the filename ends with '.gz', the file will be automatically
+        uncompressed using gzip before parsing.
+
         If format='npy', a binary numpy 'npy' file will be read using
         numpy.load().
-
-        Notes
-        -----
-        The coefficients read from the file are assumed to have units of nT.
         """
         error = None
 

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -363,21 +363,12 @@ class SHMagCoeffs(object):
 
         Notes
         -----
-        If format='shtools', the spherical harmonic coefficients will be read
-        from a text file using the function pyshtools.shio.shread().
-
-        If format='dov', the spherical harmonic coefficients will be read
-        from a text file using the function pyshtools.shio.read_dov().
-
-        If format='igrf', the real spherical harmonic coefficients will be read
-        from an International Geomagnetic Reference Field file using the
-        function pyshtools.shio.read_igrf() for a specified year.
-
-        If format='bshc', the real spherical harmonic coefficients will be read
-        from a binary file using the function pyshtools.shio.read_bshc().
-
-        If format='npy', the spherical harmonic coefficients will be read from
-        a binary numpy 'npy' using the function numpy.load().
+        Supported file formats:
+            'shtools' (see pyshtools.shio.shread)
+            'dov' (see pyshtools.shio.shread)
+            'igrf' (see pyshtools.shio.igrf)
+            'bshc' (see pyshtools.shio.read_bshc)
+            'npy' (see numpy.load)
 
         The coefficients read from the file are assumed to have units of nT.
         If coeffs_units is specified as 'T', the coefficients read from the

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -306,7 +306,7 @@ class SHMagCoeffs(object):
             File name or URL containing the spherical harmonic coefficients.
             filename will be treated as a URL if it starts with 'http://',
             'https://', or 'ftp://'. For shtools formatted files, if filename
-            ends with '.gz', the file will be uncompressed using gzip before
+            ends with '.gz' or '.zip', the file will be uncompressed before
             parsing.
         format : str, optional, default = 'shtools'
             'shtools' format or binary numpy 'npy' format.
@@ -377,8 +377,10 @@ class SHMagCoeffs(object):
         treated as a URL. In this case, the file will be downloaded in its
         entirety before it is parsed.
 
-        If the filename ends with '.gz', the file will be automatically
-        uncompressed using gzip before parsing.
+        If the filename ends with '.gz' or '.zip', the file will be
+        automatically uncompressed before parsing. For zip files, archives with
+        only a single file are supported. Note that reading '.gz' and '.zip'
+        files will be extremely slow if lmax is not specified.
 
         If format='npy', a binary numpy 'npy' file will be read using
         numpy.load().

--- a/pyshtools/shio/__init__.py
+++ b/pyshtools/shio/__init__.py
@@ -6,10 +6,13 @@ This submodule of pyshtools defines the following functions:
 Spherical harmonic I/O
 ----------------------
 shread           Read spherical harmonic coefficients from a text file.
-read_icgem_gfc   Read real spherical harmonic coefficients and associated
-                 errors from an ICGEM GFC ascii-formatted file.
+read_icgem_gfc   Read real spherical harmonic gravitational potential
+                 coefficients and associated errors from an ICGEM GFC
+                 formatted file.
 read_bshc        Read real spherical harmonic coefficients from a binary
                  bshc-formatted file.
+read_igrf        Read IGRF real spherical harmonic coefficients, and return the
+                 magnetic potential coefficients for the specified year.
 SHRead2          Read spherical harmonic coefficients from a CHAMP or GRACE-
                  like ascii-formatted file.
 SHRead2Error     Read spherical harmonic coefficients and associated errors
@@ -53,6 +56,7 @@ from ..shtools import SHctor
 from .convert import convert
 from .shread import shread
 from .icgem import read_icgem_gfc
+from .read_igrf import read_igrf
 from .read_bshc import read_bshc
 from .yilm_index_vector import YilmIndexVector
 
@@ -61,4 +65,4 @@ from .yilm_index_vector import YilmIndexVector
 __all__ = ['SHRead2', 'SHRead2Error', 'SHReadJPL', 'SHReadJPLError',
            'SHCilmToCindex', 'SHCindexToCilm', 'SHCilmToVector',
            'SHVectorToCilm', 'SHrtoc', 'SHctor', 'convert', 'shread',
-           'read_icgem_gfc', 'read_bshc', 'YilmIndexVector']
+           'read_icgem_gfc', 'read_bshc', 'read_igrf', 'YilmIndexVector']

--- a/pyshtools/shio/__init__.py
+++ b/pyshtools/shio/__init__.py
@@ -6,7 +6,7 @@ This submodule of pyshtools defines the following functions:
 Spherical harmonic I/O
 ----------------------
 shread           Read spherical harmonic coefficients from a text file.
-read_dov         Read real spherical harmonic coefficients from a text file
+read_dov         Read spherical harmonic coefficients from a text file
                  formatted as [degree, order, value].
 read_icgem_gfc   Read real spherical harmonic gravitational potential
                  coefficients and associated errors from an ICGEM GFC

--- a/pyshtools/shio/__init__.py
+++ b/pyshtools/shio/__init__.py
@@ -6,6 +6,8 @@ This submodule of pyshtools defines the following functions:
 Spherical harmonic I/O
 ----------------------
 shread           Read spherical harmonic coefficients from a text file.
+read_dov         Read real spherical harmonic coefficients from a text file
+                 formatted as [degree, order, value].
 read_icgem_gfc   Read real spherical harmonic gravitational potential
                  coefficients and associated errors from an ICGEM GFC
                  formatted file.
@@ -55,6 +57,7 @@ from ..shtools import SHctor
 
 from .convert import convert
 from .shread import shread
+from .read_dov import read_dov
 from .icgem import read_icgem_gfc
 from .read_igrf import read_igrf
 from .read_bshc import read_bshc
@@ -65,4 +68,5 @@ from .yilm_index_vector import YilmIndexVector
 __all__ = ['SHRead2', 'SHRead2Error', 'SHReadJPL', 'SHReadJPLError',
            'SHCilmToCindex', 'SHCindexToCilm', 'SHCilmToVector',
            'SHVectorToCilm', 'SHrtoc', 'SHctor', 'convert', 'shread',
-           'read_icgem_gfc', 'read_bshc', 'read_igrf', 'YilmIndexVector']
+           'read_dov', 'read_icgem_gfc', 'read_bshc', 'read_igrf',
+           'YilmIndexVector']

--- a/pyshtools/shio/__init__.py
+++ b/pyshtools/shio/__init__.py
@@ -6,6 +6,10 @@ This submodule of pyshtools defines the following functions:
 Spherical harmonic I/O
 ----------------------
 shread           Read spherical harmonic coefficients from a text file.
+read_icgem_gfc   Read real spherical harmonic coefficients and associated
+                 errors from an ICGEM GFC ascii-formatted file.
+read_bshc        Read real spherical harmonic coefficients from a binary
+                 bshc-formatted file.
 SHRead2          Read spherical harmonic coefficients from a CHAMP or GRACE-
                  like ascii-formatted file.
 SHRead2Error     Read spherical harmonic coefficients and associated errors
@@ -14,8 +18,6 @@ SHReadJPL        Read spherical harmonic coefficients from a JPL ascii-
                  formatted file.
 SHReadJPLError   Read spherical harmonic coefficients and associated errors
                  from a JPL ascii-formatted file.
-read_icgem_gfc   Read spherical harmonic coefficients or associated errors
-                 from an ICGEM GFC ascii-formatted file.
 
 Spherical harmonic storage
 --------------------------
@@ -51,6 +53,7 @@ from ..shtools import SHctor
 from .convert import convert
 from .shread import shread
 from .icgem import read_icgem_gfc
+from .read_bshc import read_bshc
 from .yilm_index_vector import YilmIndexVector
 
 
@@ -58,4 +61,4 @@ from .yilm_index_vector import YilmIndexVector
 __all__ = ['SHRead2', 'SHRead2Error', 'SHReadJPL', 'SHReadJPLError',
            'SHCilmToCindex', 'SHCindexToCilm', 'SHCilmToVector',
            'SHVectorToCilm', 'SHrtoc', 'SHctor', 'convert', 'shread',
-           'read_icgem_gfc', 'YilmIndexVector']
+           'read_icgem_gfc', 'read_bshc', 'YilmIndexVector']

--- a/pyshtools/shio/icgem.py
+++ b/pyshtools/shio/icgem.py
@@ -1,5 +1,6 @@
 """
-ICGEM-format read support
+Support for reading real gravitational-potential coefficients from
+ICGEM-formatted files.
 """
 import io
 import gzip
@@ -36,23 +37,20 @@ def _time_variable_part(epoch, ref_epoch, trnd, periodic):
 def read_icgem_gfc(filename, errors=None, lmax=None, epoch=None,
                    encoding=None):
     """
-    Read spherical harmonic coefficients from an ICGEM formatted file.
-
-    This function reads only GFC files with gravity field spherical
-    harmonic coefficients.
+    Read real spherical harmonic gravity coefficients from an ICGEM formatted
+    file.
 
     Returns
     -------
-    cilm : array
-        Array with the coefficients of shape (2, lmax + 1, lmax + 1) for the
+    cilm : ndarray, size (2, lmax + 1, lmax + 1)
+        Array of '4pi' normalized spherical harmonic coefficients for the
         given epoch.
     gm : float
         Gravitational constant of the model, in m**3/s**2.
     r0 : float
         Reference radius of the model, in meters.
-    errors : array, optional
-        Array with the errors of the coefficients of shape
-        (2, lmax + 1, lmax + 1) for the given epoch.
+    errors : ndarray, optional, shape (2, lmax + 1, lmax + 1)
+        Array of the spherical harmonic error coefficients for the given epoch.
 
     Parameters
     ----------

--- a/pyshtools/shio/icgem.py
+++ b/pyshtools/shio/icgem.py
@@ -36,50 +36,51 @@ def _time_variable_part(epoch, ref_epoch, trnd, periodic):
 def read_icgem_gfc(filename, errors=None, lmax=None, epoch=None,
                    encoding=None):
     """
-    Read spherical harmonic coefficients from an ICGEM GFC ascii-formatted
-    file.
+    Read spherical harmonic coefficients from an ICGEM formatted file.
 
-    This function only reads files with the gravity field spherical
+    This function reads only GFC files with gravity field spherical
     harmonic coefficients.
 
     Returns
     -------
     cilm : array
-        Array with the coefficients with the shape (2, lmax + 1, lmax + 1)
-        for the given epoch.
+        Array with the coefficients of shape (2, lmax + 1, lmax + 1) for the
+        given epoch.
     gm : float
-        Standard gravitational constant of the model, in m**3/s**2.
+        Gravitational constant of the model, in m**3/s**2.
     r0 : float
         Reference radius of the model, in meters.
     errors : array, optional
-        Array with the errors of the coefficients with the shape
+        Array with the errors of the coefficients of shape
         (2, lmax + 1, lmax + 1) for the given epoch.
 
     Parameters
     ----------
     filename : str
-        The ascii-formatted filename containing the spherical harmonic
-        coefficients.
-    errors : str, optional
-        Which errors to read. Can be either "calibrated", "formal" or
-        None. Default is None.
-    lmax : int, optional
+        The filename containing the spherical harmonic ICGEM-formatted
+        coefficients. filename will be treated as a URL if it starts with
+        'http://', 'https://', or 'ftp://'. If filename ends with '.gz' or
+        '.zip', the file will be uncompressed before parsing.
+    errors : str, optional, default = None
+        Which errors to read. Can be either 'calibrated', 'formal' or None.
+    lmax : int, optional, default = None
         Maximum degree to read from the file. If lmax is None, less than 0, or
         greater than lmax_model, the maximum degree of the model will be used.
-    epoch : str or float, optional
+    epoch : str or float, optional, default = None
         The epoch time to calculate time-variable coefficients in YYYYMMDD.DD
-        format. If None then reference epoch t0 of the model will be used.
-        If format of the file is 'icgem2.0' then epoch must be specified.
+        format. If None then the reference epoch t0 of the model will be used.
+        If the format of the file is 'icgem2.0' then the epoch must be
+        specified.
     encoding : str, optional
-        Encoding of the input file. Try to use 'iso-8859-1' if default (UTF-8)
-        fails.
+        Encoding of the input file. Try to use 'iso-8859-1' if the default
+        (UTF-8) fails.
     """
     header = {}
     header_keys = ['modelname', 'product_type', 'earth_gravity_constant',
                    'gravity_constant', 'radius', 'max_degree', 'errors',
                    'tide_system', 'norm', 'format']
 
-    # determine how to open filename
+    # open filename as a text file
     if _isurl(filename):
         _response = _requests.get(filename)
         if _iszipurl(filename):
@@ -254,4 +255,3 @@ def _iszipurl(filename):
             return True
 
     return False
-

--- a/pyshtools/shio/icgem.py
+++ b/pyshtools/shio/icgem.py
@@ -68,8 +68,8 @@ def read_icgem_gfc(filename, errors=None, lmax=None, epoch=None,
         format. If None then reference epoch t0 of the model will be used.
         If format of the file is 'icgem2.0' then epoch must be specified.
     encoding : str, optional
-        Encoding of the input file. Try to use 'iso-8859-1'
-        if default (UTF-8) is failed.
+        Encoding of the input file. Try to use 'iso-8859-1' if default (UTF-8)
+        is failed.
     """
 
     # read header

--- a/pyshtools/shio/icgem.py
+++ b/pyshtools/shio/icgem.py
@@ -99,8 +99,8 @@ def read_icgem_gfc(filename, errors=None, lmax=None, epoch=None,
     elif filename[-4:] == '.zip':
         zf = zipfile.ZipFile(filename, 'r')
         if len(zf.namelist()) > 1:
-            raise Exception('shread can only process zip archives that '
-                            'contain a single file. Archive contents: \n'
+            raise Exception('read_icgem_gfc can only process zip archives '
+                            'that contain a single file. Archive contents: \n'
                             '{}'.format(zf.namelist()))
         f = io.TextIOWrapper(zf.open(zf.namelist()[0]))
     else:
@@ -255,5 +255,5 @@ def _iszipfile(filename):
         return True
     elif filename[-4:] == '.zip':
         return True
-
-    return False
+    else:
+        return False

--- a/pyshtools/shio/read_bshc.py
+++ b/pyshtools/shio/read_bshc.py
@@ -1,0 +1,125 @@
+"""
+Functions for reading real spherical harmonic coefficients from binary 'bshc'
+files provided by Curtin University.
+"""
+import io
+import struct
+import gzip
+import zipfile
+import numpy as _np
+import requests as _requests
+
+
+def read_bshc(filename, lmax=None):
+    """
+    Read real spherical harmonic coefficients from a binary bshc file.
+
+    Usage
+    -----
+    coeffs, lmaxout = read_bshc(filename, [lmax])
+
+    Returns
+    -------
+    coeffs : ndarray, size(2, lmaxout+1, lmaxout+1)
+        The spherical harmonic coefficients.
+    lmaxout : int
+        The maximum spherical harmonic degree read from the file.
+
+    Parameters
+    ----------
+    filename : str
+        File name or URL that contains the spherical harmonic coefficients.
+        filename will be treated as a URL if it starts with 'http://',
+        'https://', or 'ftp://'. If filename ends with '.gz' or '.zip', the
+        file will be uncompressed before parsing.
+    lmax : int, optional, default = None
+        The maximum spherical harmonic degree to read from the file. The
+        default is to read the entire file.
+
+    Notes
+    -----
+    This function reads real spherical harmonic coefficients from binary
+    'bshc'-formatted files as used at Curtin University. The file is composed
+    solely of 8-byte floats, starting with the minimum and maximum degree,
+    and followed by the cosine coefficients and then sine coefficients
+    (with all orders being listed, one degree at a time). For a 10800 degree
+    file, the contents are
+
+    0 10800
+    C(0,0), C(1,0), C(1,1), C(2,0), C(2,1), ... C(10800,10799), C(10800,10800)
+    S(0,0), S(1,0), S(1,1), S(2,0), S(2,1), ... S(10800,10799), S(10800,10800).
+
+    If filename starts with 'http://', 'https://', or 'ftp://', the file will
+    be treated as a URL. In this case, the file will be downloaded in its
+    entirety before it is parsed.
+
+    If the filename ends with '.gz' or '.zip', the file will be automatically
+    uncompressed before parsing. For zip files, archives with only a single
+    file are supported.
+    """
+    if _isurl(filename):
+        _response = _requests.get(filename, stream=True)
+        if filename[-4:] == '.zip':
+            zf = zipfile.ZipFile(io.BytesIO(_response.content))
+            if len(zf.namelist()) > 1:
+                raise Exception('read_bshc can only process zip archives '
+                                'that contain a single file. Archive '
+                                'contents:\n{}'.format(zf.namelist()))
+            f = zf.open(zf.namelist()[0])
+        f = io.BytesIO(_response.content)
+    elif filename[-3:] == '.gz':
+        f = gzip.open(filename, mode='rb')
+    elif filename[-4:] == '.zip':
+        zf = zipfile.ZipFile(filename, 'r')
+        if len(zf.namelist()) > 1:
+            raise Exception('read_bshc can only process zip archives that '
+                            'contain a single file. Archive contents: \n'
+                            '{}'.format(zf.namelist()))
+        f = zf.open(zf.namelist()[0])
+    else:
+        f = open(filename, 'rb')
+
+    with f:
+        degree_start = int(struct.unpack('<d', f.read(8))[0])
+        degree_end = int(struct.unpack('<d', f.read(8))[0])
+        if lmax is None:
+            lmax = degree_end
+
+        if lmax > degree_end:
+            raise RuntimeError('lmax must be less than or equal to '
+                               '{:d}. Input degree is {:d}.'
+                               .format(degree_end, lmax))
+
+        coeffs = _np.zeros((2, lmax+1, lmax+1))
+
+        for degree in range(degree_start, lmax+1):
+            n = degree + 1
+            coeffs[0, degree, 0:n] = struct.unpack('<{}d'.format(n),
+                                                   f.read(8*n))
+        for degree in range(lmax+1, degree_end + 1):
+            n = degree + 1
+            f.read(8*n)
+
+        for degree in range(degree_start, lmax + 1):
+            n = degree + 1
+            coeffs[1, degree, 0:n] = struct.unpack('<{}d'.format(n),
+                                                   f.read(8*n))
+
+        return coeffs, lmax
+
+
+def _isurl(filename):
+    """
+    Determine if filename is a URL. Valid URLs start with
+        'http://'
+        'https://'
+        'ftp://'
+    """
+    if filename[0:7].lower() == 'http://':
+        return True
+    elif filename[0:8].lower() == 'https://':
+        return True
+    elif filename[0:6].lower() == 'ftp://':
+        return True
+    else:
+        return False

--- a/pyshtools/shio/read_igrf.py
+++ b/pyshtools/shio/read_igrf.py
@@ -1,0 +1,130 @@
+"""
+Support for reading real magnetic-potential spherical harmonic coefficients
+from IGRM formatted files.
+"""
+import io
+import gzip
+import zipfile
+import numpy as _np
+import requests as _requests
+
+
+def read_igrf(filename, year=2020.):
+    """
+    Read IGRF real spherical harmonic coefficients, and return the magnetic
+    potential coefficients for the specified year.
+
+    Returns
+    -------
+    clm : ndarray, size (2, 14, 14)
+        Array of Schmidt semi-normalized coefficients.
+
+    Parameters
+    ----------
+    filename : str
+        The filename containing the IGRF formatted spherical harmonic
+        coefficients. filename will be treated as a URL if it starts with
+        'http://', 'https://', or 'ftp://'. If filename ends with '.gz' or
+        '.zip', the file will be uncompressed before parsing.
+    year : float, optional, default = 2020.
+        The year to compute the coefficients.
+
+    Notes
+    -----
+    The current International Geomagnetic Reference Field (IGRF-13) is a
+    degree 13 time variable model that is valid between 1900 and 2020.
+    Coefficients are provided in 5 year intervals, and for a given year, the
+    values of the coefficients are interpolated linearly between adjacent
+    entries. For years between 2020 and 2025, the coefficients are extrapolated
+    using the provided secular variation. The reference radius is 6371.2 km.
+
+    This routine can read the models IGRF-11, 12, and 13. Prior models have a
+    different format.
+    """
+    lmax = 13
+    coeffs = _np.zeros([2, lmax+1, lmax+1])
+
+    # open filename as a text file
+    if _isurl(filename):
+        _response = _requests.get(filename)
+        if filename[-4:] == '.zip':
+            zf = zipfile.ZipFile(io.BytesIO(_response.content))
+            if len(zf.namelist()) > 1:
+                raise Exception('read_igrf can only process zip archives '
+                                'that contain a single file. Archive '
+                                'contents:\n{}'.format(zf.namelist()))
+            f = io.TextIOWrapper(zf.open(zf.namelist()[0]))
+        else:
+            f = io.StringIO(_response.text)
+    elif filename[-3:] == '.gz':
+        f = gzip.open(filename, mode='rt')
+    elif filename[-4:] == '.zip':
+        zf = zipfile.ZipFile(filename, 'r')
+        if len(zf.namelist()) > 1:
+            raise Exception('read_igrf can only process zip archives '
+                            'that contain a single file. Archive contents: \n'
+                            '{}'.format(zf.namelist()))
+        f = io.TextIOWrapper(zf.open(zf.namelist()[0]))
+    else:
+        f = open(filename, 'r')
+
+    with f:
+        lines = f.readlines()
+        year_list = lines[3].split()[3:]
+        year_list[-1] = int(year_list[-1].split(sep='-')[1]) + 2000
+        year_list = [float(i) for i in year_list]
+        year_start = year_list[0]
+        year_end = year_list[-1]
+
+        if year < year_start or year > year_end:
+            raise ValueError('Year must be between {:d} and {:d}. Input value '
+                             'is {:f}'.format(int(year_start), int(year_end),
+                                              year))
+
+        for line in lines[4:]:
+            line = line.split()
+            data = [float(i) for i in line[3:]]
+
+            if line[0] == 'g':
+                index = 0
+            elif line[0] == 'h':
+                index = 1
+            else:
+                raise ValueError("Error reading file. Expected 'g' or "
+                                 "'h' but read {:s}".format(repr(line[0])))
+
+            degree = int(line[1])
+            order = int(line[2])
+
+            if year >= year_list[-2]:
+                # use SV in file for secular variation
+                value = data[-2] + data[-1] * (year - year_list[-2])
+                coeffs[index, degree, order] = value
+
+            else:
+                # perform linear interpolation between adjacent years
+                for i in range(len(year_list) - 2):
+                    if year >= year_list[i] and year < year_list[i+1]:
+                        value = data[i] + (data[i+1] - data[i]) / \
+                            (year_list[i+1] - year_list[i]) * \
+                            (year - year_list[i])
+                        coeffs[index, degree, order] = value
+
+    return coeffs
+
+
+def _isurl(filename):
+    """
+    Determine if filename is a URL. Valid URLs start with
+        'http://'
+        'https://'
+        'ftp://'
+    """
+    if filename[0:7].lower() == 'http://':
+        return True
+    elif filename[0:8].lower() == 'https://':
+        return True
+    elif filename[0:6].lower() == 'ftp://':
+        return True
+    else:
+        return False

--- a/pyshtools/shio/shread.py
+++ b/pyshtools/shio/shread.py
@@ -206,9 +206,9 @@ def shread(filename, lmax=None, error=False, header=False, skip=0):
                                        dtype=complex)
             except ValueError:
                 raise ValueError('Coefficients can not be converted to '
-                                'either float or complex. Coefficient '
-                                'is {:s}\n'.format(line.split()[2]) +
-                                'Unformatted string is {:s}'.format(line))
+                                 'either float or complex. Coefficient '
+                                 'is {:s}\n'.format(line.split()[2]) +
+                                 'Unformatted string is {:s}'.format(line))
 
         # rewind one line and read coefficients one line at a time
         f.seek(start_position)

--- a/pyshtools/shio/shread.py
+++ b/pyshtools/shio/shread.py
@@ -1,16 +1,13 @@
 """
-Functions for reading spherical harmonic coefficients from files.
+Functions for reading spherical harmonic coefficients from text files.
 """
 import os
 import io
 import gzip
 import zipfile
-
 import numpy as _np
 import requests as _requests
 
-
-# ==== shread() ====
 
 def shread(filename, lmax=None, error=False, header=False, skip=0):
     """
@@ -58,7 +55,7 @@ def shread(filename, lmax=None, error=False, header=False, skip=0):
     Notes
     -----
     This function will read spherical harmonic coefficients from an
-    ascii-formatted text file. If the The errors associated with the spherical
+    ascii-formatted text file. The errors associated with the spherical
     harmonic coefficients, as well as the values in a single header line, can
     be read optionally by setting the parameters error and header to
     True. The optional parameter skip specifies how many lines should be

--- a/pyshtools/shio/shread.py
+++ b/pyshtools/shio/shread.py
@@ -38,8 +38,8 @@ def shread(filename, lmax=None, error=False, header=False, skip=0):
     filename : str
         File name or URL that contains the text-formatted spherical harmonic
         coefficients. filename will be treated as a URL if it starts with
-        http://, https://, or ftp://. If filename ends with '.gz' or '.zip',
-        the file will be uncompressed before parsing.
+        'http://', 'https://', or 'ftp://'. If filename ends with '.gz' or
+        '.zip', the file will be uncompressed before parsing.
     lmax : int, optional, default = None
         The maximum spherical harmonic degree to read from the file. The
         default is to read the entire file.

--- a/pyshtools/shio/shread.py
+++ b/pyshtools/shio/shread.py
@@ -97,7 +97,9 @@ def shread(filename, lmax=None, error=False, header=False, skip=0):
     file are supported. Note that reading '.gz' and '.zip' files will be
     extremely slow if lmax is not specified.
     """
-    if filename[-4:] == '.zip':
+    if _isurl(filename):
+        _response = _requests.get(filename)
+    elif filename[-4:] == '.zip':
         zf = zipfile.ZipFile(filename, 'r')
         if len(zf.namelist()) > 1:
             raise Exception('shread can only process zip archives that '
@@ -109,7 +111,6 @@ def shread(filename, lmax=None, error=False, header=False, skip=0):
     # files. Consider using indexed_gzip when SEEK_END is supported.)
     if lmax is None:
         if _isurl(filename):
-            _response = _requests.get(filename)
             f = io.BytesIO(_response.content)
         elif filename[-3:] == '.gz':
             f = gzip.open(filename, mode='rb')

--- a/setup.py
+++ b/setup.py
@@ -186,6 +186,8 @@ INSTALL_REQUIRES = [
     'astropy',
     'xarray',
     'requests'
+    'pooch',
+    'tqdm'
 ]
 
 # configure python extension to be compiled with f2py

--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,7 @@ INSTALL_REQUIRES = [
     'matplotlib',
     'astropy',
     'xarray',
-    'requests'
+    'requests',
     'pooch',
     'tqdm'
 ]

--- a/src/Curve2Mask.f95
+++ b/src/Curve2Mask.f95
@@ -214,7 +214,7 @@ subroutine Curve2Mask(dhgrid, n, sampling, profile, nprofile, NP, extend, &
                     ! There is a jump from -180 to 180
                     if (lon1 < 0._dp) lon1 = lon1 + 360._dp
                     if (lon2 < 0._dp) lon2 = lon2 + 360._dp
-                elseif (lon1 > 0._dp .and. lon2 > 0._dp) then
+                elseif (lon1 >= 0._dp .and. lon2 >= 0._dp) then
                     ! There is a jump from 360 to 0. Set the largest value
                     ! to a negative longitude.
                     if (lon1 > lon2) then
@@ -303,6 +303,7 @@ subroutine Curve2Mask(dhgrid, n, sampling, profile, nprofile, NP, extend, &
     end do
 
     if (extend_grid == 1) then
+        dhgrid(nlat_out, 1) = dhgrid(nlat_out-1, 1)
         dhgrid(1:nlat_out, nlong_out) = dhgrid(1:nlat_out, 1)
     end if
 

--- a/src/pyshtools.pyf
+++ b/src/pyshtools.pyf
@@ -1195,7 +1195,7 @@ python module _SHTOOLS
             integer,optional,intent(in) :: extend = 0
             integer,optional,intent(in),depend(profile),intent(hide) :: profile_d0 = shape(profile,0)
             integer,optional,intent(in),depend(profile),intent(hide) :: profile_d1 = shape(profile,1)
-            integer,optional,intent(in),depend(n),intent(hide) :: dhgrid_d0 = n
+            integer,optional,intent(in),depend(n,extend),intent(hide) :: dhgrid_d0 = n+extend
             integer,optional,intent(in),depend(n,sampling,extend),intent(hide) :: dhgrid_d1 = n*sampling+extend
         end subroutine Curve2Mask
 


### PR DESCRIPTION
This pull request adds the capability of downloading datasets, which get returned as `SHCoeffs`, `SHGravCoeffs` or `SHMagCoeffs` class instances.

To load a dataset, call the relevant method as in these examples:
```
    hlm = pysh.datasets.Venus.VenusTopo719()  # Venus shape
    clm = pysh.datasets.Earth.EGM2008()  # Earth gravity
    glm = pysh.datasetes.Earth.WDMAM2_800()  # Earth magnetic field
    clm = pysh.datasets.Moon.GRGM1200B()  # Gravity of the Moon
```
When accessing a pyshtools dataset, the file will first be downloaded from the original source using [pooch](https://www.fatiando.org/pooch/latest/) and stored in the pyshtools subdirectory of the user's cache directory (if it had not been done previously). The file hash will be verified to ensure that it has not been modified, and the file will then be used to initialize and return an `SHCoeffs`, `SHGravCoeffs` or `SHMagCoeffs` class instance. In most cases the files are stored in their original form: If they need to be decompressed or unzipped, this is done on the fly when they are used. Only when zip archives contain several files are the files stored in unzipped form.

The coefficients can be read up to a maximum specified degree by providing the optional variable `lmax`. For magnetic field data, the coefficients are returned in units of nT, but coefficients in units of Tesla can be returned by setting the optional variable `nt=False`. For IGRF magnetic field coefficients, the year of the output coefficients can be specified by the optional argument `year` (the default is 2020).

The following is the list of implemented datasets:
## Mercury
#### Topography
* GTMES150: Topography constructed using laser altimeter and occultation data.
#### Gravity
* JGMESS160A : Konolpiv et al. (2020)
* JGMESS160A_ACCEL :  Konolpiv et al. (2020)
* JGMESS160A_TOPOSIG :  Konolpiv et al. (2020)
* GGMES100V08        :  Genova et al. (2019)

## Venus
#### Topography
* VenusTopo719 :  Wieczorek (2015)
#### Gravity
* MGNP180U     :  Konopliv et al. (1999)

## The Moon
#### Topography
* MoonTopo2600p     :  Wieczorek (2015)
#### Gravity
* GRGM900C          :  Lemoine et al. (2014)
* GRGM1200B         :  Goossens et al. (2020)
* GRGM1200B_RM1_1E0 :  Goossens et al. (2020)
* GL0900D           :  Konopliv et al. (2014)
* GL1500E           :  Konopliv et al. (2014)
#### Magnetic Field
* T2015_449         :  Wieczorek (2018), using data from Tsunakawa et al. (2015)

## Mars
#### Topography
* MarsTopo2600     :  Wieczorek (2015)
#### Gravity
* GMM3             :  Genova et al. (2016)
* GMM3_RM1_1E0     :  Goossens et al. (2017)
* MRO120D          :  Konopliv et al. (2016)
#### Magnetic Field
* Langlais2019     :  Langlais et al. (2019)
* Morschhauser2014 :  Morschhauser et al. (2014)

## Vesta
#### Gravity
* VESTA20H         :  Konopliv et al. (2014)

## Ceres
#### Gravity
* CERES18D :  Konopliv et al. (2018)

## Earth
#### Topography
* Earth2012 : Hirt et al. (2012)
* Earth2014 : Hirt and Rexer (2014)

#### Gravity
* EGM2008                    :  Pavlis et al. (2012); degree 2190
* EIGEN_6C4                  :  Förste et al. (2014); degree 2190
* GGM05C                     :  Ries et al. (2016); degree 360
* GOCO06S                    :  Kvas et al. (2019); degree 300, satellite only
* EIGEN_GRGS_RL04_MEAN_FIELD :  Lemoine et al. (2019); degree 300, satellite only
* XGM2019E                   :  Zingerle et al. (2019); degree 2190

#### Magnetic field
* IGRF_13                    :  Thébault et al. (2015); degree 13
* SWARM_MLI_2D_0501          :  Thébault et al. (2013); degree 133
* NGDC_720_V3                :  Maus (2010); degree 740
* WDMAM2_800                 :  Lesur et al. (2016); degree 800

# Additional changes
* Added support for reading gzip and zip files in `shread`, `SHCoeffs.from_file()`, `SHGravCoeffs.from_file()`, `SHMagCoeffs.from_file()`, and `read_icgem_gfc()`
* Added support for reading "icgem gfc" files in `SHGravCoeffs.from_file()`.
* Added support for reading binary "bshc" files with the new function `shio.read_bshc()`, as well as in `SHCoeffs.from_file()`, `SHMagCoeffs.from_file()`, and `SHGravCoeffs.from_file()`.
* Fixed a bug in `Curve2Mask` python wrapper when using extended grids, and fixed a bug in the fortran code when the input file contained points at exactly 0 or 360 degree.
* Added the function `shio.read_igrf()` for reading IGRF formatted files, and returning coefficients for a specified year.
* Added support to `SHMagCoeffs.from_file()` for reading "igrf" formatted files.
* Added the function `shio.read_dov()` for reading spherical harmonic text files formatted as [degree, order, value]. Added support for reading these files in `SHCoeffs.from_file()`, `SHGravCoeffs.from_file()` and `SHMagCoeffs.from_file()`.