### PR TITLE
Compute and plot the admittance and correlation

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 # to publish on github page
 gem 'github-pages', group: :jekyll_plugins
+#gem 'jekyll_version_plugin', group: :jekyll_plugins
 
 # to publish without github page
 #gem "jekyll"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -187,6 +187,7 @@ GEM
       jekyll (>= 3.3, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
+    jekyll_version_plugin (2.0.0)
     jemoji (0.11.1)
       gemoji (~> 3.0)
       html-pipeline (~> 2.2)
@@ -236,13 +237,14 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
-    zeitwerk (2.3.1)
+    zeitwerk (2.4.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   github-pages
+  jekyll_version_plugin
 
 BUNDLED WITH
    2.1.4

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -95,4 +95,4 @@ url : https://shtools.github.io/SHTOOLS
 baseurl: /SHTOOLS
 
 plugins:
-  - "jekyll-github-metadata"
+  - jekyll-github-metadata

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -1,6 +1,6 @@
 {% assign sidebar = site.data.sidebars[page.sidebar].entries %}
 
-<ul id="mysidebar" class="nav">
+<ul id="mysidebar" class="nav"> 
   <li class="sidebarTitle">{{sidebar[0].product}} {{sidebar[0].version}}</li>
   {% for entry in sidebar %}
   {% for folder in entry.folders %}

--- a/docs/pages/mydoc/python-datasets-constants.md
+++ b/docs/pages/mydoc/python-datasets-constants.md
@@ -84,7 +84,7 @@ The following is the list of implemented datasets:
 | GGM05C | Degree 360 model of the Earth's gravity field in a zero-tide system (Ries et al. 2016). This model is based on data from altimetry, ground-based measurements, and the satellites GOCE and GRACE. |
 | GOCO06S | Degree 300 model of the Earth's gravity field in a zero-tide system (Kvas et al. 2019). This model is based solely on satellite data. |
 | EIGEN_GRGS_RL04_MEAN_FIELD | Degree 300 model of the Earth's gravity field in a tide-free system (Lemoine et al. 2019). This model is based solely on satellite data. |
-| XGM2019E | Degree 2190 experimental model of the Earth's gravity field in a zero-tide system (Zingerle et al. 2019). This model is based on data from altimetry, ground-based measurements, topography, and satellites. |
+| XGM2019E | Degree 2190 model of the Earth's gravity field in a zero-tide system (Zingerle et al. 2020). This combined model is based on data from altimetry, ground-based measurements, topography, and satellites. |
 | IGRF_13 | Degree 13 time-variable model of the Earth's main magnetic field that is valid between 1900 and 2020 (Thébault et al. 2015). |
 | SWARM_MLI_2D_0501 | Degree 133 magnetic field model of the Earth's lithsophere that is based largely on satellite data (Thébault et al. 2013). Though this model is based largely on data from the SWARM mission, data from the CHAMP mission  and some ground-based measurements are also used. |
 | NGDC_720_V3 | Degree 740 magnetic field model of the Earth's lithsophere that was compiled from satellite, marine, aeromagnetic and ground-based magnetic surveys (Maus 2010). |

--- a/docs/pages/mydoc/python-datasets-constants.md
+++ b/docs/pages/mydoc/python-datasets-constants.md
@@ -102,6 +102,7 @@ The following is the list of implemented datasets:
 | GL0900D | JPL 900 degree and order spherical harmonic model of the gravitational potential of the Moon (Konopliv et al. 2014). This model applies a Kaula constraint for degrees greater than 700. |
 | GL1500E | JPL 1500 degree and order spherical harmonic model of the gravitational potential of the Moon (Konopliv et al. 2014). This model applies a Kaula constraint for degrees greater than 700. |
 | T2015_449 | 449 degree and order spherical harmonic model of the magnetic potential of the Moon. This model was used in Wieczorek (2018) and is a spherical harmonic expansion of the global magnetic field model of Tsunakawa et al. (2015). |
+| Ravat2020 | 450 degree and order spherical harmonic model of the magnetic potential of the Moon. This model is based on using magnetic monopoles with an L1-norm regularisation. |
 
 
 ### Mars

--- a/docs/pages/mydoc/python-shcoeffs.md
+++ b/docs/pages/mydoc/python-shcoeffs.md
@@ -22,8 +22,8 @@ table:nth-of-type(n) th:nth-of-type(2) {
 
 | Subclass name | Description |
 | ------------- | ----------- |
-| SHRealCoeffs | Real spherical harmonic coefficient class. |
-| SHComplexCoeffs | Complex spherical harmonic coefficient class. |
+| SHRealCoeffs | Real spherical harmonic coefficients class. |
+| SHComplexCoeffs | Complex spherical harmonic coefficients class. |
 
 ## Initialization
 
@@ -71,11 +71,11 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | `expand()` | Evaluate the coefficients either on a spherical grid and return an SHGrid class instance, or for a list of latitude and longitude coordinates. |
 | `plot_spectrum()` | Plot the spectrum as a function of spherical harmonic degree. |
 | `plot_cross_spectrum()` | Plot the cross-spectrum of two functions. |
+| `plot_spectrum2d()` | Plot the spectrum of all spherical-harmonic coefficients. |
+| `plot_cross_spectrum2d()` | Plot the cross-spectrum of all spherical-harmonic coefficients. |
 | `plot_admittance()` | Plot the admittance with another function. |
 | `plot_correlation()` | Plot the correlation with another function. |
 | `plot_admitcorr()` | Plot the admittance and/or correlation with another function. |
-| `plot_spectrum2d()` | Plot the spectrum of all spherical-harmonic coefficients. |
-| `plot_cross_spectrum2d()` | Plot the cross-spectrum of all spherical-harmonic coefficients. |
 | `to_array()` | Return an array of spherical harmonics coefficients with a different normalization convention. |
 | `to_file()` | Save raw spherical harmonic coefficients to a text or binary file. |
 | `to_netcdf()` | Return the coefficient data as a netcdf formatted file or object. |

--- a/docs/pages/mydoc/python-shcoeffs.md
+++ b/docs/pages/mydoc/python-shcoeffs.md
@@ -59,6 +59,9 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | `degrees()` | Return an array listing the spherical harmonic degrees from `0` to `lmax`. |
 | `spectrum()` | Return the spectrum of the function. |
 | `cross_spectrum()` | Return the cross-spectrum of two functions. |
+| `admittance()` | Return the admittance of two functions. |
+| `correlation()` | Return the spectral correlation of two functions. |
+| `admitcorr()` | Return the admittance and spectral correlation of two functions. |
 | `volume()` | Calculate the volume of the body. |
 | `centroid()` | Calculate the centroid of the body. |
 | `set_coeffs()` | Set coefficients in-place to specified values. |

--- a/docs/pages/mydoc/python-shcoeffs.md
+++ b/docs/pages/mydoc/python-shcoeffs.md
@@ -71,7 +71,9 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | `expand()` | Evaluate the coefficients either on a spherical grid and return an SHGrid class instance, or for a list of latitude and longitude coordinates. |
 | `plot_spectrum()` | Plot the spectrum as a function of spherical harmonic degree. |
 | `plot_cross_spectrum()` | Plot the cross-spectrum of two functions. |
-| `plot_admitcorr()` | Plot the admittance and/or correlation of two functions. |
+| `plot_admittance()` | Plot the admittance with another function. |
+| `plot_correlation()` | Plot the correlation with another function. |
+| `plot_admitcorr()` | Plot the admittance and/or correlation with another function. |
 | `plot_spectrum2d()` | Plot the spectrum of all spherical-harmonic coefficients. |
 | `plot_cross_spectrum2d()` | Plot the cross-spectrum of all spherical-harmonic coefficients. |
 | `to_array()` | Return an array of spherical harmonics coefficients with a different normalization convention. |

--- a/docs/pages/mydoc/python-shcoeffs.md
+++ b/docs/pages/mydoc/python-shcoeffs.md
@@ -59,9 +59,9 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | `degrees()` | Return an array listing the spherical harmonic degrees from `0` to `lmax`. |
 | `spectrum()` | Return the spectrum of the function. |
 | `cross_spectrum()` | Return the cross-spectrum of two functions. |
-| `admittance()` | Return the admittance of two functions. |
-| `correlation()` | Return the spectral correlation of two functions. |
-| `admitcorr()` | Return the admittance and spectral correlation of two functions. |
+| `admittance()` | Return the admittance with another function. |
+| `correlation()` | Return the spectral correlation with another function. |
+| `admitcorr()` | Return the admittance and spectral correlation with another function. |
 | `volume()` | Calculate the volume of the body. |
 | `centroid()` | Calculate the centroid of the body. |
 | `set_coeffs()` | Set coefficients in-place to specified values. |

--- a/docs/pages/mydoc/python-shcoeffs.md
+++ b/docs/pages/mydoc/python-shcoeffs.md
@@ -71,6 +71,7 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | `expand()` | Evaluate the coefficients either on a spherical grid and return an SHGrid class instance, or for a list of latitude and longitude coordinates. |
 | `plot_spectrum()` | Plot the spectrum as a function of spherical harmonic degree. |
 | `plot_cross_spectrum()` | Plot the cross-spectrum of two functions. |
+| `plot_admitcorr()` | Plot the admittance and/or correlation of two functions. |
 | `plot_spectrum2d()` | Plot the spectrum of all spherical-harmonic coefficients. |
 | `plot_cross_spectrum2d()` | Plot the cross-spectrum of all spherical-harmonic coefficients. |
 | `to_array()` | Return an array of spherical harmonics coefficients with a different normalization convention. |

--- a/docs/pages/mydoc/python-shgravcoeffs.md
+++ b/docs/pages/mydoc/python-shgravcoeffs.md
@@ -75,6 +75,9 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | `geoid()` | Calculate the height of the geoid and return an SHGeoid class instance. |
 | `plot_spectrum()` | Plot the spectrum as a function of spherical harmonic degree. |
 | `plot_spectrum2d()` | Plot the spectrum of all spherical-harmonic coefficients. |
+| `plot_correlation()` | Plot the correlation with another function. |
+| `plot_admittance()` | Plot the admittance with an input topography function. |
+| `plot_admitcorr()` | Plot the admittance and/or correlation with an input topography function. |
 | `to_array()` | Return an array of spherical harmonics coefficients with a different normalization convention. |
 | `to_file()` | Save raw spherical harmonic coefficients to a text or binary file. |
 | `to_netcdf()` | Return the coefficient data as a netcdf formatted file or object. |

--- a/docs/pages/mydoc/python-shgravcoeffs.md
+++ b/docs/pages/mydoc/python-shgravcoeffs.md
@@ -61,6 +61,9 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | ------ | ----------- |
 | `degrees()` | Return an array listing the spherical harmonic degrees from `0` to `lmax`. |
 | `spectrum()` | Return the spectrum of the function. |
+| `admittance()` | Return the admittance with an input topography function. |
+| `correlation()` | Return the spectral correlation with another function. |
+| `admitcorr()` | Return the admittance and spectral correlation with an input topography function. |
 | `set_omega()` | Set the angular rotation rate of the body. |
 | `set_coeffs()` | Set coefficients in-place to specified values.|
 | `change_ref()` | Return a new class instance referenced to a different gm, r0, or omega. |

--- a/docs/pages/mydoc/python-shmagcoeffs.md
+++ b/docs/pages/mydoc/python-shmagcoeffs.md
@@ -68,6 +68,7 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | `tensor()` | Calculate the 9 components of the magnetic field tensor and return an SHMagTensor class instance. |
 | `plot_spectrum()` | Plot the spectrum as a function of spherical harmonic degree. |
 | `plot_spectrum2d()` | Plot the spectrum of all spherical-harmonic coefficients. |
+| `plot_correlation()` | Plot the correlation with another function. |
 | `to_array()` | Return an array of spherical harmonics coefficients with a different normalization convention. |
 | `to_file()` | Save raw spherical harmonic coefficients to a text or binary file. |
 | `to_netcdf()` | Return the coefficient data as a netcdf formatted file or object. |

--- a/docs/pages/mydoc/python-shmagcoeffs.md
+++ b/docs/pages/mydoc/python-shmagcoeffs.md
@@ -58,6 +58,7 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | ------ | ----------- |
 | `degrees()` | Return an array listing the spherical harmonic degrees from `0` to `lmax`. |
 | `spectrum()` | Return the spectrum of the function. |
+| `correlation()` | Return the spectral correlation with another function. |
 | `set_coeffs()` | Set coefficients in-place to specified values.|
 | `change_ref()` | Return a new class instance referenced to a different reference radius, r0. |
 | `rotate()` | Rotate the coordinate system used to express the spherical harmonics coefficients and return a new class instance.|

--- a/pyshtools/__init__.py
+++ b/pyshtools/__init__.py
@@ -3,7 +3,8 @@ pyshtools
 =========
 
 pyshtools a scientific package that can be used to perform spherical harmonic
-transforms and reconstructions, rotations of data expressed in spherical harmonics, and multitaper spectral analyses on the sphere.
+transforms and reconstructions, rotations of data expressed in spherical
+harmonics, and multitaper spectral analyses on the sphere.
 
 This module imports the following classes and subpackages into the
 main namespace:

--- a/pyshtools/datasets/Earth/__init__.py
+++ b/pyshtools/datasets/Earth/__init__.py
@@ -188,10 +188,10 @@ def EIGEN_GRGS_RL04_MEAN_FIELD(epoch=None, lmax=300):
 
 def XGM2019E(lmax=2190):
     '''
-    XGM2019E is a degree 2190 experimental model of the Earth's gravity field
-    in a zero-tide system. This model is based on data from altimetry,
-    ground-based measurements, topography, and satellites. The error
-    coefficients are formal.
+    XGM2019E is a degree 2190 model of the Earth's gravity field in a zero-tide
+    system. This combined model is based on data from altimetry, ground-based
+    measurements, topography, and satellites. The error coefficients are
+    formal.
 
     Parameters
     ----------
@@ -200,9 +200,9 @@ def XGM2019E(lmax=2190):
 
     Reference
     ---------
-    Zingerle, P., Pail, R., Gruber, T., Oikonomidou, X. (2019). The
-        experimental gravity field model XGM2019e, GFZ Data Services,
-        http://doi.org/10.5880/ICGEM.2019.007.
+    Zingerle, P., Pail, R., Gruber, T., Oikonomidou, X. (2020). The combined
+        global gravity field model XGM2019e, Journal of Geodesy, 94, 66,
+        doi:10.1007/s00190-020-01398-0.
     '''
     fname = _retrieve(
         url="http://icgem.gfz-potsdam.de/getmodel/gfc/eeb03971cf6e533e6eeb6b010336463286dcda0846684248d5530acf8e800055/XGM2019e_2159.gfc",  # noqa: E501

--- a/pyshtools/datasets/Mars.py
+++ b/pyshtools/datasets/Mars.py
@@ -23,6 +23,7 @@ from ..shclasses import SHCoeffs as _SHCoeffs
 from ..shclasses import SHGravCoeffs as _SHGravCoeffs
 from ..shclasses import SHMagCoeffs as _SHMagCoeffs
 from pooch import Decompress as _Decompress
+from ..constants.Mars import omega as _omega
 
 
 def MarsTopo2600(lmax=2600):
@@ -75,7 +76,8 @@ def GMM3(lmax=120):
         path=_os_cache('pyshtools'),
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
-                                   r0_index=0, gm_index=1, errors=True)
+                                   r0_index=0, gm_index=1, errors=True,
+                                   omega=_omega.value)
 
 
 def GMM3_RM1_1E0(lmax=150):
@@ -104,7 +106,8 @@ def GMM3_RM1_1E0(lmax=150):
         path=_os_cache('pyshtools'),
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='m',
-                                   r0_index=1, gm_index=0, errors=False)
+                                   r0_index=1, gm_index=0, errors=False,
+                                   omega=_omega.value)
 
 
 def MRO120D(lmax=120):
