### PR TITLE
Set xarray.gmt accessor for grids when pygmt is loaded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -341,6 +341,7 @@ clean-python:
 	@-rm -rf _SHTOOLS.so.dSYM/
 	@-rm -rf pyshtools/_SHTOOLS.so.dSYM/
 	@-rm -f *.so
+	@-rm -rf __pycache__/
 	@-rm -f pyshtools/*.so
 	@-rm -f pyshtools/*.pyc
 	@-rm -rf pyshtools/__pycache__/

--- a/pyshtools/__init__.py
+++ b/pyshtools/__init__.py
@@ -3,7 +3,8 @@ pyshtools
 =========
 
 pyshtools a scientific package that can be used to perform spherical harmonic
-transforms and reconstructions, rotations of data expressed in spherical harmonics, and multitaper spectral analyses on the sphere.
+transforms and reconstructions, rotations of data expressed in spherical
+harmonics, and multitaper spectral analyses on the sphere.
 
 This module imports the following classes and subpackages into the
 main namespace:

--- a/pyshtools/shclasses/shgeoid.py
+++ b/pyshtools/shclasses/shgeoid.py
@@ -6,6 +6,7 @@ import copy as _copy
 import xarray as _xr
 
 from .shgrid import SHGrid as _SHGrid
+from .shgrid import _pygmt_module
 
 
 class SHGeoid(object):
@@ -339,10 +340,14 @@ class SHGeoid(object):
         if self.epoch is not None:
             attrs['epoch'] = self.epoch
 
-        return _xr.DataArray(self.geoid.to_array(),
-                             dims=('latitude', 'longitude'),
-                             coords=[('latitude', self.geoid.lats(),
-                                      {'units': 'degrees_north'}),
-                                     ('longitude', self.geoid.lons(),
-                                      {'units': 'degrees_east'})],
-                             attrs=attrs)
+        da = _xr.DataArray(self.geoid.to_array(),
+                           dims=('latitude', 'longitude'),
+                           coords=[('latitude', self.geoid.lats(),
+                                    {'units': 'degrees_north'}),
+                                   ('longitude', self.geoid.lons(),
+                                    {'units': 'degrees_east'})],
+                           attrs=attrs)
+        if _pygmt_module:
+            da.gmt.registration = 0
+            da.gmt.gtype = 1
+        return da

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -481,18 +481,22 @@ class SHGrid(object):
         if units is not None:
             attrs['units'] = units
 
-        return _xr.DataArray(self.to_array(),
-                             coords=[('lat', self.lats(),
-                                      {'long_name': 'latitude',
-                                       'units': 'degrees_north',
-                                       'actual_range': [self.lats()[0],
-                                                        self.lats()[-1]]}),
-                                     ('lon', self.lons(),
-                                      {'long_name': 'longitude',
-                                       'units': 'degrees_east',
-                                       'actual_range': [self.lons()[0],
-                                                        self.lons()[-1]]})],
-                             attrs=attrs)
+        da = _xr.DataArray(self.to_array(),
+                           coords=[('lat', self.lats(),
+                                    {'long_name': 'latitude',
+                                     'units': 'degrees_north',
+                                     'actual_range': [self.lats()[0],
+                                                      self.lats()[-1]]}),
+                                   ('lon', self.lons(),
+                                    {'long_name': 'longitude',
+                                     'units': 'degrees_east',
+                                     'actual_range': [self.lons()[0],
+                                                      self.lons()[-1]]})],
+                           attrs=attrs)
+        if _pygmt_module:
+            da.gmt.registration = 0
+            da.gmt.gtype = 1
+        return da
 
     def to_netcdf(self, filename=None, title=None, description=None,
                   comment='pyshtools grid', name='data',


### PR DESCRIPTION
This simple PR sets the gmt xarray accessor when exporting numpy grids to xarray.