### PR TITLE
Add initial support for fpm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ matrix:
   include:
     # Test Python 3.7 on Linux and OSX
     - os: linux
-      env: PYTHON_VERSION=3.7
+      env: PYTHON_VERSION=3.8
     - os: osx
-      env: PYTHON_VERSION=3.7
+      env: PYTHON_VERSION=3.8
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ install-fortran: fortran
 	mkdir -pv $(DESTDIR)$(SYSMODPATH)
 	cp $(MODPATH)/*.mod $(DESTDIR)$(SYSMODPATH)/
 	mkdir -pv $(DESTDIR)$(SYSSHAREPATH)/examples/shtools
-	cp -R examples/fortran $(DESTDIR)$(SYSSHAREPATH)/examples/shtools/
+	cp -R examples/fortran/ $(DESTDIR)$(SYSSHAREPATH)/examples/shtools/
 	mkdir -pv $(DESTDIR)$(SYSSHAREPATH)/man/man1
 	cp -R man/man1/ $(DESTDIR)$(SYSSHAREPATH)/man/man1/
 	awk '{gsub("../../lib","$(PREFIX)/lib");print}' "examples/fortran/Makefile" > "temp.txt"

--- a/Makefile
+++ b/Makefile
@@ -122,36 +122,37 @@
 ###############################################################################
 
 VERSION = 4.7
+
 LIBNAME = SHTOOLS
 LIBNAMEMP = SHTOOLS-mp
+
+LAPACK_UNDERSCORE = 0
 
 F95 = gfortran
 PYTHON = python3
 JUPYTER = jupyter nbconvert --ExecutePreprocessor.kernel_name=python3
 JEKYLL = bundle exec jekyll
 FLAKE8 = flake8
-
-PREFIX = /usr/local
-SYSLIBPATH = $(PREFIX)/lib
-
-FFTW = -L$(SYSLIBPATH) -lfftw3 -lm
-LAPACK_UNDERSCORE = 0
-
 SHELL = /bin/sh
+
 FDOCDIR = src/fdoc
 PYDOCDIR = src/pydoc
 SRCDIR = src
 LIBDIR = lib
-INCDIR = modules
+MODDIR = modules
 FEXDIR = examples/fortran
 PEXDIR = examples/python
 NBDIR = examples/notebooks
 WWWSRC = docs
 WWWDEST = www
-
 LIBPATH = $(PWD)/$(LIBDIR)
-MODPATH = $(PWD)/$(INCDIR)
+MODPATH = $(PWD)/$(MODDIR)
 PYPATH = $(PWD)
+
+PREFIX = /usr/local
+
+SYSLIBPATH = $(PREFIX)/lib
+FFTW = -L$(SYSLIBPATH) -lfftw3 -lm
 SYSMODPATH = $(PREFIX)/include
 PY3EXT = $(shell $(PYTHON) -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))' || echo nopy3)
 SYSSHAREPATH = $(PREFIX)/share
@@ -238,9 +239,9 @@ help:
 all: fortran
 
 fortran:
-	mkdir -pv lib
-	mkdir -pv modules
-	$(MAKE) -C $(SRCDIR) -f Makefile all F95="$(F95)" F95FLAGS="$(F95FLAGS)" LIBNAME="$(LIBNAME)" LAPACK_FLAGS="$(LAPACK_FLAGS)"
+	mkdir -pv $(LIBPATH)
+	mkdir -pv $(MODPATH)
+	$(MAKE) -C $(SRCDIR) -f Makefile all F95="$(F95)" F95FLAGS="$(F95FLAGS)" LIBNAME="$(LIBNAME)" LAPACK_FLAGS="$(LAPACK_FLAGS)" LIBPATH="$(LIBPATH)" MODPATH="$(MODPATH)"
 	@echo "--> make fortran successful!"
 	@echo
 	@echo "Compile your Fortran code with the following flags:"
@@ -250,10 +251,10 @@ fortran:
 
 fortran-mp:
 # Delete .o files before and after compiling with OpenMP to avoid issues with "fortran" build.
-	mkdir -pv lib
-	mkdir -pv modules
+	mkdir -pv $(LIBPATH)
+	mkdir -pv $(MODPATH)
 	-$(MAKE) -C $(SRCDIR) -f Makefile clean-obs-mod
-	$(MAKE) -C $(SRCDIR) -f Makefile all F95="$(F95)" F95FLAGS="$(OPENMPFLAGS) $(F95FLAGS)" LIBNAME="$(LIBNAMEMP)" LAPACK_FLAGS="$(LAPACK_FLAGS)"
+	$(MAKE) -C $(SRCDIR) -f Makefile all F95="$(F95)" F95FLAGS="$(OPENMPFLAGS) $(F95FLAGS)" LIBNAME="$(LIBNAMEMP)" LAPACK_FLAGS="$(LAPACK_FLAGS)" LIBPATH="$(LIBPATH)" MODPATH="$(MODPATH)"
 	-$(MAKE) -C $(SRCDIR) -f Makefile clean-obs-mod
 	@echo "--> make fortran-mp successful!"
 	@echo
@@ -267,10 +268,10 @@ install-fortran: fortran
 	-rm -r $(DESTDIR)$(SYSMODPATH)/planetsconstants.mod
 	-rm -r $(DESTDIR)$(SYSMODPATH)/shtools.mod
 	mkdir -pv $(DESTDIR)$(SYSLIBPATH)
-	cp $(LIBDIR)/lib$(LIBNAME).a $(DESTDIR)$(SYSLIBPATH)/lib$(LIBNAME).a
-	-cp $(LIBDIR)/lib$(LIBNAMEMP).a $(DESTDIR)$(SYSLIBPATH)/lib$(LIBNAMEMP).a
+	cp $(LIBPATH)/lib$(LIBNAME).a $(DESTDIR)$(SYSLIBPATH)/lib$(LIBNAME).a
+	-cp $(LIBPATH)/lib$(LIBNAMEMP).a $(DESTDIR)$(SYSLIBPATH)/lib$(LIBNAMEMP).a
 	mkdir -pv $(DESTDIR)$(SYSMODPATH)
-	cp $(INCDIR)/*.mod $(DESTDIR)$(SYSMODPATH)/
+	cp $(MODPATH)/*.mod $(DESTDIR)$(SYSMODPATH)/
 	mkdir -pv $(DESTDIR)$(SYSSHAREPATH)/shtools
 	cp -R examples $(DESTDIR)$(SYSSHAREPATH)/shtools/
 	mkdir -pv $(DESTDIR)$(SYSSHAREPATH)/man/man1
@@ -349,8 +350,8 @@ clean-python:
 
 clean-libs:
 	@-$(MAKE) -C $(SRCDIR) -f Makefile clean
-	@-rm -rf lib
-	@-rm -rf modules
+	@-rm -rf $(LIBPATH)
+	@-rm -rf $(MODPATH)
 	@-rm -rf NONE
 	@-rm -rf build
 	@-rm -rf pyshtools.egg-info

--- a/Makefile
+++ b/Makefile
@@ -63,15 +63,18 @@
 #       Remove the compiled lib, module, object, and Python files. Also removes
 #       compiled fortran and Python tests.
 #
-#   make fortran-tests
-#       Compile and run example Fortran programs and test suite. Optional
-#       parameters should be identical to those used to make "all".
-#
 #   make run-fortran-tests
 #       Run all Fortran examples and test suite.
 #
 #   make run-fortran-tests-no-timing
 #       Run all Fortran examples and test suite (excluding the timing tests).
+#
+#   make run-fortran-tests-mp
+#       Run all Fortran OpenMP examples and test suite.
+#
+#   make run-fortran-tests-no-timing-mp
+#       Run all Fortran OpenMP examples and test suite (excluding the timing
+#       tests).
 #
 #   make clean-fortran-tests
 #       Delete compiled Fortran test suite programs.
@@ -395,12 +398,22 @@ fortran-tests-no-timing-mp: fortran-mp
 	@echo "--> Ran all Fortran examples and tests"
 
 run-fortran-tests: fortran
-	@$(MAKE) -C $(FEXDIR) -f Makefile run-fortran-tests
+	@$(MAKE) -C $(FEXDIR) -f Makefile run-fortran-tests F95="$(F95)" F95FLAGS="$(F95FLAGS)" LIBNAME="$(LIBNAME)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)"
 	@echo
 	@echo "--> Ran all Fortran examples and tests"
 
 run-fortran-tests-no-timing: fortran
-	@$(MAKE) -C $(FEXDIR) -f Makefile run-fortran-tests-no-timing
+	@$(MAKE) -C $(FEXDIR) -f Makefile run-fortran-tests-no-timing F95="$(F95)" F95FLAGS="$(F95FLAGS)" LIBNAME="$(LIBNAME)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)"
+	@echo
+	@echo "--> Ran all Fortran examples and tests"
+
+run-fortran-tests-mp: fortran-mp
+	@$(MAKE) -C $(FEXDIR) -f Makefile run-fortran-tests LIBNAME="$(LIBNAMEMP)" F95="$(F95)" F95FLAGS="$(OPENMPFLAGS) $(F95FLAGS)" LIBNAME="$(LIBNAMEMP)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)"
+	@echo
+	@echo "--> Ran all Fortran examples and tests"
+
+run-fortran-tests-no-timing-mp: fortran-mp
+	@$(MAKE) -C $(FEXDIR) -f Makefile run-fortran-tests-no-timing LIBNAME="$(LIBNAMEMP)" F95="$(F95)" F95FLAGS="$(OPENMPFLAGS) $(F95FLAGS)" LIBNAME="$(LIBNAMEMP)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)"
 	@echo
 	@echo "--> Ran all Fortran examples and tests"
 

--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ Further installation instructions and options can be found in the [web documenta
 
 SHTOOLS can be invoked in any Fortran 95 or Python program. The core software is written in Fortran 95, and Python wrappers and dedicated classes allow simple access to the fortran-compiled routines. A variety of Python tutorials and guides are included that demonstrate the major features of the library.
 
-To get started, check out the following Python tutorial notebooks:
+To get started, check out the following Python tutorials:
 
-* [Spherical harmonic coefficients and grids](https://shtools.github.io/SHTOOLS/pages/mydoc/notebooks/grids-and-coefficients.html)
-* [Localization windows and spectral analysis](https://shtools.github.io/SHTOOLS/pages/mydoc/notebooks/localized-spectral-analysis.html)
-* [Gravity and magnetic fields](https://shtools.github.io/SHTOOLS/pages/mydoc/notebooks/gravity-and-magnetic-fields.html)
-* [Plotting maps](https://shtools.github.io/SHTOOLS/pages/mydoc/notebooks/plotting-maps.html)
+* [Spherical harmonic coefficients and grids](https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/master/examples/notebooks/grids-and-coefficients.ipynb)
+* [Localization windows and spectral analysis](https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/master/examples/notebooks/localized-spectral-analysis.ipynb)
+* [Gravity and magnetic fields](https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/master/examples/notebooks/gravity-and-magnetic-fields.ipynb)
+* [Plotting maps](https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/master/examples/notebooks/plotting-maps.ipynb)
 
 ### DEVELOPERS ###
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ spherical harmonic transforms, multitaper spectral analyses, expansions of funct
 * OpenMP compatible and OpenMP thread-safe versions of the Fortran routines.
 
 ### INSTALLATION ###
-#### pyshtools for Python ####
+#### pyshtools (for Python) ####
 
-Binary install using pip or conda (Linux, macOS and Windows):
+Binary install using pip or conda:
 ```bash
 pip install pyshtools
 pip install --upgrade pyshtools  # to upgrade a pre-existing installation
@@ -46,42 +46,44 @@ Build from source:
 pip install pyshtools --no-binary pyshtools
 ```
 
-To install the develop branch from source:
+Install the develop branch from source:
 ```bash
 pip install git+https://github.com/SHTOOLS/SHTOOLS@develop
 ```
 
-#### pyshtools for developers ####
-Linux requirements:
+For developers, install the requirements
 ```bash
+# Linux
 sudo apt-get install libblas-dev liblapack-dev g++ gfortran libfftw3-dev tcsh
-```
-macOS requirements:
-```bash
+# macOS: install fftw using brew or macports
 brew install fftw
-# for lapack and blas, link to the system '-framework Accelerate'
+sudo port install fftw-3
+# macOS: for LAPACK, link to the system '-framework Accelerate'
 ```
 
-Clone the shtools repo and then install:
+then clone the shtools repo and install manually:
 ```bash
 git clone https://github.com/SHTOOLS/SHTOOLS.git
 cd shtools
 git checkout develop
-pip install .  # install into the active python environment lib folder, or
-pip install -e .  # install into the SHTOOLS/pyshtools folder and link to the active python environment
+pip install -e .  # install into the shtools folder and link to the active python environment
 ```
 
-#### Fortran Library ####
-Clone the shtools repo, and then execute one of the following commands in the shtools directory:
+#### SHTOOLS (for Fortran 95) ####
+Clone the shtools repo, and then execute one (or both) of the following commands in the shtools directory:
 ```bash
 make fortran
 make fortran-mp  # for OpenMP Fortran routines
 ```
-Or use the [brew](http://brew.sh/) package manager (macOS):
+Alternatively, use the [brew](http://brew.sh/) package manager (macOS)
 ```bash
 brew tap shtools/shtools
 brew install shtools
 brew install shtools --with-openmp  # to install shtools with the OpenMP components.
+```
+or the [macports](https://www.macports.org/) package manager (macOS)
+```bash
+sudo port install shtools
 ```
 
 Further installation instructions and options can be found in the [web documentation](https://shtools.github.io/SHTOOLS/).

--- a/docs/pages/fortran/fortran-installing.md
+++ b/docs/pages/fortran/fortran-installing.md
@@ -8,7 +8,7 @@ toc: true
 folder: fortran
 ---
 
-## Fortran 95 library using brew (macOS)
+## brew (macOS)
 
 If the [brew](https://brew.sh/) package manager is already installed, it is only necessary to enter the following commands in the terminal:
 ```bash
@@ -25,7 +25,7 @@ To install the example data files and test programs, add the option `--with-exam
 brew install shtools --with-examples
 ```
 
-## Fortran 95 library using the Makefile
+## Using the Makefile
 
 Before trying to install the Fortran 95 components of SHTOOLS, it will be necessary to have a Fortran 95 compiler and [LAPACK](https://www.netlib.org/lapack/), [BLAS](https://www.netlib.org/blas/) and [FFTW3](http://www.fftw.org)-compatible libraries. On most linux distributions, this can be accomplished using
 ```bash

--- a/docs/pages/fortran/fortran-installing.md
+++ b/docs/pages/fortran/fortran-installing.md
@@ -3,7 +3,7 @@ title: "Installing SHTOOLS"
 keywords: spherical harmonics software package, spherical harmonic transform, legendre functions, multitaper spectral analysis, fortran, Python, gravity, magnetic field
 sidebar: fortran_sidebar
 permalink: fortran-installing.html
-summary: SHTOOLS can be installed manually using the Makefile or by using the macOS package manager brew.
+summary: SHTOOLS can be installed using the brew and macports package managers, or manually using the Makefile.
 toc: true
 folder: fortran
 ---
@@ -20,9 +20,30 @@ To install the OpenMP components along with the standard Fortran 95 library, add
 brew install shtools --with-openmp
 ```
 
-To install the example data files and test programs, add the option `--with-examples`:
+To install the example data files and test programs in the directory `/usr/local/share/shtools/` use:
 ```bash
 brew install shtools --with-examples
+```
+
+To run the test suite, use
+```bash
+brew test shtools
+```
+The output of the tests can be inspected in the user's `Library/Logs/Homebrew/shtools` directory.
+
+## macports (macOS)
+
+If the [macports](https://www.macports.org/) package manager is already installed, it is only necessary to enter the following command in the terminal:
+```bash
+sudo port install shtools
+```
+To install the OpenMP components along with the standard Fortran 95 library, add the option `+openmp` to the last command:
+```bash
+sudo port install shtools +openmp
+```
+To run the test suite, which is located in `/opt/local/share/examples/shtools`, use the command
+```bash
+sudo port test shtools
 ```
 
 ## Using the Makefile
@@ -31,9 +52,10 @@ Before trying to install the Fortran 95 components of SHTOOLS, it will be necess
 ```bash
 sudo apt-get install libblas-dev liblapack-dev g++ gfortran libfftw3-dev tcsh
 ```
-or on macOS using [brew](https://brew.sh/)
+or on macOS using either [brew](https://brew.sh/) or [macports](https://www.macports.org/)
 ```bash
 brew install fftw
+sudo port install fftw-3
 # lapack and blas can be accessed by linking to the system '-framework Accelerate'
 ```
 

--- a/docs/pages/fortran/index-fortran.md
+++ b/docs/pages/fortran/index-fortran.md
@@ -33,11 +33,17 @@ make fortran
 make fortran-mp  # for OpenMP support
 ```
 
-Alternatively, install using the macOS package manager brew
+Alternatively, install using the [brew](http://brew.sh/) package manager (macOS)
 
 ```bash
 brew tap shtools/shtools
 brew install shtools
+brew install shtools --with-openmp  # to install shtools with the OpenMP components.
+```
+
+or the [macports](https://www.macports.org/) package manager (macOS)
+```bash
+sudo port install shtools
 ```
 
 ## Permissive licensing

--- a/docs/pages/fortran/using-with-f95.md
+++ b/docs/pages/fortran/using-with-f95.md
@@ -86,4 +86,4 @@ Documentation for the Fortran 95 subroutines and functions in SHTOOLS can be acc
 ```bash
 man makegriddh
 ```
-Alternatively, the man pages can be accessed from the *Fortran 95 Routines* menu on this web site.
+Alternatively, the man pages can be accessed from the *Fortran 95 Reference* menu on this web site.

--- a/docs/pages/mydoc/python-examples.md
+++ b/docs/pages/mydoc/python-examples.md
@@ -26,10 +26,10 @@ The tutorials are designed for python users who are encountering pyshtools for t
 
 | Tutorial | Description |
 | ------------- | ----------- |
-| <a href="https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/develop/examples/notebooks/grids-and-coefficients.ipynb" target="_blank" rel="noopener">Spherical harmonic coefficients and grids</a> | Learn how to transform spherical harmonic coefficients into maps, maps into spherical harmonic coefficients, and how to plot the power spectrum. |
-| <a href="https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/develop/examples/notebooks/localized-spectral-analysis.ipynb" target="_blank" rel="noopener">Localization windows and spectral analysis</a> | Learn how to obtain the power spectrum of a function, localized to any region on the sphere. |
-| <a href="https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/develop/examples/notebooks/gravity-and-magnetic-fields.ipynb" target="_blank" rel="noopener">Gravity and magnetic fields</a> | Learn how to read gravity spherical harmonic coefficients from a file, and to make maps of the geoid and free-air gravity. |
-| <a href="https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/develop/examples/notebooks/plotting-maps.ipynb" target="_blank" rel="noopener">Plotting maps</a> | Learn how to make publication quality images using geographical projections. |
+| <a href="https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/master/examples/notebooks/grids-and-coefficients.ipynb" target="_blank" rel="noopener">Spherical harmonic coefficients and grids</a> | Learn how to transform spherical harmonic coefficients into maps, maps into spherical harmonic coefficients, and how to plot the power spectrum. |
+| <a href="https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/master/examples/notebooks/localized-spectral-analysis.ipynb" target="_blank" rel="noopener">Localization windows and spectral analysis</a> | Learn how to obtain the power spectrum of a function, localized to any region on the sphere. |
+| <a href="https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/master/examples/notebooks/gravity-and-magnetic-fields.ipynb" target="_blank" rel="noopener">Gravity and magnetic fields</a> | Learn how to read gravity spherical harmonic coefficients from a file, and to make maps of the geoid and free-air gravity. |
+| <a href="https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/master/examples/notebooks/plotting-maps.ipynb" target="_blank" rel="noopener">Plotting maps</a> | Learn how to make publication quality images using geographical projections. |
 
 
 ## Guides
@@ -38,9 +38,9 @@ These guides assume that the user already has a basic understanding of how pysht
 
 | Guide | Description |
 | ------------- | ----------- |
-| <a href="https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/develop/examples/notebooks/low-level-spherical-harmonic-analyses.ipynb" target="_blank" rel="noopener">Low-level spherical harmonic analyses</a> | Learn how to do spherical harmonic analyses using low-level functions (without SHCoeffs and SHGrid classes). |
-| <a href="https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/develop/examples/notebooks/advanced-shcoeffs-and-shgrid-usage.ipynb" target="_blank" rel="noopener">Advanced usage of SHCoeffs and SHGrid</a> | Learn advanced features of the SHCoeffs and SHGrid class interfaces. |
-| <a href="https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/develop/examples/notebooks/spherical-harmonic-normalizations.ipynb" target="_blank" rel="noopener">Spherical harmonic normalizations</a> | Learn more about spherical harmonic normalizations and Parseval's theorem. |
-| <a href="https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/develop/examples/notebooks/advanced-localized-spectral-analysis.ipynb" target="_blank" rel="noopener">Advanced localized spectral analysis</a> | Learn more about performing localized spectral analyses on the sphere. |
-| <a href="https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/develop/examples/notebooks/advanced-shwindow-usage.ipynb" target="_blank" rel="noopener">Advanced usage of SHWindow</a> | Learn advanced features of the SHWindow class interface. |
-| <a href="https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/develop/examples/notebooks/3d-plots.ipynb" target="_blank" rel="noopener">3D plots</a> | Learn how to make 3-dimensional plots of gridded data. |
+| <a href="https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/master/examples/notebooks/low-level-spherical-harmonic-analyses.ipynb" target="_blank" rel="noopener">Low-level spherical harmonic analyses</a> | Learn how to do spherical harmonic analyses using low-level functions (without SHCoeffs and SHGrid classes). |
+| <a href="https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/master/examples/notebooks/advanced-shcoeffs-and-shgrid-usage.ipynb" target="_blank" rel="noopener">Advanced usage of SHCoeffs and SHGrid</a> | Learn advanced features of the SHCoeffs and SHGrid class interfaces. |
+| <a href="https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/master/examples/notebooks/spherical-harmonic-normalizations.ipynb" target="_blank" rel="noopener">Spherical harmonic normalizations</a> | Learn more about spherical harmonic normalizations and Parseval's theorem. |
+| <a href="https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/master/examples/notebooks/advanced-localized-spectral-analysis.ipynb" target="_blank" rel="noopener">Advanced localized spectral analysis</a> | Learn more about performing localized spectral analyses on the sphere. |
+| <a href="https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/master/examples/notebooks/advanced-shwindow-usage.ipynb" target="_blank" rel="noopener">Advanced usage of SHWindow</a> | Learn advanced features of the SHWindow class interface. |
+| <a href="https://nbviewer.jupyter.org/github/SHTOOLS/SHTOOLS/blob/master/examples/notebooks/3d-plots.ipynb" target="_blank" rel="noopener">3D plots</a> | Learn how to make 3-dimensional plots of gridded data. |

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: pyshtools
 channels:
     - conda-forge
 dependencies:
-    - python=3.7
+    - python>=3.5
     - numpy
     - scipy>=0.14.0
     - matplotlib

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,0 +1,10 @@
+name = "SHTOOLS"
+version = "4.7"
+license = "BSD-3-Clause"
+author = "Mark A. Wieczorek"
+maintainer = "mark.a.wieczorek@gmail.com"
+copyright = "2020 SHTOOLS"
+
+[library]
+source-dir="src"
+build-script = "make all F95=$FC LIBPATH=$BUILD_DIR MODPATH=$BUILD_DIR"

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,6 +12,11 @@ F95 = gfortran
 
 SHELL = /bin/sh
 
+LIBNAME = SHTOOLS
+LIBPATH = ../lib
+MODPATH = ../modules
+PROG = $(LIBPATH)/lib$(LIBNAME).a
+
 LIBTOOL = libtool
 LIBTOOLFLAGS = -static
 AR = ar
@@ -19,9 +24,6 @@ ARFLAGS = -r
 RLIB = ranlib
 RLIBFLAGS =
 LDFLAGS = -s
-
-LIBNAME = SHTOOLS
-PROG = ../lib/lib$(LIBNAME).a
 
 ifeq ($(F95),f95)
 # Default Absoft Pro Fortran flags
@@ -123,9 +125,9 @@ $(PROG): $(OBJS)
 	@echo
 	@echo "--> Creation of static library successful"
 #	@rm -f $(OBJS)
-#	@mv -f *.mod ../modules/
-	@cp -f *.mod ../modules/
-	@echo "--> Library and module files moved to ../lib and ../modules"
+#	@mv -f *.mod $(MODPATH)/
+	@cp -f *.mod $(MODPATH)/
+	@echo "--> Library and module files moved to $(LIBPATH) and $(MODPATH)"
 	@echo "--> Archive created successfully"
 
 .PHONY: clean clean-obs-mod clean-prog-mod all
@@ -142,7 +144,7 @@ clean-obs-mod:
 
 clean-prog-mod:
 	@-rm -f $(PROG)
-	@-rm -f ../modules/*.mod
+	@-rm -f $(MODPATH)/*.mod
 
 %.mod: %.f95
 	$(F95) -c $(F95FLAGS) $<

--- a/src/fdoc/Makefile
+++ b/src/fdoc/Makefile
@@ -15,6 +15,7 @@
 ###############################################################################
 
 SHELL=/bin/sh
+PREFIX=/usr/local
 
 PANDOC = pandoc
 MANDIR = ../../man/man1
@@ -95,7 +96,7 @@ clean:
 	-rm -f $(MANFILES)
 
 uninstall:
-	-cd /usr/local/share/man/man1/ ; rm $(MANFILES)
+	-cd $(PREFIX)/share/man/man1/ ; rm $(MANFILES)
 
 
 .SUFFIXES: $(SUFFIXES) .md .1


### PR DESCRIPTION
This PR adds initial experimental support for fpm: the [fortran package manager](https://github.com/fortran-lang/fpm).

To install as a stand-alone project, it is only necesssary to use the command
```
fpm build
```
This will place the necessary .mod and .a files in a subdirectory of `build`.

To include shtools as a dependency in a project that compiles with fpm, you only need to add the following to the `fpm.toml` file:
```
[dependencies]
SHTOOLS = {git="https://github.com/SHTOOLS/SHTOOLS.git"}
```

Note that this feature is experimental. In the current state of fpm (which is undergoing active development), it is not possible to link to system wide libraries, such as fftw and lapack, which are required by shtools. This will hopefully be resolved [soon](https://github.com/fortran-lang/fpm/issues/119).