@@ -131,7 +134,8 @@ def MRO120D(lmax=120):
         path=_os_cache('pyshtools'),
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
-                                   r0_index=0, gm_index=1, errors=True)
+                                   r0_index=0, gm_index=1, errors=True,
+                                   omega=_omega.value)
 
 
 def Langlais2019(lmax=134):

--- a/pyshtools/datasets/Mercury.py
+++ b/pyshtools/datasets/Mercury.py
@@ -18,6 +18,7 @@ from pooch import retrieve as _retrieve
 from pooch import HTTPDownloader as _HTTPDownloader
 from ..shclasses import SHCoeffs as _SHCoeffs
 from ..shclasses import SHGravCoeffs as _SHGravCoeffs
+from ..constants.Mercury import omega as _omega
 
 
 def GTMES150(lmax=150):
@@ -73,7 +74,7 @@ def JGMESS160A(lmax=160):
         path=_os_cache('pyshtools'),
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
-                                   errors=True)
+                                   errors=True, omega=_omega.value)
 
 
 def JGMESS160A_ACCEL(lmax=160):
@@ -102,7 +103,7 @@ def JGMESS160A_ACCEL(lmax=160):
         path=_os_cache('pyshtools'),
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
-                                   errors=True)
+                                   errors=True, omega=_omega.value)
 
 
 def JGMESS160A_TOPOSIG(lmax=160):
@@ -131,7 +132,7 @@ def JGMESS160A_TOPOSIG(lmax=160):
         path=_os_cache('pyshtools'),
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
-                                   errors=True)
+                                   errors=True, omega=_omega.value)
 
 
 def GGMES100V08(lmax=100):
@@ -160,7 +161,7 @@ def GGMES100V08(lmax=100):
         path=_os_cache('pyshtools'),
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
-                                   errors=True)
+                                   errors=True, omega=_omega.value)
 
 
 __all__ = ['GTMES150', 'JGMESS160A', 'JGMESS160A_ACCEL', 'JGMESS160A_TOPOSIG',

--- a/pyshtools/datasets/Moon.py
+++ b/pyshtools/datasets/Moon.py
@@ -16,6 +16,7 @@ GL1500E           :  Konopliv et al. (2014)
 Magnetic field
 --------------
 T2015_449         :  Wieczorek (2018), using data from Tsunakawa et al. (2015)
+Ravat2020         :  Ravat et al. (2020)
 '''
 from pooch import os_cache as _os_cache
 from pooch import retrieve as _retrieve
@@ -82,6 +83,35 @@ def T2015_449(lmax=449):
     )
     return _SHMagCoeffs.from_file(fname, lmax=lmax, header=True,
                                   file_units='T', units='nT')
+
+
+def Ravat2020(lmax=450):
+    '''
+    Ravat2020 is a 450 degree and order spherical harmonic model of the
+    magnetic potential of the Moon. This model is based on using magnetic
+    monopoles with an L1-norm regularisation. The coefficients are output
+    in units of nT.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    References
+    ----------
+    Ravat, D., Purucker, M. E., Olsen, N. (2020). Lunar magnetic field models
+        from Lunar Prospector and SELENE/Kaguya along‐track magnetic field
+        gradients, Journal of Geophysical Research: Planets, 125,
+        e2019JE006187, doi:10.1029/2019JE006187.
+    '''
+    fname = _retrieve(
+        url="https://uknowledge.uky.edu/cgi/viewcontent.cgi?filename=4&article=1001&context=ees_data&type=additional",  # noqa: E501
+        known_hash="sha256:dd1128d7819a8de097f3abeba93fee4cb80fced5bd63d56cca5a9bc70ac2bea9",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHMagCoeffs.from_file(fname, lmax=lmax, header=True, skip=8,
+                                  header_units='km')
 
 
 def GRGM900C(lmax=900):
@@ -232,5 +262,5 @@ def GL1500E(lmax=1500):
                                    errors=True)
 
 
-__all__ = ['MoonTopo2600p', 'T2015_449', 'GRGM900C', 'GRGM1200B',
+__all__ = ['MoonTopo2600p', 'T2015_449', 'Ravat2020', 'GRGM900C', 'GRGM1200B',
            'GRGM1200B_RM1_1E0', 'GL0900D', 'GL1500E']

--- a/pyshtools/datasets/Moon.py
+++ b/pyshtools/datasets/Moon.py
@@ -24,6 +24,7 @@ from pooch import HTTPDownloader as _HTTPDownloader
 from ..shclasses import SHCoeffs as _SHCoeffs
 from ..shclasses import SHGravCoeffs as _SHGravCoeffs
 from ..shclasses import SHMagCoeffs as _SHMagCoeffs
+from ..constants.Moon import omega as _omega
 
 
 def MoonTopo2600p(lmax=2600):
@@ -140,7 +141,7 @@ def GRGM900C(lmax=900):
         path=_os_cache('pyshtools'),
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
-                                   errors=True)
+                                   errors=True, omega=_omega.value)
 
 
 def GRGM1200B(lmax=1200):
@@ -170,7 +171,8 @@ def GRGM1200B(lmax=1200):
         path=_os_cache('pyshtools'),
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='m',
-                                   r0_index=1, gm_index=0, errors=True)
+                                   r0_index=1, gm_index=0, errors=True,
+                                   omega=_omega.value)
 
 
 def GRGM1200B_RM1_1E0(lmax=1200):
@@ -201,7 +203,8 @@ def GRGM1200B_RM1_1E0(lmax=1200):
         path=_os_cache('pyshtools'),
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='m',
-                                   r0_index=1, gm_index=0, errors=True)
+                                   r0_index=1, gm_index=0, errors=True,
+                                   omega=_omega.value)
 
 
 def GL0900D(lmax=900):
@@ -230,7 +233,7 @@ def GL0900D(lmax=900):
         path=_os_cache('pyshtools'),
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
-                                   errors=True)
+                                   errors=True, omega=_omega.value)
 
 
 def GL1500E(lmax=1500):
@@ -259,7 +262,7 @@ def GL1500E(lmax=1500):
         path=_os_cache('pyshtools'),
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
-                                   errors=True)
+                                   errors=True, omega=_omega.value)
 
 
 __all__ = ['MoonTopo2600p', 'T2015_449', 'Ravat2020', 'GRGM900C', 'GRGM1200B',

--- a/pyshtools/datasets/Venus.py
+++ b/pyshtools/datasets/Venus.py
@@ -14,6 +14,7 @@ from pooch import retrieve as _retrieve
 from pooch import HTTPDownloader as _HTTPDownloader
 from ..shclasses import SHCoeffs as _SHCoeffs
 from ..shclasses import SHGravCoeffs as _SHGravCoeffs
+from ..constants.Venus import omega as _omega
 
 
 def VenusTopo719(lmax=719):
@@ -64,7 +65,7 @@ def MGNP180U(lmax=180):
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, skip=236, header=True,
                                    r0_index=1, gm_index=2, header_units='km',
-                                   errors=True)
+                                   errors=True, omega=_omega.value)
 
 
 __all__ = ['VenusTopo719', 'MGNP180U']

--- a/pyshtools/shclasses/shcoeffs.py
+++ b/pyshtools/shclasses/shcoeffs.py
@@ -25,7 +25,7 @@ from ..shio import write_bshc as _write_bshc
 
 class SHCoeffs(object):
     """
-    Spherical Harmonics Coefficient class.
+    Spherical Harmonic Coefficients class.
 
     The coefficients of this class can be initialized using one of the four
     constructor methods:
@@ -1060,13 +1060,14 @@ class SHCoeffs(object):
 
         ds.to_netcdf(filename)
 
-    def to_array(self, normalization=None, csphase=None, lmax=None):
+    def to_array(self, normalization=None, csphase=None, lmax=None,
+                 errors=True):
         """
         Return spherical harmonic coefficients (and errors) as a numpy array.
 
         Usage
         -----
-        coeffs, [errors] = x.to_array([normalization, csphase, lmax])
+        coeffs, [errors] = x.to_array([normalization, csphase, lmax, errors])
 
         Returns
         -------
@@ -1074,7 +1075,7 @@ class SHCoeffs(object):
             numpy ndarray of the spherical harmonic coefficients.
         errors : ndarry, shape (2, lmax+1, lmax+1)
             numpy ndarray of the errors of the spherical harmonic
-            coefficients if they are not None.
+            coefficients if they are not None and errors is True.
 
         Parameters
         ----------
@@ -1089,6 +1090,9 @@ class SHCoeffs(object):
         lmax : int, optional, default = x.lmax
             Maximum spherical harmonic degree to output. If lmax is greater
             than x.lmax, the array will be zero padded.
+        errors : bool, optional, default = True
+            If True, return separate arrays of the coefficients and errors. If
+            False, return only the coefficients.
 
         Notes
         -----
@@ -1113,7 +1117,7 @@ class SHCoeffs(object):
                           csphase_in=self.csphase, csphase_out=csphase,
                           lmax=lmax)
 
-        if self.errors is not None:
+        if self.errors is not None and errors:
             errors = _convert(self.errors, normalization_in=self.normalization,
                               normalization_out=normalization,
                               csphase_in=self.csphase, csphase_out=csphase,
@@ -1517,7 +1521,7 @@ class SHCoeffs(object):
 
         Usage
         -----
-        admittance = g.admittance(hlm, [lmax])
+        admittance = g.admittance(hlm, [errors, lmax])
 
         Returns
         -------
@@ -1558,7 +1562,8 @@ class SHCoeffs(object):
 
         sgh = _cross_spectrum(self.coeffs,
                               hlm.to_array(normalization=self.normalization,
-                                           csphase=self.csphase, lmax=lmax),
+                                           csphase=self.csphase, lmax=lmax,
+                                           errors=False),
                               normalization=self.normalization,
                               lmax=lmax)
         shh = _spectrum(hlm.coeffs, normalization=hlm.normalization, lmax=lmax)
@@ -1618,7 +1623,8 @@ class SHCoeffs(object):
         shh = _spectrum(hlm.coeffs, normalization=hlm.normalization, lmax=lmax)
         sgh = _cross_spectrum(self.coeffs,
                               hlm.to_array(normalization=self.normalization,
-                                           csphase=self.csphase, lmax=lmax),
+                                           csphase=self.csphase, lmax=lmax,
+                                           errors=False),
                               normalization=self.normalization,
                               lmax=lmax)
 
@@ -1631,7 +1637,7 @@ class SHCoeffs(object):
 
         Usage
         -----
-        admittance, correlation = g.admitcorr(hlm, [lmax])
+        admittance, correlation = g.admitcorr(hlm, [errors, lmax])
 
         Returns
         -------
@@ -1680,7 +1686,8 @@ class SHCoeffs(object):
         shh = _spectrum(hlm.coeffs, normalization=hlm.normalization, lmax=lmax)
         sgh = _cross_spectrum(self.coeffs,
                               hlm.to_array(normalization=self.normalization,
-                                           csphase=self.csphase, lmax=lmax),
+                                           csphase=self.csphase, lmax=lmax,
+                                           errors=False),
                               normalization=self.normalization,
                               lmax=lmax)
 
@@ -2453,334 +2460,6 @@ class SHCoeffs(object):
                 fig.savefig(fname)
             return fig, axes
 
-    def plot_admitcorr(self, hlm, errors=True, style='separate', lmax=None,
-                       grid=True, legend=None, legend_loc='best',
-                       axes_labelsize=None, tick_labelsize=None,
-                       elinewidth=0.75, show=True, ax=None, ax2=None,
-                       fname=None, **kwargs):
-        """
-        Plot the admittance and/or correlation with another function.
-
-        Usage
-        -----
-        x.plot_admitcorr(hlm, [errors, style, lmax, grid, legend, legend_loc,
-                               axes_labelsize, tick_labelsize, elinewidth,
-                               show, ax, ax2, fname, **kwargs])
-
-        Parameters
-        ----------
-        hlm : SHCoeffs class instance.
-            The second function used in computing the admittance and
-            correlation.
-        errors : bool, optional, default = True
-            Plot the uncertainty of the admittance.
-        style : str, optional, default = 'separate'
-            Style of the plot. 'separate' to plot the admittance and
-            correlation in separate plots, 'combined' to plot the admittance
-            and correlation in a single plot, 'admit' to plot only the
-            admittance, or 'corr' to plot only the correlation.
-        lmax : int, optional, default = self.lmax
-            The maximum spherical harmonic degree to plot.
-        grid : bool, optional, default = True
-            If True, plot grid lines. grid is set to False when style is
-            'combined'.
-        legend : str, optional, default = None
-            Text to use for the legend. If style is 'combined' or 'separate',
-            provide a list of two strings for the admittance and correlation,
-            respectively.
-        legend_loc : str, optional, default = 'best'
-            Location of the legend, such as 'upper right' or 'lower center'
-            (see pyplot.legend for all options). If style is 'separate',
-            provide a list of two strings for the admittance and correlation,
-            respectively.
-        axes_labelsize : int, optional, default = None
-            The font size for the x and y axes labels.
-        tick_labelsize : int, optional, default = None
-            The font size for the x and y tick labels.
-        elinewidth : float, optional, default = 0.75
-            Line width of the error bars when errors is True.
-        show : bool, optional, default = True
-            If True, plot to the screen.
-        ax : matplotlib axes object, optional, default = None
-            A single matplotlib axes object where the plot will appear.
-        ax2 : matplotlib axes object, optional, default = None
-            A single matplotlib axes object where the second plot will appear
-            when style is 'separate'.
-        fname : str, optional, default = None
-            If present, and if axes is not specified, save the image to the
-            specified file.
-        **kwargs : keyword arguments, optional
-            Keyword arguments for pyplot.plot() and pyplot.errorbar().
-
-        Notes
-        -----
-        If two functions g and h are related by the equation
-
-            glm = Z(l) hlm + nlm
-
-        where nlm is a zero-mean random variable, the admittance and spectral
-        correlation gamma(l) can be estimated using
-
-            Z(l) = Sgh(l) / Shh(l)
-            gamma(l) = Sgh(l) / sqrt( Sgg(l) Shh(l) )
-
-        where Sgh, Shh and Sgg are the cross-power and power spectra of the
-        functions g (self) and h (input).
-        """
-        if not isinstance(hlm, SHCoeffs):
-            raise ValueError('hlm must be an SHCoeffs class instance. Input '
-                             'type is {:s}.'.format(repr(type(hlm))))
-
-        if lmax is None:
-            lmax = min(self.lmax, hlm.lmax)
-
-        if style in ('combined', 'separate'):
-            admit, corr = self.admitcorr(hlm, errors=errors, lmax=lmax)
-        elif style == 'corr':
-            corr = self.correlation(hlm, lmax=lmax)
-        elif style == 'admit':
-            admit = self.admittance(hlm, errors=errors, lmax=lmax)
-        else:
-            raise ValueError("style must be 'combined', 'separate', 'admit' "
-                             "or 'corr'. Input value is {:s}"
-                             .format(repr(style)))
-
-        ls = _np.arange(lmax + 1)
-
-        if style == 'separate':
-            if ax is None:
-                scale = 0.4
-                figsize = (_mpl.rcParams['figure.figsize'][0],
-                           _mpl.rcParams['figure.figsize'][0]*scale)
-                fig, (axes, axes2) = _plt.subplots(1, 2, figsize=figsize)
-            else:
-                axes = ax
-                axes2 = ax2
-        elif style == 'combined':
-            if ax is None:
-                fig, axes = _plt.subplots(1, 1)
-                axes2 = axes.twinx()
-            else:
-                axes = ax
-                axes2 = axes.twinx()
-        else:
-            if ax is None:
-                fig, axes = _plt.subplots(1, 1)
-            else:
-                axes = ax
-
-        if style in ('separate', 'combined'):
-            admitax = axes
-            corrax = axes2
-        elif style == 'admit':
-            admitax = axes
-        elif style == 'corr':
-            corrax = axes
-
-        if legend is None:
-            legend = [None, None]
-        elif style == 'admit':
-            legend = [legend, None]
-            legend_loc = [legend_loc, None]
-        elif style == 'corr':
-            legend = [None, legend]
-            legend_loc = [None, legend_loc]
-        elif style == 'combined':
-            legend_loc = [legend_loc, legend_loc]
-        else:
-            if type(legend_loc) is str:
-                legend_loc = [legend_loc, legend_loc]
-
-        if axes_labelsize is None:
-            axes_labelsize = _mpl.rcParams['axes.labelsize']
-        if tick_labelsize is None:
-            tick_labelsize = _mpl.rcParams['xtick.labelsize']
-
-        if style in ('admit', 'separate', 'combined'):
-            if errors:
-                admitax.errorbar(ls, admit[:, 0], yerr=admit[:, 1],
-                                 label=legend[0], elinewidth=elinewidth,
-                                 **kwargs)
-            else:
-                admitax.plot(ls, admit, label=legend[0], **kwargs)
-            if ax is None:
-                admitax.set(xlim=(0, lmax))
-            else:
-                admitax.set(xlim=(0, max(lmax, ax.get_xbound()[1])))
-            admitax.set_xlabel('Spherical harmonic degree',
-                               fontsize=axes_labelsize)
-            admitax.set_ylabel('Admittance', fontsize=axes_labelsize)
-            admitax.minorticks_on()
-            admitax.tick_params(labelsize=tick_labelsize)
-            if legend[0] is not None:
-                if style != 'combined':
-                    admitax.legend(loc=legend_loc[0])
-            if style != 'combined':
-                admitax.grid(grid, which='major')
-
-        if style in ('corr', 'separate', 'combined'):
-            if style == 'combined':
-                # plot with next color
-                next(corrax._get_lines.prop_cycler)['color']
-            corrax.plot(ls, corr, label=legend[1], **kwargs)
-            if ax is None:
-                corrax.set(xlim=(0, lmax))
-                corrax.set(ylim=(-1, 1))
-            else:
-                corrax.set(xlim=(0, max(lmax, ax.get_xbound()[1])))
-            corrax.set_xlabel('Spherical harmonic degree',
-                              fontsize=axes_labelsize)
-            corrax.set_ylabel('Correlation', fontsize=axes_labelsize)
-            corrax.minorticks_on()
-            corrax.tick_params(labelsize=tick_labelsize)
-            if legend[1] is not None:
-                if style == 'combined':
-                    lines, labels = admitax.get_legend_handles_labels()
-                    lines2, labels2 = corrax.get_legend_handles_labels()
-                    corrax.legend(lines + lines2, labels + labels2,
-                                  loc=legend_loc[1])
-                else:
-                    corrax.legend(loc=legend_loc[1])
-            if style != 'combined':
-                corrax.grid(grid, which='major')
-
-        if ax is None:
-            fig.tight_layout(pad=0.5)
-            if show:
-                fig.show()
-            if fname is not None:
-                fig.savefig(fname)
-            if style in ('separate', 'combined'):
-                return fig, (axes, axes2)
-            else:
-                return fig, axes
-
-    def plot_admittance(self, hlm, errors=True, style='admit', lmax=None,
-                        grid=True, legend=None, legend_loc='best',
-                        axes_labelsize=None, tick_labelsize=None,
-                        elinewidth=0.75, show=True, ax=None, fname=None,
-                        **kwargs):
-        """
-        Plot the admittance with another function.
-
-        Usage
-        -----
-        x.plot_admittance(hlm, [errors, lmax, grid, legend, legend_loc,
-                                axes_labelsize, tick_labelsize, elinewidth,
-                                show, ax, fname, **kwargs])
-
-        Parameters
-        ----------
-        hlm : SHCoeffs class instance.
-            The second function used in computing the admittance.
-        errors : bool, optional, default = True
-            Plot the uncertainty of the admittance.
-        lmax : int, optional, default = self.lmax
-            The maximum spherical harmonic degree to plot.
-        grid : bool, optional, default = True
-            If True, plot grid lines. grid is set to False when style is
-            'combined'.
-        legend : str, optional, default = None
-            Text to use for the legend.
-        legend_loc : str, optional, default = 'best'
-            Location of the legend, such as 'upper right' or 'lower center'
-            (see pyplot.legend for all options).
-        axes_labelsize : int, optional, default = None
-            The font size for the x and y axes labels.
-        tick_labelsize : int, optional, default = None
-            The font size for the x and y tick labels.
-        elinewidth : float, optional, default = 0.75
-            Line width of the error bars when errors is True.
-        show : bool, optional, default = True
-            If True, plot to the screen.
-        ax : matplotlib axes object, optional, default = None
-            A single matplotlib axes object where the plot will appear.
-        fname : str, optional, default = None
-            If present, and if axes is not specified, save the image to the
-            specified file.
-        **kwargs : keyword arguments, optional
-            Keyword arguments for pyplot.plot() and pyplot.errorbar().
-
-        Notes
-        -----
-        If two functions g and h are related by the equation
-
-            glm = Z(l) hlm + nlm
-
-        where nlm is a zero-mean random variable, the admittance can be
-        estimated using
-
-            Z(l) = Sgh(l) / Shh(l)
-
-        where Sgh and Shh are the cross-power and power spectra of the
-        functions g (self) and h (input).
-        """
-        return self.plot_admitcorr(hlm, errors=errors, style='admit',
-                                   lmax=lmax, grid=grid, legend=legend,
-                                   legend_loc=legend_loc,
-                                   axes_labelsize=axes_labelsize,
-                                   tick_labelsize=tick_labelsize,
-                                   elinewidth=elinewidth, show=True,
-                                   fname=fname, ax=ax, **kwargs)
-
-    def plot_correlation(self, hlm, style='corr', lmax=None, grid=True,
-                         legend=None, legend_loc='best', axes_labelsize=None,
-                         tick_labelsize=None, elinewidth=0.75, show=True,
-                         ax=None, fname=None, **kwargs):
-        """
-        Plot the correlation with another function.
-
-        Usage
-        -----
-        x.plot_correlation(hlm, [lmax, grid, legend, legend_loc,
-                                 axes_labelsize, tick_labelsize, elinewidth,
-                                 show, ax, fname, **kwargs])
-
-        Parameters
-        ----------
-        hlm : SHCoeffs class instance.
-            The second function used in computing the correlation.
-        lmax : int, optional, default = self.lmax
-            The maximum spherical harmonic degree to plot.
-        grid : bool, optional, default = True
-            If True, plot grid lines. grid is set to False when style is
-            'combined'.
-        legend : str, optional, default = None
-            Text to use for the legend.
-        legend_loc : str, optional, default = 'best'
-            Location of the legend, such as 'upper right' or 'lower center'
-            (see pyplot.legend for all options).
-        axes_labelsize : int, optional, default = None
-            The font size for the x and y axes labels.
-        tick_labelsize : int, optional, default = None
-            The font size for the x and y tick labels.
-        elinewidth : float, optional, default = 0.75
-            Line width of the error bars when errors is True.
-        show : bool, optional, default = True
-            If True, plot to the screen.
-        ax : matplotlib axes object, optional, default = None
-            A single matplotlib axes object where the plot will appear.
-        fname : str, optional, default = None
-            If present, and if axes is not specified, save the image to the
-            specified file.
-        **kwargs : keyword arguments, optional
-            Keyword arguments for pyplot.plot() and pyplot.errorbar().
-
-        Notes
-        -----
-        The spectral correlation is defined as
-
-            gamma(l) = Sgh(l) / sqrt( Sgg(l) Shh(l) )
-
-        where Sgh, Shh and Sgg are the cross-power and power spectra of the
-        functions g (self) and h (input).
-        """
-        return self.plot_admitcorr(hlm, style='corr', lmax=lmax, grid=grid,
-                                   legend=legend, legend_loc=legend_loc,
-                                   axes_labelsize=axes_labelsize,
-                                   tick_labelsize=tick_labelsize,
-                                   show=True, fname=fname, ax=ax, **kwargs)
-
     def plot_spectrum2d(self, convention='power', xscale='lin', yscale='lin',
                         grid=True, axes_labelsize=None, tick_labelsize=None,
                         vscale='log', vrange=None, vmin=None, vmax=None,
@@ -3210,6 +2889,327 @@ class SHCoeffs(object):
             if fname is not None:
                 fig.savefig(fname)
             return fig, axes
+
+    def plot_admitcorr(self, hlm, errors=True, style='separate', lmax=None,
+                       grid=True, legend=None, legend_loc='best',
+                       axes_labelsize=None, tick_labelsize=None,
+                       elinewidth=0.75, show=True, ax=None, ax2=None,
+                       fname=None, **kwargs):
+        """
+        Plot the admittance and/or correlation with another function.
+
+        Usage
+        -----
+        x.plot_admitcorr(hlm, [errors, style, lmax, grid, legend, legend_loc,
+                               axes_labelsize, tick_labelsize, elinewidth,
+                               show, ax, ax2, fname, **kwargs])
+
+        Parameters
+        ----------
+        hlm : SHCoeffs class instance.
+            The second function used in computing the admittance and
+            correlation.
+        errors : bool, optional, default = True
+            Plot the uncertainty of the admittance.
+        style : str, optional, default = 'separate'
+            Style of the plot. 'separate' to plot the admittance and
+            correlation in separate plots, 'combined' to plot the admittance
+            and correlation in a single plot, 'admit' to plot only the
+            admittance, or 'corr' to plot only the correlation.
+        lmax : int, optional, default = self.lmax
+            The maximum spherical harmonic degree to plot.
+        grid : bool, optional, default = True
+            If True, plot grid lines. grid is set to False when style is
+            'combined'.
+        legend : str, optional, default = None
+            Text to use for the legend. If style is 'combined' or 'separate',
+            provide a list of two strings for the admittance and correlation,
+            respectively.
+        legend_loc : str, optional, default = 'best'
+            Location of the legend, such as 'upper right' or 'lower center'
+            (see pyplot.legend for all options). If style is 'separate',
+            provide a list of two strings for the admittance and correlation,
+            respectively.
+        axes_labelsize : int, optional, default = None
+            The font size for the x and y axes labels.
+        tick_labelsize : int, optional, default = None
+            The font size for the x and y tick labels.
+        elinewidth : float, optional, default = 0.75
+            Line width of the error bars when errors is True.
+        show : bool, optional, default = True
+            If True, plot to the screen.
+        ax : matplotlib axes object, optional, default = None
+            A single matplotlib axes object where the plot will appear.
+        ax2 : matplotlib axes object, optional, default = None
+            A single matplotlib axes object where the second plot will appear
+            when style is 'separate'.
+        fname : str, optional, default = None
+            If present, and if axes is not specified, save the image to the
+            specified file.
+        **kwargs : keyword arguments, optional
+            Keyword arguments for pyplot.plot() and pyplot.errorbar().
+
+        Notes
+        -----
+        If two functions g and h are related by the equation
+
+            glm = Z(l) hlm + nlm
+
+        where nlm is a zero-mean random variable, the admittance and spectral
+        correlation gamma(l) can be estimated using
+
+            Z(l) = Sgh(l) / Shh(l)
+            gamma(l) = Sgh(l) / sqrt( Sgg(l) Shh(l) )
+
+        where Sgh, Shh and Sgg are the cross-power and power spectra of the
+        functions g (self) and h (input).
+        """
+        if lmax is None:
+            lmax = min(self.lmax, hlm.lmax)
+
+        if style in ('combined', 'separate'):
+            admit, corr = self.admitcorr(hlm, errors=errors, lmax=lmax)
+        elif style == 'corr':
+            corr = self.correlation(hlm, lmax=lmax)
+        elif style == 'admit':
+            admit = self.admittance(hlm, errors=errors, lmax=lmax)
+        else:
+            raise ValueError("style must be 'combined', 'separate', 'admit' "
+                             "or 'corr'. Input value is {:s}"
+                             .format(repr(style)))
+
+        ls = _np.arange(lmax + 1)
+
+        if style == 'separate':
+            if ax is None:
+                scale = 0.4
+                figsize = (_mpl.rcParams['figure.figsize'][0],
+                           _mpl.rcParams['figure.figsize'][0]*scale)
+                fig, (axes, axes2) = _plt.subplots(1, 2, figsize=figsize)
+            else:
+                axes = ax
+                axes2 = ax2
+        elif style == 'combined':
+            if ax is None:
+                fig, axes = _plt.subplots(1, 1)
+                axes2 = axes.twinx()
+            else:
+                axes = ax
+                axes2 = axes.twinx()
+        else:
+            if ax is None:
+                fig, axes = _plt.subplots(1, 1)
+            else:
+                axes = ax
+
+        if style in ('separate', 'combined'):
+            admitax = axes
+            corrax = axes2
+        elif style == 'admit':
+            admitax = axes
+        elif style == 'corr':
+            corrax = axes
+
+        if legend is None:
+            legend = [None, None]
+        elif style == 'admit':
+            legend = [legend, None]
+            legend_loc = [legend_loc, None]
+        elif style == 'corr':
+            legend = [None, legend]
+            legend_loc = [None, legend_loc]
+        elif style == 'combined':
+            legend_loc = [legend_loc, legend_loc]
+        else:
+            if type(legend_loc) is str:
+                legend_loc = [legend_loc, legend_loc]
+
+        if axes_labelsize is None:
+            axes_labelsize = _mpl.rcParams['axes.labelsize']
+        if tick_labelsize is None:
+            tick_labelsize = _mpl.rcParams['xtick.labelsize']
+
+        if style in ('admit', 'separate', 'combined'):
+            if errors:
+                admitax.errorbar(ls, admit[:, 0], yerr=admit[:, 1],
+                                 label=legend[0], elinewidth=elinewidth,
+                                 **kwargs)
+            else:
+                admitax.plot(ls, admit, label=legend[0], **kwargs)
+            if ax is None:
+                admitax.set(xlim=(0, lmax))
+            else:
+                admitax.set(xlim=(0, max(lmax, ax.get_xbound()[1])))
+            admitax.set_xlabel('Spherical harmonic degree',
+                               fontsize=axes_labelsize)
+            admitax.set_ylabel('Admittance', fontsize=axes_labelsize)
+            admitax.minorticks_on()
+            admitax.tick_params(labelsize=tick_labelsize)
+            if legend[0] is not None:
+                if style != 'combined':
+                    admitax.legend(loc=legend_loc[0])
+            if style != 'combined':
+                admitax.grid(grid, which='major')
+
+        if style in ('corr', 'separate', 'combined'):
+            if style == 'combined':
+                # plot with next color
+                next(corrax._get_lines.prop_cycler)['color']
+            corrax.plot(ls, corr, label=legend[1], **kwargs)
+            if ax is None:
+                corrax.set(xlim=(0, lmax))
+                corrax.set(ylim=(-1, 1))
+            else:
+                corrax.set(xlim=(0, max(lmax, ax.get_xbound()[1])))
+            corrax.set_xlabel('Spherical harmonic degree',
+                              fontsize=axes_labelsize)
+            corrax.set_ylabel('Correlation', fontsize=axes_labelsize)
+            corrax.minorticks_on()
+            corrax.tick_params(labelsize=tick_labelsize)
+            if legend[1] is not None:
+                if style == 'combined':
+                    lines, labels = admitax.get_legend_handles_labels()
+                    lines2, labels2 = corrax.get_legend_handles_labels()
+                    corrax.legend(lines + lines2, labels + labels2,
+                                  loc=legend_loc[1])
+                else:
+                    corrax.legend(loc=legend_loc[1])
+            if style != 'combined':
+                corrax.grid(grid, which='major')
+
+        if ax is None:
+            fig.tight_layout(pad=0.5)
+            if show:
+                fig.show()
+            if fname is not None:
+                fig.savefig(fname)
+            if style in ('separate', 'combined'):
+                return fig, (axes, axes2)
+            else:
+                return fig, axes
+
+    def plot_admittance(self, hlm, errors=True, lmax=None, grid=True,
+                        legend=None, legend_loc='best', axes_labelsize=None,
+                        tick_labelsize=None, elinewidth=0.75, show=True,
+                        ax=None, fname=None, **kwargs):
+        """
+        Plot the admittance with another function.
+
+        Usage
+        -----
+        x.plot_admittance(hlm, [errors, lmax, grid, legend, legend_loc,
+                                axes_labelsize, tick_labelsize, elinewidth,
+                                show, ax, fname, **kwargs])
+
+        Parameters
+        ----------
+        hlm : SHCoeffs class instance.
+            The second function used in computing the admittance.
+        errors : bool, optional, default = True
+            Plot the uncertainty of the admittance.
+        lmax : int, optional, default = self.lmax
+            The maximum spherical harmonic degree to plot.
+        grid : bool, optional, default = True
+            If True, plot grid lines.
+        legend : str, optional, default = None
+            Text to use for the legend.
+        legend_loc : str, optional, default = 'best'
+            Location of the legend, such as 'upper right' or 'lower center'
+            (see pyplot.legend for all options).
+        axes_labelsize : int, optional, default = None
+            The font size for the x and y axes labels.
+        tick_labelsize : int, optional, default = None
+            The font size for the x and y tick labels.
+        elinewidth : float, optional, default = 0.75
+            Line width of the error bars when errors is True.
+        show : bool, optional, default = True
+            If True, plot to the screen.
+        ax : matplotlib axes object, optional, default = None
+            A single matplotlib axes object where the plot will appear.
+        fname : str, optional, default = None
+            If present, and if axes is not specified, save the image to the
+            specified file.
+        **kwargs : keyword arguments, optional
+            Keyword arguments for pyplot.plot() and pyplot.errorbar().
+
+        Notes
+        -----
+        If two functions g and h are related by the equation
+
+            glm = Z(l) hlm + nlm
+
+        where nlm is a zero-mean random variable, the admittance can be
+        estimated using
+
+            Z(l) = Sgh(l) / Shh(l)
+
+        where Sgh and Shh are the cross-power and power spectra of the
+        functions g (self) and h (input).
+        """
+        return self.plot_admitcorr(hlm, errors=errors, style='admit',
+                                   lmax=lmax, grid=grid, legend=legend,
+                                   legend_loc=legend_loc,
+                                   axes_labelsize=axes_labelsize,
+                                   tick_labelsize=tick_labelsize,
+                                   elinewidth=elinewidth, show=True,
+                                   fname=fname, ax=ax, **kwargs)
+
+    def plot_correlation(self, hlm, lmax=None, grid=True, legend=None,
+                         legend_loc='best', axes_labelsize=None,
+                         tick_labelsize=None, elinewidth=0.75, show=True,
+                         ax=None, fname=None, **kwargs):
+        """
+        Plot the correlation with another function.
+
+        Usage
+        -----
+        x.plot_correlation(hlm, [lmax, grid, legend, legend_loc,
+                                 axes_labelsize, tick_labelsize, elinewidth,
+                                 show, ax, fname, **kwargs])
+
+        Parameters
+        ----------
+        hlm : SHCoeffs class instance.
+            The second function used in computing the correlation.
+        lmax : int, optional, default = self.lmax
+            The maximum spherical harmonic degree to plot.
+        grid : bool, optional, default = True
+            If True, plot grid lines.
+        legend : str, optional, default = None
+            Text to use for the legend.
+        legend_loc : str, optional, default = 'best'
+            Location of the legend, such as 'upper right' or 'lower center'
+            (see pyplot.legend for all options).
+        axes_labelsize : int, optional, default = None
+            The font size for the x and y axes labels.
+        tick_labelsize : int, optional, default = None
+            The font size for the x and y tick labels.
+        elinewidth : float, optional, default = 0.75
+            Line width of the error bars when errors is True.
+        show : bool, optional, default = True
+            If True, plot to the screen.
+        ax : matplotlib axes object, optional, default = None
+            A single matplotlib axes object where the plot will appear.
+        fname : str, optional, default = None
+            If present, and if axes is not specified, save the image to the
+            specified file.
+        **kwargs : keyword arguments, optional
+            Keyword arguments for pyplot.plot() and pyplot.errorbar().
+
+        Notes
+        -----
+        The spectral correlation is defined as
+
+            gamma(l) = Sgh(l) / sqrt( Sgg(l) Shh(l) )
+
+        where Sgh, Shh and Sgg are the cross-power and power spectra of the
+        functions g (self) and h (input).
+        """
+        return self.plot_admitcorr(hlm, style='corr', lmax=lmax, grid=grid,
+                                   legend=legend, legend_loc=legend_loc,
+                                   axes_labelsize=axes_labelsize,
+                                   tick_labelsize=tick_labelsize,
+                                   show=True, fname=fname, ax=ax, **kwargs)
 
 
 # ================== REAL SPHERICAL HARMONICS ================

--- a/pyshtools/shclasses/shcoeffs.py
+++ b/pyshtools/shclasses/shcoeffs.py
@@ -87,6 +87,10 @@ class SHCoeffs(object):
                             of spherical harmonic degree.
     cross_spectrum()      : Return the cross-spectrum of two functions as a
                             function of spherical harmonic degree.
+    admittance()          : Return the admittance of two functions.
+    correlation()         : Return the spectral correlation of two functions.
+    admitcorr()           : Return the admittance and spectral correlation of
+                            two functions.
     volume()              : Calculate the volume of the body.
     centroid()            : Compute the centroid of the body.
     set_coeffs()          : Set coefficients in-place to specified values.
@@ -1504,6 +1508,138 @@ class SHCoeffs(object):
                                normalization=self.normalization,
                                convention=convention, unit=unit, base=base,
                                lmax=lmax)
+
+    def admittance(self, hlm, lmax=None):
+        """
+        Return the admittance of two functions, Sgh(l) / Shh(l).
+
+        Usage
+        -----
+        admittance = g.admittance(hlm, [lmax])
+
+        Returns
+        -------
+        admittance : ndarray, shape (lmax+1)
+            1-D numpy ndarray of the admittance, where lmax is the maximum
+            spherical harmonic degree.
+
+        Parameters
+        ----------
+        hlm : SHCoeffs class instance.
+            The function h used in computing the admittance Sgh / Shh.
+        lmax : int, optional, default = g.lmax
+            Maximum spherical harmonic degree of the spectrum to output.
+
+        Notes
+        -----
+        The admittance is defined as
+
+            Z(l) = Sgh(l) / Shh(l)
+
+        where Sgh(l) is the cross-power spectrum of the functions g (self) and
+        h (input), and Shh(l) is the power spectrum of h.
+        """
+        if not isinstance(hlm, SHCoeffs):
+            raise ValueError('hlm must be an SHCoeffs class instance. Input '
+                             'type is {:s}.'.format(repr(type(hlm))))
+
+        if lmax is None:
+            lmax = min(self.lmax, hlm.lmax)
+
+        sgh = self.cross_spectrum(hlm, lmax=lmax)
+        shh = hlm.spectrum(lmax=lmax)
+        return sgh / shh
+
+    def correlation(self, hlm, lmax=None):
+        """
+        Return the spectral correlation of two functions.
+
+        Usage
+        -----
+        correlation = g.correlation(hlm, [lmax])
+
+        Returns
+        -------
+        correlation : ndarray, shape (lmax+1)
+            1-D numpy ndarray of the spectral correlation, where lmax is the
+            maximum spherical harmonic degree.
+
+        Parameters
+        ----------
+        hlm : SHCoeffs class instance.
+            The function h used in computing the spectral correlation.
+        lmax : int, optional, default = g.lmax
+            Maximum spherical harmonic degree of the spectrum to output.
+
+        Notes
+        -----
+        The spectral correlation is defined as
+
+            gamma(l) = Sgh(l) / sqrt( Sgg(l) Shh(l) )
+
+        where Sgh(l) is the cross-power spectrum of the functions g (self) and
+        h (input), and Sgg(l) and Shh(l) are respectively the power spectra of
+        g and h.
+        """
+        if not isinstance(hlm, SHCoeffs):
+            raise ValueError('hlm must be an SHCoeffs class instance. Input '
+                             'type is {:s}.'.format(repr(type(hlm))))
+
+        if lmax is None:
+            lmax = min(self.lmax, hlm.lmax)
+
+        sgh = self.cross_spectrum(hlm, lmax=lmax)
+        sgg = self.spectrum(lmax=lmax)
+        shh = hlm.spectrum(lmax=lmax)
+        return sgh / _np.sqrt(sgg * shh)
+
+    def admitcorr(self, hlm, lmax=None):
+        """
+        Return the admittance and spectral correlation of two functions.
+
+        Usage
+        -----
+        admittance, correlation = g.admitcorr(hlm, [lmax])
+
+        Returns
+        -------
+        admittance : ndarray, shape (lmax+1)
+            1-D numpy ndarray of the admittance, where lmax is the maximum
+            spherical harmonic degree.
+        correlation : ndarray, shape (lmax+1)
+            1-D numpy ndarray of the spectral correlation, where lmax is the
+            maximum spherical harmonic degree.
+
+        Parameters
+        ----------
+        hlm : SHCoeffs class instance.
+            The function h used in computing the admittance and spectral
+            correlation.
+        lmax : int, optional, default = g.lmax
+            Maximum spherical harmonic degree of the spectrum to output.
+
+        Notes
+        -----
+        The admittance and spectral correlation are defined as
+
+            Z(l) = Sgh(l) / Shh(l)
+            gamma(l) = Sgh(l) / sqrt( Sgg(l) Shh(l) )
+
+        where Sgh(l) is the cross-power spectrum of the functions g (self) and
+        h (input), and Sgg(l) and Shh(l) are respectively the power spectra of
+        g and h.
+        """
+        if not isinstance(hlm, SHCoeffs):
+            raise ValueError('hlm must be an SHCoeffs class instance. Input '
+                             'type is {:s}.'.format(repr(type(hlm))))
+
+        if lmax is None:
+            lmax = min(self.lmax, hlm.lmax)
+
+        sgh = self.cross_spectrum(hlm, lmax=lmax)
+        sgg = self.spectrum(lmax=lmax)
+        shh = hlm.spectrum(lmax=lmax)
+        return sgh / shh, sgh / _np.sqrt(sgg * shh)
 
     def volume(self, lmax=None):
         """

--- a/pyshtools/shclasses/shcoeffs.py
+++ b/pyshtools/shclasses/shcoeffs.py
@@ -2122,9 +2122,9 @@ class SHCoeffs(object):
     # ---- Plotting routines ----
     def plot_spectrum(self, convention='power', unit='per_l', base=10.,
                       lmax=None, xscale='lin', yscale='log', grid=True,
-                      legend=None, legend_error='error', axes_labelsize=None,
-                      tick_labelsize=None, show=True, ax=None, fname=None,
-                      **kwargs):
+                      legend=None, legend_error='error', legend_loc='best',
+                      axes_labelsize=None, tick_labelsize=None, show=True,
+                      ax=None, fname=None, **kwargs):
         """
         Plot the spectrum as a function of spherical harmonic degree.
 
@@ -2132,7 +2132,7 @@ class SHCoeffs(object):
         -----
         x.plot_spectrum([convention, unit, base, lmax, xscale, yscale, grid,
                          axes_labelsize, tick_labelsize, legend, legend_error,
-                         show, ax, fname, **kwargs])
+                         legend_loc, show, ax, fname, **kwargs])
 
         Parameters
         ----------
@@ -2161,6 +2161,9 @@ class SHCoeffs(object):
             Text to use for the legend.
         legend_error : str, optional, default = 'error'
             Text to use for the legend of the error spectrum.
+        legend_loc : str, optional, default = 'best'
+            Location of the legend, such as 'upper right' or 'lower center'
+            (see pyplot.legend for all options).
         axes_labelsize : int, optional, default = None
             The font size for the x and y axes labels.
         tick_labelsize : int, optional, default = None
@@ -2273,7 +2276,7 @@ class SHCoeffs(object):
         axes.grid(grid, which='major')
         axes.minorticks_on()
         axes.tick_params(labelsize=tick_labelsize)
-        axes.legend()
+        axes.legend(loc=legend_loc)
 
         if ax is None:
             fig.tight_layout(pad=0.5)
@@ -2285,9 +2288,9 @@ class SHCoeffs(object):
 
     def plot_cross_spectrum(self, clm, convention='power', unit='per_l',
                             base=10., lmax=None, xscale='lin', yscale='log',
-                            grid=True, legend=None, axes_labelsize=None,
-                            tick_labelsize=None, show=True, ax=None,
-                            fname=None, **kwargs):
+                            grid=True, legend=None, legend_loc='best',
+                            axes_labelsize=None, tick_labelsize=None,
+                            show=True, ax=None, fname=None, **kwargs):
         """
         Plot the cross-spectrum of two functions.
 
@@ -2295,8 +2298,8 @@ class SHCoeffs(object):
         -----
         x.plot_cross_spectrum(clm, [convention, unit, base, lmax, xscale,
                                     yscale, grid, axes_labelsize,
-                                    tick_labelsize, legend, show, ax,
-                                    fname, **kwargs])
+                                    tick_labelsize, legend, legend_loc, show,
+                                    ax, fname, **kwargs])
 
         Parameters
         ----------
@@ -2325,6 +2328,9 @@ class SHCoeffs(object):
             If True, plot grid lines.
         legend : str, optional, default = None
             Text to use for the legend.
+        legend_loc : str, optional, default = 'best'
+            Location of the legend, such as 'upper right' or 'lower center'
+            (see pyplot.legend for all options).
         axes_labelsize : int, optional, default = None
             The font size for the x and y axes labels.
         tick_labelsize : int, optional, default = None
@@ -2432,7 +2438,7 @@ class SHCoeffs(object):
         axes.grid(grid, which='major')
         axes.minorticks_on()
         axes.tick_params(labelsize=tick_labelsize)
-        axes.legend()
+        axes.legend(loc=legend_loc)
 
         if ax is None:
             fig.tight_layout(pad=0.5)

--- a/pyshtools/shclasses/shcoeffs.py
+++ b/pyshtools/shclasses/shcoeffs.py
@@ -104,6 +104,11 @@ class SHCoeffs(object):
     plot_spectrum()       : Plot the spectrum as a function of spherical
                             harmonic degree.
     plot_cross_spectrum() : Plot the cross-spectrum of two functions.
+    plot_admittance()     : Plot the admittance with another function.
+    plot_correlation()    : Plot the spectral correlation with another
+                            function.
+    plot_admitcorr()      : Plot the admittance and spectral correlation with
+                            another function.
     plot_spectrum2d()     : Plot the 2D spectrum of all spherical harmonic
                             degrees and orders.
     plot_cross_spectrum2d() : Plot the 2D cross-spectrum of all spherical
@@ -2454,7 +2459,7 @@ class SHCoeffs(object):
                        elinewidth=0.75, show=True, ax=None, ax2=None,
                        fname=None, **kwargs):
         """
-        Plot the admittance and/or correlation of two functions.
+        Plot the admittance and/or correlation with another function.
 
         Usage
         -----
@@ -2649,6 +2654,132 @@ class SHCoeffs(object):
                 return fig, (axes, axes2)
             else:
                 return fig, axes
+
+    def plot_admittance(self, hlm, errors=True, style='admit', lmax=None,
+                        grid=True, legend=None, legend_loc='best',
+                        axes_labelsize=None, tick_labelsize=None,
+                        elinewidth=0.75, show=True, ax=None, fname=None,
+                        **kwargs):
+        """
+        Plot the admittance with another function.
+
+        Usage
+        -----
+        x.plot_admittance(hlm, [errors, lmax, grid, legend, legend_loc,
+                                axes_labelsize, tick_labelsize, elinewidth,
+                                show, ax, fname, **kwargs])
+
+        Parameters
+        ----------
+        hlm : SHCoeffs class instance.
+            The second function used in computing the admittance.
+        errors : bool, optional, default = True
+            Plot the uncertainty of the admittance.
+        lmax : int, optional, default = self.lmax
+            The maximum spherical harmonic degree to plot.
+        grid : bool, optional, default = True
+            If True, plot grid lines. grid is set to False when style is
+            'combined'.
+        legend : str, optional, default = None
+            Text to use for the legend.
+        legend_loc : str, optional, default = 'best'
+            Location of the legend, such as 'upper right' or 'lower center'
+            (see pyplot.legend for all options).
+        axes_labelsize : int, optional, default = None
+            The font size for the x and y axes labels.
+        tick_labelsize : int, optional, default = None
+            The font size for the x and y tick labels.
+        elinewidth : float, optional, default = 0.75
+            Line width of the error bars when errors is True.
+        show : bool, optional, default = True
+            If True, plot to the screen.
+        ax : matplotlib axes object, optional, default = None
+            A single matplotlib axes object where the plot will appear.
+        fname : str, optional, default = None
+            If present, and if axes is not specified, save the image to the
+            specified file.
+        **kwargs : keyword arguments, optional
+            Keyword arguments for pyplot.plot() and pyplot.errorbar().
+
+        Notes
+        -----
+        If two functions g and h are related by the equation
+
+            glm = Z(l) hlm + nlm
+
+        where nlm is a zero-mean random variable, the admittance can be
+        estimated using
+
+            Z(l) = Sgh(l) / Shh(l)
+
+        where Sgh and Shh are the cross-power and power spectra of the
+        functions g (self) and h (input).
+        """
+        return self.plot_admitcorr(hlm, errors=errors, style='admit',
+                                   lmax=lmax, grid=grid, legend=legend,
+                                   legend_loc=legend_loc,
+                                   axes_labelsize=axes_labelsize,
+                                   tick_labelsize=tick_labelsize,
+                                   elinewidth=elinewidth, show=True,
+                                   fname=fname, ax=ax, **kwargs)
+
+    def plot_correlation(self, hlm, style='corr', lmax=None, grid=True,
+                         legend=None, legend_loc='best', axes_labelsize=None,
+                         tick_labelsize=None, elinewidth=0.75, show=True,
+                         ax=None, fname=None, **kwargs):
+        """
+        Plot the correlation with another function.
+
+        Usage
+        -----
+        x.plot_correlation(hlm, [lmax, grid, legend, legend_loc,
+                                 axes_labelsize, tick_labelsize, elinewidth,
+                                 show, ax, fname, **kwargs])
+
+        Parameters
+        ----------
+        hlm : SHCoeffs class instance.
+            The second function used in computing the correlation.
+        lmax : int, optional, default = self.lmax
+            The maximum spherical harmonic degree to plot.
+        grid : bool, optional, default = True
+            If True, plot grid lines. grid is set to False when style is
+            'combined'.
+        legend : str, optional, default = None
+            Text to use for the legend.
+        legend_loc : str, optional, default = 'best'
+            Location of the legend, such as 'upper right' or 'lower center'
+            (see pyplot.legend for all options).
+        axes_labelsize : int, optional, default = None
+            The font size for the x and y axes labels.
+        tick_labelsize : int, optional, default = None
+            The font size for the x and y tick labels.
+        elinewidth : float, optional, default = 0.75
+            Line width of the error bars when errors is True.
+        show : bool, optional, default = True
+            If True, plot to the screen.
+        ax : matplotlib axes object, optional, default = None
+            A single matplotlib axes object where the plot will appear.
+        fname : str, optional, default = None
+            If present, and if axes is not specified, save the image to the
+            specified file.
+        **kwargs : keyword arguments, optional
+            Keyword arguments for pyplot.plot() and pyplot.errorbar().
+
+        Notes
+        -----
+        The spectral correlation is defined as
+
+            gamma(l) = Sgh(l) / sqrt( Sgg(l) Shh(l) )
+
+        where Sgh, Shh and Sgg are the cross-power and power spectra of the
+        functions g (self) and h (input).
+        """
+        return self.plot_admitcorr(hlm, style='corr', lmax=lmax, grid=grid,
+                                   legend=legend, legend_loc=legend_loc,
+                                   axes_labelsize=axes_labelsize,
+                                   tick_labelsize=tick_labelsize,
+                                   show=True, fname=fname, ax=ax, **kwargs)
 
     def plot_spectrum2d(self, convention='power', xscale='lin', yscale='lin',
                         grid=True, axes_labelsize=None, tick_labelsize=None,

--- a/pyshtools/shclasses/shcoeffs.py
+++ b/pyshtools/shclasses/shcoeffs.py
@@ -1558,7 +1558,7 @@ class SHCoeffs(object):
                               lmax=lmax)
         shh = _spectrum(hlm.coeffs, normalization=hlm.normalization, lmax=lmax)
 
-        with _np.errstate(invalid='ignore'):
+        with _np.errstate(invalid='ignore', divide='ignore'):
             admit = sgh / shh
             if errors:
                 sgg = _spectrum(self.coeffs, normalization=self.normalization,
@@ -1617,7 +1617,7 @@ class SHCoeffs(object):
                               normalization=self.normalization,
                               lmax=lmax)
 
-        with _np.errstate(invalid='ignore'):
+        with _np.errstate(invalid='ignore', divide='ignore'):
             return sgh / _np.sqrt(sgg * shh)
 
     def admitcorr(self, hlm, errors=True, lmax=None):
@@ -1679,7 +1679,7 @@ class SHCoeffs(object):
                               normalization=self.normalization,
                               lmax=lmax)
 
-        with _np.errstate(invalid='ignore'):
+        with _np.errstate(invalid='ignore', divide='ignore'):
             admit = sgh / shh
             corr = sgh / _np.sqrt(sgg * shh)
             if errors:
@@ -2441,6 +2441,208 @@ class SHCoeffs(object):
             if fname is not None:
                 fig.savefig(fname)
             return fig, axes
+
+    def plot_admitcorr(self, hlm, errors=True, style='separate', lmax=None,
+                       grid=True, legend=None, legend_loc='best',
+                       axes_labelsize=None, tick_labelsize=None,
+                       elinewidth=0.75, show=True, ax=None, ax2=None,
+                       fname=None, **kwargs):
+        """
+        Plot the admittance and/or correlation of two functions.
+
+        Usage
+        -----
+        x.plot_admitcorr(hlm, [errors, style, lmax, grid, legend, legend_loc,
+                               axes_labelsize, tick_labelsize, elinewidth,
+                               show, ax, ax2, fname, **kwargs])
+
+        Parameters
+        ----------
+        hlm : SHCoeffs class instance.
+            The second function used in computing the admittance and
+            correlation.
+        errors : bool, optional, default = True
+            Plot the uncertainty of the admittance.
+        style : str, optional, default = 'separate'
+            Style of the plot. 'separate' to plot the admittance and
+            correlation in separate plots, 'combined' to plot the admittance
+            and correlation in a single plot, 'admit' to plot only the
+            admittance, or 'corr' to plot only the correlation.
+        lmax : int, optional, default = self.lmax
+            The maximum spherical harmonic degree to plot.
+        grid : bool, optional, default = True
+            If True, plot grid lines. grid is set to False when style is
+            'combined'.
+        legend : str, optional, default = None
+            Text to use for the legend. If style is 'combined' or 'separate',
+            provide a list of two strings for the admittance and correlation,
+            respectively.
+        legend_loc : str, optional, default = 'best'
+            Location of the legend, such as 'upper right' or 'lower center'
+            (see pyplot.legend for all options). If style is 'separate',
+            provide a list of two strings for the admittance and correlation,
+            respectively.
+        axes_labelsize : int, optional, default = None
+            The font size for the x and y axes labels.
+        tick_labelsize : int, optional, default = None
+            The font size for the x and y tick labels.
+        elinewidth : float, optional, default = 0.75
+            Line width of the error bars when errors is True.
+        show : bool, optional, default = True
+            If True, plot to the screen.
+        ax : matplotlib axes object, optional, default = None
+            A single matplotlib axes object where the plot will appear.
+        ax2 : matplotlib axes object, optional, default = None
+            A single matplotlib axes object where the second plot will appear
+            when style is 'separate'.
+        fname : str, optional, default = None
+            If present, and if axes is not specified, save the image to the
+            specified file.
+        **kwargs : keyword arguments, optional
+            Keyword arguments for pyplot.plot() and pyplot.errorbar().
+
+        Notes
+        -----
+        If two functions g and h are related by the equation
+
+            glm = Z(l) hlm + nlm
+
+        where nlm is a zero-mean random variable, the admittance and spectral
+        correlation gamma(l) can be estimated using
+
+            Z(l) = Sgh(l) / Shh(l)
+            gamma(l) = Sgh(l) / sqrt( Sgg(l) Shh(l) )
+
+        where Sgh, Shh and Sgg are the cross-power and power spectra of the
+        functions g (self) and h (input).
+        """
+        if not isinstance(hlm, SHCoeffs):
+            raise ValueError('hlm must be an SHCoeffs class instance. Input '
+                             'type is {:s}.'.format(repr(type(hlm))))
+
+        if lmax is None:
+            lmax = min(self.lmax, hlm.lmax)
+
+        if style in ('combined', 'separate'):
+            admit, corr = self.admitcorr(hlm, errors=errors, lmax=lmax)
+        elif style == 'corr':
+            corr = self.correlation(hlm, lmax=lmax)
+        elif style == 'admit':
+            admit = self.admittance(hlm, errors=errors, lmax=lmax)
+        else:
+            raise ValueError("style must be 'combined', 'separate', 'admit' "
+                             "or 'corr'. Input value is {:s}"
+                             .format(repr(style)))
+
+        ls = _np.arange(lmax + 1)
+
+        if style == 'separate':
+            if ax is None:
+                scale = 0.4
+                figsize = (_mpl.rcParams['figure.figsize'][0],
+                           _mpl.rcParams['figure.figsize'][0]*scale)
+                fig, (axes, axes2) = _plt.subplots(1, 2, figsize=figsize)
+            else:
+                axes = ax
+                axes2 = ax2
+        elif style == 'combined':
+            if ax is None:
+                fig, axes = _plt.subplots(1, 1)
+                axes2 = axes.twinx()
+            else:
+                axes = ax
+                axes2 = axes.twinx()
+        else:
+            if ax is None:
+                fig, axes = _plt.subplots(1, 1)
+            else:
+                axes = ax
+
+        if style in ('separate', 'combined'):
+            admitax = axes
+            corrax = axes2
+        elif style == 'admit':
+            admitax = axes
+        elif style == 'corr':
+            corrax = axes
+
+        if legend is None:
+            legend = [None, None]
+        elif style == 'admit':
+            legend = [legend, None]
+            legend_loc = [legend_loc, None]
+        elif style == 'corr':
+            legend = [None, legend]
+            legend_loc = [None, legend_loc]
+        elif style == 'combined':
+            legend_loc = [legend_loc, legend_loc]
+        else:
+            if type(legend_loc) is str:
+                legend_loc = [legend_loc, legend_loc]
+
+        if axes_labelsize is None:
+            axes_labelsize = _mpl.rcParams['axes.labelsize']
+        if tick_labelsize is None:
+            tick_labelsize = _mpl.rcParams['xtick.labelsize']
+
+        if style in ('admit', 'separate', 'combined'):
+            if errors:
+                admitax.errorbar(ls, admit[:, 0], yerr=admit[:, 1],
+                                 label=legend[0], elinewidth=elinewidth,
+                                 **kwargs)
+            else:
+                admitax.plot(ls, admit, label=legend[0], **kwargs)
+            if ax is None:
+                admitax.set(xlim=(0, lmax))
+            else:
+                admitax.set(xlim=(0, max(lmax, ax.get_xbound()[1])))
+            admitax.set_xlabel('Spherical harmonic degree',
+                               fontsize=axes_labelsize)
+            admitax.set_ylabel('Admittance', fontsize=axes_labelsize)
+            admitax.minorticks_on()
+            admitax.tick_params(labelsize=tick_labelsize)
+            if legend[0] is not None:
+                if style != 'combined':
+                    admitax.legend(loc=legend_loc[0])
+            if style != 'combined':
+                admitax.grid(grid, which='major')
+
+        if style in ('corr', 'separate', 'combined'):
+            if style == 'combined':
+                # plot with next color
+                next(corrax._get_lines.prop_cycler)['color']
+            corrax.plot(ls, corr, label=legend[1], **kwargs)
+            if ax is None:
+                corrax.set(xlim=(0, lmax))
+                corrax.set(ylim=(-1, 1))
+            else:
+                corrax.set(xlim=(0, max(lmax, ax.get_xbound()[1])))
+            corrax.set_xlabel('Spherical harmonic degree',
+                              fontsize=axes_labelsize)
+            corrax.set_ylabel('Correlation', fontsize=axes_labelsize)
+            corrax.minorticks_on()
+            corrax.tick_params(labelsize=tick_labelsize)
+            if legend[1] is not None:
+                if style == 'combined':
+                    lines, labels = admitax.get_legend_handles_labels()
+                    lines2, labels2 = corrax.get_legend_handles_labels()
+                    corrax.legend(lines + lines2, labels + labels2,
+                                  loc=legend_loc[1])
+                else:
+                    corrax.legend(loc=legend_loc[1])
+            if style != 'combined':
+                corrax.grid(grid, which='major')
+
+        if ax is None:
+            fig.tight_layout(pad=0.5)
+            if show:
+                fig.show()
+            if fname is not None:
+                fig.savefig(fname)
+            if style in ('separate', 'combined'):
+                return fig, (axes, axes2)
+            else:
+                return fig, axes
 
     def plot_spectrum2d(self, convention='power', xscale='lin', yscale='lin',
                         grid=True, axes_labelsize=None, tick_labelsize=None,

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -1846,7 +1846,7 @@ class SHGravCoeffs(object):
                               lmax=lmax)
         shh = _spectrum(hlm.coeffs, normalization=hlm.normalization, lmax=lmax)
 
-        with _np.errstate(invalid='ignore'):
+        with _np.errstate(invalid='ignore', divide='ignore'):
             admit = sgh / shh
             if errors:
                 sgg = _spectrum(self.coeffs, normalization=self.normalization,
@@ -1913,7 +1913,7 @@ class SHGravCoeffs(object):
                               normalization=self.normalization,
                               lmax=lmax)
 
-        with _np.errstate(invalid='ignore'):
+        with _np.errstate(invalid='ignore', divide='ignore'):
             return sgh / _np.sqrt(sgg * shh)
 
     def admitcorr(self, hlm, errors=True, function='radial', lmax=None):
@@ -1979,7 +1979,7 @@ class SHGravCoeffs(object):
         sgg = _spectrum(self.coeffs, normalization=self.normalization,
                         lmax=lmax)
 
-        with _np.errstate(invalid='ignore'):
+        with _np.errstate(invalid='ignore', divide='ignore'):
             admit = sgh / shh
             corr = sgh / _np.sqrt(sgg * shh)
             if errors:

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -2596,17 +2596,17 @@ class SHGravCoeffs(object):
     # ---- Plotting routines ----
     def plot_spectrum(self, function='geoid', unit='per_l', base=10.,
                       lmax=None, xscale='lin', yscale='log', grid=True,
-                      legend=None, legend_error='error', axes_labelsize=None,
-                      tick_labelsize=None, show=True, ax=None, fname=None,
-                      **kwargs):
+                      legend=None, legend_error='error', legend_loc='best',
+                      axes_labelsize=None, tick_labelsize=None, show=True,
+                      ax=None, fname=None, **kwargs):
         """
         Plot the spectrum as a function of spherical harmonic degree.
 
         Usage
         -----
         x.plot_spectrum([function, unit, base, lmax, xscale, yscale, grid,
-                         legend, axes_labelsize, tick_labelsize, show, ax,
-                         fname, **kwargs])
+                         legend, legend_loc, axes_labelsize, tick_labelsize,
+                         show, ax, fname, **kwargs])
 
         Parameters
         ----------
@@ -2635,6 +2635,9 @@ class SHGravCoeffs(object):
             Text to use for the legend.
         legend_error : str, optional, default = 'error'
             Text to use for the legend of the error spectrum.
+        legend_loc : str, optional, default = 'best'
+            Location of the legend, such as 'upper right' or 'lower center'
+            (see pyplot.legend for all options).
         axes_labelsize : int, optional, default = None
             The font size for the x and y axes labels.
         tick_labelsize : int, optional, default = None
@@ -2742,7 +2745,7 @@ class SHGravCoeffs(object):
         axes.grid(grid, which='major')
         axes.minorticks_on()
         axes.tick_params(labelsize=tick_labelsize)
-        axes.legend()
+        axes.legend(loc=legend_loc)
 
         if ax is None:
             fig.tight_layout(pad=0.5)

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -25,10 +25,6 @@ except ModuleNotFoundError:
     _pygmt_module = False
 
 
-# =============================================================================
-# =========    GRID CLASSES    ================================================
-# =============================================================================
-
 class SHGrid(object):
     """
     Class for spatial gridded data on the sphere.

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -1963,17 +1963,17 @@ class SHMagCoeffs(object):
     # ---- Plotting routines ----
     def plot_spectrum(self, function='total', unit='per_l', base=10.,
                       lmax=None, xscale='lin', yscale='log', grid=True,
-                      legend=None, legend_error='error', axes_labelsize=None,
-                      tick_labelsize=None, show=True, ax=None, fname=None,
-                      **kwargs):
+                      legend=None, legend_error='error', legend_loc='best',
+                      axes_labelsize=None, tick_labelsize=None, show=True,
+                      ax=None, fname=None, **kwargs):
         """
         Plot the spectrum as a function of spherical harmonic degree.
 
         Usage
         -----
         x.plot_spectrum([function, unit, base, lmax, xscale, yscale, grid,
-                         legend, axes_labelsize, tick_labelsize, show, ax,
-                         fname, **kwargs])
+                         legend, legend_loc, axes_labelsize, tick_labelsize,
+                         show, ax, fname, **kwargs])
 
         Parameters
         ----------
@@ -2002,6 +2002,9 @@ class SHMagCoeffs(object):
             Text to use for the legend.
         legend_error : str, optional, default = 'error'
             Text to use for the legend of the error spectrum.
+        legend_loc : str, optional, default = 'best'
+            Location of the legend, such as 'upper right' or 'lower center'
+            (see pyplot.legend for all options).
         axes_labelsize : int, optional, default = None
             The font size for the x and y axes labels.
         tick_labelsize : int, optional, default = None
@@ -2105,7 +2108,7 @@ class SHMagCoeffs(object):
         axes.grid(grid, which='major')
         axes.minorticks_on()
         axes.tick_params(labelsize=tick_labelsize)
-        axes.legend()
+        axes.legend(loc=legend_loc)
 
         if ax is None:
             fig.tight_layout(pad=0.5)

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -1495,7 +1495,7 @@ class SHMagCoeffs(object):
                               normalization=self.normalization,
                               lmax=lmax)
 
-        with _np.errstate(invalid='ignore'):
+        with _np.errstate(invalid='ignore', divide='ignore'):
             return sgh / _np.sqrt(sgg * shh)
 
     # ---- Operations that return a new SHMagCoeffs class instance ----

--- a/pyshtools/shclasses/slepiancoeffs.py
+++ b/pyshtools/shclasses/slepiancoeffs.py
@@ -207,17 +207,17 @@ class SlepianCoeffs(object):
 
     def plot_spectrum(self, nmax=None, convention='power', unit='per_l',
                       base=10., lmax=None, xscale='lin', yscale='log',
-                      grid=True, legend=None, axes_labelsize=None,
-                      tick_labelsize=None, show=True, ax=None, fname=None,
-                      **kwargs):
+                      grid=True, legend=None, legend_loc='best',
+                      axes_labelsize=None, tick_labelsize=None, show=True,
+                      ax=None, fname=None, **kwargs):
         """
         Plot the spectrum as a function of spherical harmonic degree.
 
         Usage
         -----
         x.plot_spectrum([nmax, convention, unit, base, lmax, xscale, yscale,
-                         grid, axes_labelsize, tick_labelsize, legend, show,
-                         ax, fname, **kwargs])
+                         grid, legend, legend_loc, axes_labelsize,
+                         tick_labelsize, legend, show, ax, fname, **kwargs])
 
         Parameters
         ----------
@@ -247,6 +247,9 @@ class SlepianCoeffs(object):
             If True, plot grid lines.
         legend : str, optional, default = None
             Text to use for the legend.
+        legend_loc : str, optional, default = 'best'
+            Location of the legend, such as 'upper right' or 'lower center'
+            (see pyplot.legend for all options).
         axes_labelsize : int, optional, default = None
             The font size for the x and y axes labels.
         tick_labelsize : int, optional, default = None
@@ -291,8 +294,9 @@ class SlepianCoeffs(object):
                                            yscale=yscale, grid=grid,
                                            axes_labelsize=axes_labelsize,
                                            tick_labelsize=tick_labelsize,
-                                           legend=legend, show=show, ax=ax,
-                                           fname=fname, **kwargs)
+                                           legend=legend,
+                                           legend_loc=legend_loc, show=show,
+                                           ax=ax, fname=fname, **kwargs)
             return fig, axes
         else:
             temp.plot_spectrum(convention=convention, unit=unit,
@@ -300,5 +304,5 @@ class SlepianCoeffs(object):
                                yscale=yscale, grid=grid,
                                axes_labelsize=axes_labelsize,
                                tick_labelsize=tick_labelsize,
-                               legend=legend, show=show, ax=ax,
-                               fname=fname, **kwargs)
+                               legend=legend, legend_loc=legend_loc, show=show,
+                               ax=ax, fname=fname, **kwargs)

--- a/pyshtools/utils/figstyle.py
+++ b/pyshtools/utils/figstyle.py
@@ -85,6 +85,8 @@ def figstyle(rel_width=0.75, screen_dpi=114, aspect_ratio=4/3,
         # legends
         'legend.framealpha': 1.,
         'legend.edgecolor': 'k',
+        # error bars
+        'errorbar.capsize': 1.5,
         # images
         'image.lut': 65536,  # 16 bit
         # savefig


### PR DESCRIPTION
* Add the method `admittance()`, `correlation()` and `admitcorr()` to `SHCoeffs`, `SHMagCoeffs` and `SHGravCoeffs` in order to compute the admittance and/or correlation with another function. Add the methods `plot_admittance()`, `plot_correlation()` and `plot_admitcorr()` to easily plot these functions.
* Add the boolean option `errors` to the method `to_array()` in order to control whether the error coefficients are returned with the function spherical harmonic coefficients.
* Add the lunar magnet field dataset of Ravat et al. (2020)
* Add the option `legend_loc` to most plotting routines to allow fine control over where the legend is placed.