### PR TITLE
update binder dependecies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
         fftw>=3.3.8
         liblapack>=3.8
         openblas
-        gmt
+        gmt>=6.1.1
         scipy>=0.14.0
         matplotlib>=3.3
         astropy
@@ -46,10 +46,10 @@ install:
         requests
         cartopy>=0.18.0
         pygmt
-        pooch
+        pooch>=1.1
         tqdm
         jupyter
-        palettable
+        palettable>=3.3
         pypandoc
   - conda activate test-environment
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,12 @@ matrix:
       cache:
         directories:
           - $HOME/Library/Caches/Homebrew
+          - /usr/local
 
 addons:
   apt:
     packages:
+    - gcc
     - gfortran
   homebrew:
     packages:
@@ -30,29 +32,30 @@ install:
       export OS="Linux";
     fi
 
-    wget https://repo.continuum.io/miniconda/Miniconda3-latest-${OS}-x86_64.sh -O miniconda.sh
+  - curl https://repo.continuum.io/miniconda/Miniconda3-latest-${OS}-x86_64.sh -o miniconda.sh
+  #- wget https://repo.continuum.io/miniconda/Miniconda3-latest-${OS}-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -u -b -p $HOME/miniconda
   - source "$HOME/miniconda/etc/profile.d/conda.sh"
   - hash -r
 
   # Configure conda testing environment
   - conda config --set always_yes yes --set changeps1 no
-  - conda config --append channels conda-forge
+  - conda config --add channels conda-forge
   - conda update -q conda
 
   - conda create -q -n test-environment
         python=$PYTHON_VERSION
+        numpy
         fftw>=3.3.8
         liblapack>=3.8
         openblas
         gmt
-        numpy
-        scipy
-        matplotlib=3.3.*
+        scipy>=0.14.0
+        matplotlib>=3.3
         astropy
         xarray
         requests
-        cartopy
+        cartopy>=0.18.0
         pygmt
         pooch
         tqdm

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,7 @@ install:
       export OS="Linux";
     fi
 
-  - curl https://repo.continuum.io/miniconda/Miniconda3-latest-${OS}-x86_64.sh -o miniconda.sh
-  #- wget https://repo.continuum.io/miniconda/Miniconda3-latest-${OS}-x86_64.sh -O miniconda.sh
+  - curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-${OS}-x86_64.sh -o miniconda.sh
   - bash miniconda.sh -u -b -p $HOME/miniconda
   - source "$HOME/miniconda/etc/profile.d/conda.sh"
   - hash -r

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,22 +7,12 @@ matrix:
       env: PYTHON_VERSION=3.8
     - os: osx
       env: PYTHON_VERSION=3.8
-      before_cache:
-        - brew cleanup
-      cache:
-        directories:
-          - $HOME/Library/Caches/Homebrew
-          - /usr/local
 
 addons:
   apt:
     packages:
     - gcc
     - gfortran
-  homebrew:
-    packages:
-    - wget
-    update: true
 
 install:
   # Download and install miniconda

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@
 #       make python-tests-no-timing  : Run the Python test/example suite,
 #                                      (excluding timing tests).
 #       make run-notebooks    : Run notebooks to test for errors.
-#       make install-fortran  : Place the compiled libraries and docs in
-#                               $(DESTDIR)$(PREFIX) [default is /usr/local].
+#       make install          : Place the compiled libraries and docs in
+#                               $(DESTDIR)$(PREFIX) [default is {}{usr/local}].
 #       make uninstall        : Remove files copied to $(DESTDIR)$(PREFIX).
 #       make clean            : Return the folder to its original state.
 #       make check            : Check syntax of python files using flake8.
@@ -133,6 +133,8 @@ JUPYTER = jupyter nbconvert --ExecutePreprocessor.kernel_name=python3
 JEKYLL = bundle exec jekyll
 FLAKE8 = flake8
 SHELL = /bin/sh
+PY3EXT = $(shell $(PYTHON) -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))' || echo nopy3)
+
 
 FDOCDIR = src/fdoc
 PYDOCDIR = src/pydoc
@@ -151,7 +153,6 @@ PYPATH = $(PWD)
 PREFIX = /usr/local
 SYSLIBPATH = $(PREFIX)/lib
 SYSMODPATH = $(PREFIX)/include
-PY3EXT = $(shell $(PYTHON) -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))' || echo nopy3)
 SYSSHAREPATH = $(PREFIX)/share
 
 FFTW = -L$(SYSLIBPATH) -lfftw3 -lm
@@ -215,7 +216,7 @@ LAPACK_FLAGS = -DLAPACK_UNDERSCORE
 endif
 
 
-.PHONY: all fortran fortran-mp install-fortran fortran-tests fortran-tests-mp \
+.PHONY: all fortran fortran-mp install fortran-tests fortran-tests-mp \
 	fortran-tests-no-timing fortran-tests-no-timing-mp run-fortran-tests \
 	run-fortran-tests-no-timing doc remove-doc python-tests \
 	python-tests-no-timing uninstall clean clean-fortran-tests \
@@ -265,7 +266,7 @@ fortran-mp:
 	@echo $(F95) $(MODFLAG) $(OPENMPFLAGS) $(F95FLAGS) -L$(LIBPATH) -l$(LIBNAMEMP) $(FFTW) $(LAPACK) $(BLAS)
 	@echo
 
-install-fortran: fortran
+install: fortran
 	mkdir -pv $(DESTDIR)$(SYSLIBPATH)
 	cp $(LIBPATH)/lib$(LIBNAME).a $(DESTDIR)$(SYSLIBPATH)/lib$(LIBNAME).a
 	-cp $(LIBPATH)/lib$(LIBNAMEMP).a $(DESTDIR)$(SYSLIBPATH)/lib$(LIBNAMEMP).a

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -16,9 +16,9 @@ dependencies:
     - requests
     - cartopy>=0.18.0
     - pygmt>=0.2
-    - pooch
+    - pooch>=1.1
     - tqdm
     - jupyter
-    - palettable
+    - palettable>=3.3
     - pypandoc
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,6 +1,5 @@
 name: pyshtools
 channels:
-    - defaults
     - conda-forge
 dependencies:
     - python=3.8
@@ -11,14 +10,15 @@ dependencies:
     - pyshtools>=4.7
     - numpy
     - scipy>=0.14.0
-    - matplotlib=3.3.*
+    - matplotlib>=3.3
     - astropy
     - xarray
     - requests
-    - cartopy
+    - cartopy>=0.18.0
     - pygmt>=0.2
     - pooch
     - tqdm
     - jupyter
     - palettable
     - pypandoc
+

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,18 +1,24 @@
 name: pyshtools
 channels:
+    - defaults
     - conda-forge
 dependencies:
-    - python>=3.6
-    - numpy
+    - python=3.8
+    - fftw>=3.3.8
+    - liblapack>=3.8
+    - openblas
+    - gmt>=6.1.1
     - pyshtools>=4.7
+    - numpy
     - scipy>=0.14.0
-    - matplotlib>=3.3
+    - matplotlib=3.3.*
     - astropy
     - xarray
     - requests
-    - pooch
-    - tqdm
     - cartopy
     - pygmt>=0.2
-    - gmt>=6.1.1
+    - pooch
+    - tqdm
+    - jupyter
     - palettable
+    - pypandoc

--- a/docs/pages/fortran/fortran-examples.md
+++ b/docs/pages/fortran/fortran-examples.md
@@ -18,7 +18,7 @@ table:nth-of-type(n) th:nth-of-type(2) {
 }
 </style>
 
-{% include note.html content="In order to access the fortran example programs and example datasets, it will be necessary to either dowload (or clone) the entire shtools repo from [GitHub](https://github.com/SHTOOLS/SHTOOLS/), or to install with *brew* using the option `--with-examples`. If the entire repo was downloaded, the example programs will be found in the folder `examples/fortran`. If shtools was instead installed with *brew*, they will be found in `/usr/local/share/shtools/examples/fortran/`." %}
+{% include note.html content="In order to access the fortran example programs and example datasets, it will be necessary to dowload the entire shtools repo from [GitHub](https://github.com/SHTOOLS/SHTOOLS/), install with *brew* using the option `--with-examples`, or install with *macports*. If the entire repo was downloaded, the example programs will be found in the folder `examples/fortran`. If shtools was instead installed with *brew* or *macports*, they will be found in `/usr/local/share/shtools/examples/fortran/` or `/opt/local/share/shtools/examples/fortran/`, respectively." %}
 
 
 | Folder | Description |

--- a/docs/pages/fortran/fortran-installing.md
+++ b/docs/pages/fortran/fortran-installing.md
@@ -19,12 +19,12 @@ To install the OpenMP components along with the standard Fortran 95 library, add
 ```bash
 brew install shtools --with-openmp
 ```
+The shtools library `libSHTOOLS.a` will be installed in the directory `/usr/local/lib`, and the compiled module files will be installed in `/usr/local/include`.
 
 To install the example data files and test programs in the directory `/usr/local/share/shtools/` use:
 ```bash
 brew install shtools --with-examples
 ```
-
 To run the test suite, use
 ```bash
 brew test shtools
@@ -41,7 +41,7 @@ To install the OpenMP components along with the standard Fortran 95 library, add
 ```bash
 sudo port install shtools +openmp
 ```
-To run the test suite, which is located in `/opt/local/share/examples/shtools`, use the command
+The shtools library `libSHTOOLS.a` will be installed in the directory `/opt/local/lib`, and the compiled module files will be installed in `/opt/local/include`. To run the test suite, which is located in `/opt/local/share/examples/shtools`, use the command
 ```bash
 sudo port test shtools
 ```
@@ -50,12 +50,13 @@ sudo port test shtools
 
 Before trying to install the Fortran 95 components of SHTOOLS, it will be necessary to have a Fortran 95 compiler and [LAPACK](https://www.netlib.org/lapack/), [BLAS](https://www.netlib.org/blas/) and [FFTW3](http://www.fftw.org)-compatible libraries. On most linux distributions, this can be accomplished using
 ```bash
-sudo apt-get install libblas-dev liblapack-dev g++ gfortran libfftw3-dev tcsh
+sudo apt-get install gcc gfortran libfftw3-dev libblas-dev liblapack-dev
 ```
-or on macOS using either [brew](https://brew.sh/) or [macports](https://www.macports.org/)
+or on macOS using
 ```bash
-brew install fftw
-sudo port install fftw-3
+brew install fftw  # using brew
+sudo port install fftw-3  # using macports
+conda install fftw  # using conda
 # lapack and blas can be accessed by linking to the system '-framework Accelerate'
 ```
 

--- a/docs/pages/fortran/index-fortran.md
+++ b/docs/pages/fortran/index-fortran.md
@@ -38,12 +38,13 @@ Alternatively, install using the [brew](http://brew.sh/) package manager (macOS)
 ```bash
 brew tap shtools/shtools
 brew install shtools
-brew install shtools --with-openmp  # to install shtools with the OpenMP components.
+brew install shtools --with-openmp  # to install shtools with the OpenMP components
 ```
 
 or the [macports](https://www.macports.org/) package manager (macOS)
 ```bash
 sudo port install shtools
+sudo port install shtools +openmp  # to install shtools with the OpenMP components
 ```
 
 ## Permissive licensing

--- a/docs/pages/mydoc/python-datasets-constants.md
+++ b/docs/pages/mydoc/python-datasets-constants.md
@@ -22,7 +22,7 @@ table:nth-of-type(n) th:nth-of-type(2) {
 
 The *constants* subpackage defines physical constants related to the terrestrial planets and moons. Each constant is an instance of an [astropy](http://docs.astropy.org/en/stable/constants/index.html) `Constant` class, which has the attributes `name`, `value`, `uncertainty`, `unit`, and `reference`.
 
-The pyshtools constants are organized by planet: Mercury, Venus, Earth, Moon, and Mars. Each planet has several attributes, such as the the mean planetary radius `r`, `mass`, and flattening `f`. To see all information about an individual constant, it is only necessary to use the print function:
+The pyshtools constants are organized primarily by planet: Mercury, Venus, Earth, Moon, and Mars. Each planet has several attributes, such as the the mean planetary radius `r`, `mass`, and flattening `f`. To see all information about an individual constant, it is only necessary to use the print function:
 ```python
 In [1]: print(pysh.constants.Mars.r)
   Name   = Mean radius of Mars
@@ -34,9 +34,10 @@ In [1]: print(pysh.constants.Mars.r)
 To use the value of a constant in a calculation, it is only necessary to access its `value` attribute:
 
 ```python
-In [2]: print(pysh.constants.Mars.r.value)
-3389500.0
+In [2]: 2 * pysh.constants.Mars.r.value
+6779000.0
 ```
+Physical constants from the *Committee on Data for Science and Technology* are provided in the submodule `codata`. A few of these (such as `G` and `mu0`) are referenced in the main constants namespace.
 
 ## Datasets
 

--- a/docs/pages/mydoc/python-installing.md
+++ b/docs/pages/mydoc/python-installing.md
@@ -3,10 +3,18 @@ title: "Installing pyshtools"
 keywords: spherical harmonics software package, spherical harmonic transform, legendre functions, multitaper spectral analysis, fortran, Python, gravity, magnetic field
 sidebar: mydoc_sidebar
 permalink: python-installing.html
-summary: pyshtools can be installed using the pip package manager or conda.
+summary: pyshtools can be installed using the conda or pip package manager.
 toc: true
 folder: mydoc
 ---
+
+## Conda package installer
+
+The binary pre-compiled pyshtools library, with all required dependencies, can be installed with the conda package manager using the command:
+```bash
+conda install -c conda-forge pyshtools  # Linux and macOS only
+```
+The conda packages do not support Windows architectures at the present time.
 
 ## Python package installer (pip)
 
@@ -15,24 +23,19 @@ On Linux, macOS and Windows architectures, the binary wheels can be installed us
 pip install pyshtools
 pip install --upgrade pyshtools  # to upgrade a pre-existing installation
 ```
-
-## Conda package installer
-
-The binary pre-compiled pyshtools library can also be installed with the conda package manager using the command:
-```bash
-conda install -c conda-forge pyshtools  # Linux and macOS only
-```
-The conda packages do not support Windows architectures at the present time.
+In order to use the map projection routines, it will be necessary to install either Cartopy and/or pygmt separately, as described in the section [Python dependencies](#dependencies).
 
 ## Build from source (pip)
 
-If you wish to compile the archive yourself, first make sure that you have the required dependencies installed for the Fortran-95 components (see [these instruction](fortran-installing.html)). On most Linux distributions, this can be accomplished using
+If you wish to compile the archive yourself, first make sure that you have the required dependencies installed for the Fortran-95 components, which inlcude FFTW3 and LAPACK compatible libraries (see [these instructions](fortran-installing.html)). This can be accomplished on most Linux distributions using
 ```bash
-sudo apt-get install libblas-dev liblapack-dev gcc gfortran libfftw3-dev
+sudo apt-get install gcc gfortran libfftw3-dev libblas-dev liblapack-dev
 ```
-or on macOS using [brew](https://brew.sh/)
+or on macOS by using one of the following
 ```bash
-brew install fftw
+brew install fftw  # using brew
+sudo port install fftw-3  # using macports
+conda install fftw  # using conda
 ```
 Then build from source using the command
 ```bash
@@ -60,9 +63,9 @@ pip uninstall pyshtools
 ```
 Note that these commands will install only the Python version that corresponds to the version of `pip` being used. On some systems, it may be necessary to specify explicitly `pip3` or `pip3.x`.
 
-## Python dependencies
+## Python dependencies {#dependencies}
 
-When installing pyshtools using pip or conda, the following packages should be installed automatically:
+When installing pyshtools using `pip` or `conda`, the following packages should be installed automatically:
 
 * [numpy](https://numpy.org/): required for all numerical calculations
 * [scipy](https://www.scipy.org/): required for a few specialized functions.
@@ -73,19 +76,21 @@ When installing pyshtools using pip or conda, the following packages should be i
 * [pooch](https://www.fatiando.org/pooch/latest/index.html): required for reading datasets.
 * [tqdm](https://tqdm.github.io/): required for showing progress bars when downloading datasets.
 
-For more specialized operations related to map projections, it will be necessary to install manually the following packages:
+When installing pyshtools using `conda`, the following will also be installed automatically:
 
-* [Cartopy](https://scitools.org.uk/cartopy/docs/latest/): required for Cartopy map projections. Cartopy requires (see below) *proj*, *geos*, *cython*, *pyshp*, *six*, and *shapely*.
+* [cartopy](https://scitools.org.uk/cartopy/docs/latest/): required for Cartopy map projections. Cartopy requires (see below) *proj*, *geos*, *cython*, *pyshp*, *six*, and *shapely*.
 * [pygmt](https://www.pygmt.org) (>=0.2): required for pygmt map projections. pygmt requires (see below) *gmt (>=6.1.1)*.
 * [palettable](https://jiffyclub.github.io/palettable/): scientific color maps required by one of the tutorials.
 
+The above three packages will need to be installed separately when installing pyshtools with `pip`, as described in the following subsections.
+
 ### How to install Cartopy
 
-The easiest way to install Cartopy is with conda:
+The easiest way to install Cartopy is with `conda`:
 ```bash
 conda install -c conda-forge cartopy
 ```
-Cartopy can also be installed using pip, but there are several dependencies that need to be installed first. On macOS, this can be accomplished using
+Cartopy can also be installed using `pip`, but there are several dependencies that need to be installed first. On macOS, this can be accomplished using
 ```bash
 brew install proj geos
 pip install --upgrade cython numpy pyshp six
@@ -101,7 +106,7 @@ In order to use the *pygmt* plotting routines, it will be necessary to install b
 ```bash
 conda install -c conda-forge pygmt gmt
 ```
-Alternatively, *pygmt* can be installed using pip
+Alternatively, *pygmt* can be installed using `pip`
 ```bash
 pip install pygmt
 ```

--- a/docs/pages/mydoc/python-installing.md
+++ b/docs/pages/mydoc/python-installing.md
@@ -110,7 +110,9 @@ Alternatively, *pygmt* can be installed using `pip`
 ```bash
 pip install pygmt
 ```
-The *gmt* library will then need to be installed using other means, such as with brew on macOS
+The *gmt* library will then need to be installed using other means, such as with brew, macports or apt-get:
 ```bash
-brew install gmt
+brew install gmt  # using brew on macOS
+sudo port install gmt6  # using macports on macOS
+sudo apt-get install gmt  # using apt-get on linux
 ```

--- a/docs/pages/mydoc/python-installing.md
+++ b/docs/pages/mydoc/python-installing.md
@@ -28,7 +28,7 @@ The conda packages do not support Windows architectures at the present time.
 
 If you wish to compile the archive yourself, first make sure that you have the required dependencies installed for the Fortran-95 components (see [these instruction](fortran-installing.html)). On most Linux distributions, this can be accomplished using
 ```bash
-sudo apt-get install libblas-dev liblapack-dev g++ gfortran libfftw3-dev
+sudo apt-get install libblas-dev liblapack-dev gcc gfortran libfftw3-dev
 ```
 or on macOS using [brew](https://brew.sh/)
 ```bash

--- a/environment.yml
+++ b/environment.yml
@@ -9,13 +9,13 @@ dependencies:
     - gmt>=6.1.1
     - numpy
     - scipy>=0.14.0
-    - matplotlib=3.3.*
+    - matplotlib>=3.3
     - astropy
     - xarray
     - requests
     - pooch
     - tqdm
-    - cartopy
+    - cartopy>=0.18.0
     - pygmt>=0.2
     - palettable
     - jupyter

--- a/pyshtools/constants/__init__.py
+++ b/pyshtools/constants/__init__.py
@@ -22,10 +22,10 @@ Inspect a constant using the print function:
 
     >>> print(G)
       Name   = Gravitational constant
-      Value  = 6.67408e-11
-      Uncertainty  = 3.1e-15
+      Value  = 6.6743e-11
+      Uncertainty  = 1.5e-15
       Unit  = m3 / (kg s2)
-      Reference = CODATA 2014
+      Reference = CODATA 2018
 """
 
 try:
@@ -40,6 +40,7 @@ except ImportError:
 
 from astropy.constants import G
 from astropy.constants import mu0
+from astropy.constants import codata
 
 # == Constants organized by planet ===
 
@@ -49,9 +50,7 @@ from . import Earth
 from . import Moon
 from . import Mars
 
-# === Define groups of constants and __all__ ===
+# === Define __all__ ===
 
-_constants_fundamental = ['G', 'mu0']
-
-__all__ = ['Constant', 'Quantity', 'G', 'mu0', 'Mercury', 'Venus', 'Earth',
-           'Moon', 'Mars']
+__all__ = ['Constant', 'Quantity', 'G', 'mu0', 'codata', 'Mercury', 'Venus',
+           'Earth', 'Moon', 'Mars']

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 ipython
-palettable
+palettable>=3.3
 jupyter
 pypandoc
 cython

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,5 @@ cython
 pyshp
 six
 shapely
-cartopy
+cartopyy>=0.18.0
 pygmt>=0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ matplotlib>=3.3
 astropy
 xarray
 requests
-pooch
+pooch>=1.1
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ from subprocess import check_call  # noqa: E402
 # Convert markdown README.md to restructured text (.rst) for PyPi, and
 # remove the first 5 lines that contain a reference to the shtools logo.
 # pandoc can be installed either by conda or pip:
-#     conda install -c conda-forge pandoc pypandoc
+#     conda install -c conda-forge pypandoc
 #     pip install pypandoc
 try:
     import pypandoc
@@ -87,7 +87,7 @@ EXTRAS_REQUIRE = {
 print('INSTALLING SHTOOLS {}'.format(VERSION))
 
 
-# Custom Builder
+# Custom build class
 class build(_build):
     """This overrides the standard build class to include the doc build."""
 
@@ -109,21 +109,9 @@ class build(_build):
         print('---- ALL DONE ----')
 
 
-# Custom Installer
-class install(_install):
-    """This overrides the standard build class to include the doc build."""
-
-    description = "builds python documentation"
-
-    def run(self):
-        """Build the Fortran library, all python extensions and the docs."""
-        print('---- CUSTOM INSTALL ----')
-        _install.run(self)
-
-
-# Custom Installer
+# Custom develop classs
 class develop(_develop):
-    """This overrides the standard build class to include the doc build."""
+    """This overrides the standard develop class to include the doc build."""
 
     description = "builds python documentation"
 
@@ -144,8 +132,19 @@ class develop(_develop):
         print('---- ALL DONE ----')
 
 
-# configure python extension to be compiled with f2py
+# Custom install class
+class install(_install):
+    """This overrides the standard install class to include the doc build."""
 
+    description = "builds python documentation"
+
+    def run(self):
+        """Build the Fortran library, all python extensions and the docs."""
+        print('---- CUSTOM INSTALL ----')
+        _install.run(self)
+
+
+# configure python extension to be compiled with f2py
 def configuration(parent_package='', top_path=None):
     """Configure all packages that need to be built."""
     config = Configuration('', parent_package, top_path)
@@ -163,7 +162,8 @@ def configuration(parent_package='', top_path=None):
 
     # collect all Fortran sources
     files = os.listdir('src')
-    exclude_sources = ['PlanetsConstants.f95', 'PythonWrapper.f95']
+    exclude_sources = ['PlanetsConstants.f95', 'PythonWrapper.f95',
+                       'cWrapper.f95']
     sources = [os.path.join('src', file) for file in files if
                file.lower().endswith(('.f95', '.c')) and file not in
                exclude_sources]
@@ -223,7 +223,7 @@ metadata = dict(
     download_url='https://github.com/SHTOOLS/SHTOOLS/zipball/master',
     author='The SHTOOLS developers',
     author_email="mark.a.wieczorek@gmail.com",
-    license='BSD',
+    license='BSD-3-Clause',
     keywords=KEYWORDS,
     python_requires=PYTHON_REQUIRES,
     install_requires=INSTALL_REQUIRES,

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ INSTALL_REQUIRES = [
 ]
 
 EXTRAS_REQUIRE = {
-    'maps': ['cartopy', 'pygmt>=0.2', 'palettable']
+    'maps': ['cartopy>=0.18.0', 'pygmt>=0.2', 'palettable']
 }
 
 print('INSTALLING SHTOOLS {}'.format(VERSION))

--- a/setup.py
+++ b/setup.py
@@ -33,14 +33,14 @@ from subprocess import check_call  # noqa: E402
 # Convert markdown README.md to restructured text (.rst) for PyPi, and
 # remove the first 5 lines that contain a reference to the shtools logo.
 # pandoc can be installed either by conda or pip:
-# conda install -c conda-forge pandoc pypandoc
-# pip install pypandoc
+#     conda install -c conda-forge pandoc pypandoc
+#     pip install pypandoc
 try:
     import pypandoc
     rst = pypandoc.convert_file('README.md', 'rst')
     long_description = rst.split('\n', 5)[5]
 except(IOError, ImportError):
-    print('*** pypandoc is not installed. PYPI description will not be '
+    print('*** pypandoc is not installed. PYPI long_description will not be '
           'formatted correctly. ***')
     long_description = open('README.md').read()
 
@@ -76,12 +76,12 @@ INSTALL_REQUIRES = [
     'astropy',
     'xarray',
     'requests',
-    'pooch',
+    'pooch>=1.1',
     'tqdm'
 ]
 
 EXTRAS_REQUIRE = {
-    'maps': ['cartopy>=0.18.0', 'pygmt>=0.2', 'palettable']
+    'extras': ['cartopy>=0.18.0', 'pygmt>=0.2', 'palettable>=3.3']
 }
 
 print('INSTALLING SHTOOLS {}'.format(VERSION))

--- a/src/SHTOOLS.f95
+++ b/src/SHTOOLS.f95
@@ -307,11 +307,11 @@ module SHTOOLS
             integer, intent(in), optional :: norm, csphase, dealloc
         end function MakeGridPointC
 
-        subroutine SHMultiply(shout, sh1, lmax1, sh2, lmax2, precomp, &
+        subroutine SHMultiply(cilmout, cilm1, lmax1, cilm2, lmax2, precomp, &
                               norm, csphase, exitstatus)
             integer, parameter :: dp = selected_real_kind(p=15)
-            real(dp), intent(out) :: shout(:,:,:)
-            real(dp), intent(in) :: sh1(:,:,:), sh2(:,:,:)
+            real(dp), intent(out) :: cilmout(:,:,:)
+            real(dp), intent(in) :: cilm1(:,:,:), cilm2(:,:,:)
             integer, intent(in) :: lmax1, lmax2
             integer, intent(in), optional :: precomp, norm, csphase
             integer, intent(out), optional :: exitstatus
@@ -423,71 +423,72 @@ module SHTOOLS
             integer, intent(out), optional :: exitstatus
         end subroutine SHRotateRealCoef
 
-        function SHPowerL(c, l)
+        function SHPowerL(cilm, l)
             integer, parameter :: dp = selected_real_kind(p=15)
             real(dp) :: SHPowerL
-            real(dp), intent(in) :: c(:,:,:)
+            real(dp), intent(in) :: cilm(:,:,:)
             integer, intent(in) :: l
         end function SHPowerL
 
-        function SHPowerDensityL(c, l)
+        function SHPowerDensityL(cilm, l)
             integer, parameter :: dp = selected_real_kind(p=15)
             real(dp) :: SHPowerDensityL
-            real(dp), intent(in) :: c(:,:,:)
+            real(dp), intent(in) :: cilm(:,:,:)
             integer, intent(in) :: l
         end function SHPowerDensityL
 
-        function SHCrossPowerL(c1, c2, l)
+        function SHCrossPowerL(cilm1, cilm2, l)
             integer, parameter :: dp = selected_real_kind(p=15)
             real(dp) :: SHCrossPowerL
-            real(dp), intent(in) :: c1(:,:,:), c2(:,:,:)
+            real(dp), intent(in) :: cilm1(:,:,:), cilm2(:,:,:)
             integer, intent(in) :: l
         end function SHCrossPowerL
 
-        function SHCrossPowerDensityL(c1, c2, l)
+        function SHCrossPowerDensityL(cilm1, cilm2, l)
             integer, parameter :: dp = selected_real_kind(p=15)
             real(dp) :: SHCrossPowerDensityL
-            real(dp), intent(in) :: c1(:,:,:), c2(:,:,:)
+            real(dp), intent(in) :: cilm1(:,:,:), cilm2(:,:,:)
             integer, intent(in) :: l
         end function SHCrossPowerDensityL
 
-        subroutine SHPowerSpectrum(c, lmax, spectra, exitstatus)
+        subroutine SHPowerSpectrum(cilm, lmax, spectra, exitstatus)
             integer, parameter :: dp = selected_real_kind(p=15)
-            real(dp), intent(in) :: c(:,:,:)
+            real(dp), intent(in) :: cilm(:,:,:)
             integer, intent(in) :: lmax
             real(dp), intent(out) :: spectra(:)
             integer, intent(out), optional :: exitstatus
         end subroutine SHPowerSpectrum
 
-        subroutine SHPowerSpectrumDensity(c, lmax, spectra, exitstatus)
+        subroutine SHPowerSpectrumDensity(cilm, lmax, spectra, exitstatus)
             integer, parameter :: dp = selected_real_kind(p=15)
-            real(dp), intent(in) :: c(:,:,:)
+            real(dp), intent(in) :: cilm(:,:,:)
             integer, intent(in) :: lmax
             real(dp), intent(out) :: spectra(:)
             integer, intent(out), optional :: exitstatus
         end subroutine SHPowerSpectrumDensity
 
-        subroutine SHCrossPowerSpectrum(c1, c2, lmax, cspectra, exitstatus)
+        subroutine SHCrossPowerSpectrum(cilm1, cilm2, lmax, cspectra, &
+                                        exitstatus)
             integer, parameter :: dp = selected_real_kind(p=15)
-            real(dp), intent(in) :: c1(:,:,:), c2(:,:,:)
+            real(dp), intent(in) :: cilm1(:,:,:), cilm2(:,:,:)
             integer, intent(in) :: lmax
             real(dp), intent(out) :: cspectra(:)
             integer, intent(out), optional :: exitstatus
         end subroutine SHCrossPowerSpectrum
 
-        subroutine SHCrossPowerSpectrumDensity(c1, c2, lmax, cspectra, &
+        subroutine SHCrossPowerSpectrumDensity(cilm1, cilm2, lmax, cspectra, &
                                                exitstatus)
             integer, parameter :: dp = selected_real_kind(p=15)
-            real(dp), intent(in) :: c1(:,:,:), c2(:,:,:)
+            real(dp), intent(in) :: cilm1(:,:,:), cilm2(:,:,:)
             integer, intent(in) :: lmax
             real(dp), intent(out) :: cspectra(:)
             integer, intent(out), optional :: exitstatus
         end subroutine SHCrossPowerSpectrumDensity
 
-        subroutine SHAdmitCorr(G, T, lmax, admit, corr, admit_error, &
+        subroutine SHAdmitCorr(gilm, tilm, lmax, admit, corr, admit_error, &
                                exitstatus)
             integer, parameter :: dp = selected_real_kind(p=15)
-            real(dp), intent(in) :: G(:,:,:), T(:,:,:)
+            real(dp), intent(in) :: gilm(:,:,:), tilm(:,:,:)
             integer, intent(in) :: lmax
             real(dp), intent(out) :: admit(:), corr(:)
             real(dp), intent(out), optional :: admit_error(:)
@@ -501,85 +502,86 @@ module SHTOOLS
             integer, intent(in) :: l_conf
         end function SHConfidence
 
-        function SHPowerLC(c, l)
+        function SHPowerLC(cilm, l)
             integer, parameter :: dp = selected_real_kind(p=15)
             real(dp) :: SHPowerLC
-            complex(dp), intent(in) :: c(:,:,:)
+            complex(dp), intent(in) :: cilm(:,:,:)
             integer, intent(in) :: l
         end function SHPowerLC
 
-        function SHPowerDensityLC(c, l)
+        function SHPowerDensityLC(cilm, l)
             integer, parameter :: dp = selected_real_kind(p=15)
             real(dp) :: SHPowerDensityLC
-            complex(dp), intent(in) :: c(:,:,:)
+            complex(dp), intent(in) :: cilm(:,:,:)
             integer, intent(in) :: l
         end function SHPowerDensityLC
 
-        function SHCrossPowerLC(c1, c2, l)
+        function SHCrossPowerLC(cilm1, cilm2, l)
             integer, parameter :: dp = selected_real_kind(p=15)
             complex(dp) :: SHCrossPowerLC
-            complex(dp), intent(in) :: c1(:,:,:), c2(:,:,:)
+            complex(dp), intent(in) :: cilm1(:,:,:), cilm2(:,:,:)
             integer, intent(in) :: l
         end function SHCrossPowerLC
 
-        function SHCrossPowerDensityLC(c1, c2, l)
+        function SHCrossPowerDensityLC(cilm1, cilm2, l)
             integer, parameter :: dp = selected_real_kind(p=15)
             complex(dp) :: SHCrossPowerDensityLC
-            complex(dp), intent(in) :: c1(:,:,:), c2(:,:,:)
+            complex(dp), intent(in) :: cilm1(:,:,:), cilm2(:,:,:)
             integer, intent(in) :: l
         end function SHCrossPowerDensityLC
 
-        subroutine SHPowerSpectrumC(c, lmax, spectra, exitstatus)
+        subroutine SHPowerSpectrumC(cilm, lmax, spectra, exitstatus)
             integer, parameter :: dp = selected_real_kind(p=15)
-            complex(dp), intent(in) :: c(:,:,:)
+            complex(dp), intent(in) :: cilm(:,:,:)
             integer, intent(in) :: lmax
             real(dp), intent(out) :: spectra(:)
             integer, intent(out), optional :: exitstatus
         end subroutine SHPowerSpectrumC
 
-        subroutine SHPowerSpectrumDensityC(c, lmax, spectra, exitstatus)
+        subroutine SHPowerSpectrumDensityC(cilm, lmax, spectra, exitstatus)
             integer, parameter :: dp = selected_real_kind(p=15)
-            complex(dp), intent(in) :: c(:,:,:)
+            complex(dp), intent(in) :: cilm(:,:,:)
             integer, intent(in) :: lmax
             real(dp), intent(out) :: spectra(:)
             integer, intent(out), optional :: exitstatus
         end subroutine SHPowerSpectrumDensityC
 
-        subroutine SHCrossPowerSpectrumC(c1, c2, lmax, cspectra, exitstatus)
+        subroutine SHCrossPowerSpectrumC(cilm1, cilm2, lmax, cspectra, &
+                                         exitstatus)
             integer, parameter :: dp = selected_real_kind(p=15)
-            complex(dp), intent(in) :: c1(:,:,:), c2(:,:,:)
+            complex(dp), intent(in) :: cilm1(:,:,:), cilm2(:,:,:)
             integer, intent(in) :: lmax
             complex(dp), intent(out) :: cspectra(:)
             integer, intent(out), optional :: exitstatus
         end subroutine SHCrossPowerSpectrumC
 
-        subroutine SHCrossPowerSpectrumDensityC(c1, c2, lmax, cspectra,&
+        subroutine SHCrossPowerSpectrumDensityC(cilm1, cilm2, lmax, cspectra, &
                                                 exitstatus)
             integer, parameter :: dp = selected_real_kind(p=15)
-            complex(dp), intent(in) :: c1(:,:,:), c2(:,:,:)
+            complex(dp), intent(in) :: cilm1(:,:,:), cilm2(:,:,:)
             integer, intent(in) :: lmax
             complex(dp), intent(out) :: cspectra(:)
             integer, intent(out), optional :: exitstatus
         end subroutine SHCrossPowerSpectrumDensityC
 
-        subroutine SHMultiTaperSE(mtse, sd, sh, lmax, tapers, taper_order, &
+        subroutine SHMultiTaperSE(mtse, sd, cilm, lmax, tapers, taper_order, &
                                   lmaxt, k, alpha, lat, lon, taper_wt, norm, &
                                   csphase, exitstatus)
             integer, parameter :: dp = selected_real_kind(p=15)
             real(dp), intent(out) :: mtse(:), sd(:)
-            real(dp), intent(in) :: sh(:,:,:), tapers(:,:)
+            real(dp), intent(in) :: cilm(:,:,:), tapers(:,:)
             integer, intent(in) :: lmax, lmaxt, k, taper_order(:)
             real(dp), intent(in), optional :: alpha(:), lat, lon, taper_wt(:)
             integer, intent(in), optional :: csphase, norm
             integer, intent(out), optional :: exitstatus
         end subroutine SHMultiTaperSE
 
-        subroutine SHMultiTaperCSE(mtse, sd, sh1, lmax1, sh2, lmax2, tapers, &
-                                   taper_order, lmaxt, k, alpha, lat, lon, &
-                                   taper_wt, norm, csphase, exitstatus)
+        subroutine SHMultiTaperCSE(mtse, sd, cilm1, lmax1, cilm2, lmax2, &
+                                   tapers, taper_order, lmaxt, k, alpha, lat, &
+                                   lon, taper_wt, norm, csphase, exitstatus)
             integer, parameter :: dp = selected_real_kind(p=15)
             real(dp), intent(out) :: mtse(:), sd(:)
-            real(dp), intent(in) :: sh1(:,:,:), sh2(:,:,:), tapers(:,:)
+            real(dp), intent(in) :: cilm1(:,:,:), cilm2(:,:,:), tapers(:,:)
             integer, intent(in) :: lmax1, lmax2, lmaxt, k, taper_order(:)
             real(dp), intent(in), optional :: alpha(:), lat, lon, taper_wt(:)
             integer, intent(in), optional :: csphase, norm
@@ -587,11 +589,12 @@ module SHTOOLS
         end subroutine SHMultiTaperCSE
 
         subroutine SHLocalizedAdmitCorr(tapers, taper_order, lwin, lat, lon, &
-                                        g, t, lmax, admit, corr, k, &
+                                        gilm, tilm, lmax, admit, corr, k, &
                                         admit_error, corr_error, taper_wt, &
                                         mtdef, k1linsig, exitstatus)
             integer, parameter :: dp = selected_real_kind(p=15)
-            real(dp), intent(in) :: tapers(:,:), lat, lon, g(:,:,:), t(:,:,:)
+            real(dp), intent(in) :: tapers(:,:), lat, lon, gilm(:,:,:), &
+                                    tilm(:,:,:)
             integer, intent(in) :: lwin, lmax, k, taper_order(:)
             real(dp), intent(out) :: admit(:), corr(:)
             real(dp), intent(out), optional :: admit_error(:), corr_error(:)
@@ -746,24 +749,24 @@ module SHTOOLS
             integer, intent(out), optional :: exitstatus
         end subroutine SHBiasKMask
 
-        subroutine SHMultiTaperMaskSE(mtse, sd, sh, lmax, tapers, &
+        subroutine SHMultiTaperMaskSE(mtse, sd, cilm, lmax, tapers, &
                                       lmaxt, k, taper_wt, norm, csphase, &
                                       exitstatus)
             integer, parameter :: dp = selected_real_kind(p=15)
             real(dp), intent(out) :: mtse(:), sd(:)
-            real(dp), intent(in) :: sh(:,:,:), tapers(:,:)
+            real(dp), intent(in) :: cilm(:,:,:), tapers(:,:)
             integer, intent(in) :: lmax, lmaxt, k
             real(dp), intent(in), optional :: taper_wt(:)
             integer, intent(in), optional :: csphase, norm
             integer, intent(out), optional :: exitstatus
         end subroutine SHMultiTaperMaskSE
 
-        subroutine SHMultiTaperMaskCSE(mtse, sd, sh1, lmax1, sh2, lmax2, &
+        subroutine SHMultiTaperMaskCSE(mtse, sd, cilm1, lmax1, cilm2, lmax2, &
                                        tapers, lmaxt, k, taper_wt, norm, &
                                        csphase, exitstatus)
             integer, parameter :: dp = selected_real_kind(p=15)
             real(dp), intent(out) :: mtse(:), sd(:)
-            real(dp), intent(in) :: sh1(:,:,:), sh2(:,:,:), tapers(:,:)
+            real(dp), intent(in) :: cilm1(:,:,:), cilm2(:,:,:), tapers(:,:)
             integer, intent(in) :: lmax1, lmax2, lmaxt, k
             real(dp), intent(in), optional :: taper_wt(:)
             integer, intent(in), optional :: csphase, norm
@@ -963,19 +966,19 @@ module SHTOOLS
             integer, intent(out), optional :: exitstatus
         end subroutine MakeMagGridDH
 
-        subroutine SHMagPowerSpectrum(c, a, r, lmax, spectra, exitstatus)
+        subroutine SHMagPowerSpectrum(cilm, a, r, lmax, spectra, exitstatus)
             integer, parameter :: dp = selected_real_kind(p=15)
-            real(dp), intent(in) :: c(:,:,:)
+            real(dp), intent(in) :: cilm(:,:,:)
             real(dp), intent(in) :: a, r
             integer, intent(in) :: lmax
             real(dp), intent(out) :: spectra(:)
             integer, intent(out), optional :: exitstatus
         end subroutine SHMagPowerSpectrum
 
-        function SHMagPowerL(c, a, r, l)
+        function SHMagPowerL(cilm, a, r, l)
             integer, parameter :: dp = selected_real_kind(p=15)
             real(dp) :: SHMagPowerL
-            real(dp), intent(in) :: c(:,:,:)
+            real(dp), intent(in) :: cilm(:,:,:)
             real(dp), intent(in) :: a, r
             integer, intent(in) :: l
         end function SHMagPowerL
@@ -1088,19 +1091,19 @@ module SHTOOLS
             integer, intent(out), optional :: exitstatus
         end subroutine SHRotateTapers
 
-        subroutine SlepianCoeffs(falpha, galpha, flm, lmax, nmax, &
+        subroutine SlepianCoeffs(falpha, galpha, film, lmax, nmax, &
                                  exitstatus)
             integer, parameter :: dp = selected_real_kind(p=15)
             real(dp), intent(out) :: falpha(:)
-            real(dp), intent(in) :: galpha(:,:), flm(:,:,:)
+            real(dp), intent(in) :: galpha(:,:), film(:,:,:)
             integer, intent(in) :: lmax, nmax
             integer, intent(out), optional :: exitstatus
         end subroutine SlepianCoeffs
 
-        subroutine SlepianCoeffsToSH(flm, falpha, galpha, lmax, nmax, &
+        subroutine SlepianCoeffsToSH(film, falpha, galpha, lmax, nmax, &
                                      exitstatus)
             integer, parameter :: dp = selected_real_kind(p=15)
-            real(dp), intent(out) :: flm(:,:,:)
+            real(dp), intent(out) :: film(:,:,:)
             real(dp), intent(in) :: falpha(:), galpha(:,:)
             integer, intent(in) :: lmax, nmax
             integer, intent(out), optional :: exitstatus

--- a/src/fdoc/shmagpowerl.md
+++ b/src/fdoc/shmagpowerl.md
@@ -4,14 +4,14 @@ Compute the power of the magnetic field for a single degree `l` given the Schmid
 
 # Usage
 
-`power` = SHMagPowerL (`c`, `a`, `r`, `l`)
+`power` = SHMagPowerL (`cilm`, `a`, `r`, `l`)
 
 # Parameters
 
 `power` : output, real(dp)
 :   The power at degree `l`
 
-`c` : input, real(dp), dimension (2, l+1, l+1)
+`cilm` : input, real(dp), dimension (2, l+1, l+1)
 :   The Schmidt seminormalized spherical harmonic coefficients of the magnetic potential.
 
 `a` : input, real(dp)
@@ -27,7 +27,7 @@ Compute the power of the magnetic field for a single degree `l` given the Schmid
 
 `SHMagPowerL` will calculate the power of the magnetic field at radius `r` for a single degree `l` given the magnetic potential Schmidt seminormalized spherical harmonic coefficients `c` evaluated at radius `a`. This is explicitly calculated as:
 
-`S(l) = (l+1) (a/r)**(2l+4) Sum_{m=0}^l [ c(1, l+1, m+1)**2 + c(2, l+1, m+1)**2 ].`
+`S(l) = (l+1) (a/r)**(2l+4) Sum_{m=0}^l [ cilm(1, l+1, m+1)**2 + cilm(2, l+1, m+1)**2 ].`
 
 # See also
 

--- a/src/fdoc/shmagpowerspectrum.md
+++ b/src/fdoc/shmagpowerspectrum.md
@@ -4,11 +4,11 @@ Compute the power spectrum of the magnetic field given the Schmidt seminormalize
 
 # Usage
 
-call SHMagPowerSpectrum (`c`, `a`, `r`, `lmax`, `spectrum`, `exitstatus`)
+call SHMagPowerSpectrum (`cilm`, `a`, `r`, `lmax`, `spectrum`, `exitstatus`)
 
 # Parameters
 
-`c` : input, real(dp), dimension (2, `lmax`+1, `lmax`+1)
+`cilm` : input, real(dp), dimension (2, `lmax`+1, `lmax`+1)
 :   The Schmidt seminormalized spherical harmonic coefficients of the magnetic potential.
 
 `a` : input, real(dp)
@@ -28,9 +28,9 @@ call SHMagPowerSpectrum (`c`, `a`, `r`, `lmax`, `spectrum`, `exitstatus`)
 
 # Description
 
-`SHMagPowerSpectrum` will calculate the power spectrum of the magnetic field at radius `r` given the magnetic potential Schmidt seminormalized spherical harmonic coefficients `c` evaluated at radius `a`. For a given degree `l`, this is explicitly calculated as (Lowes 1966):
+`SHMagPowerSpectrum` will calculate the power spectrum of the magnetic field at radius `r` given the magnetic potential Schmidt seminormalized spherical harmonic coefficients `cilm` evaluated at radius `a`. For a given degree `l`, this is explicitly calculated as (Lowes 1966):
 
-`S(l) = (l+1) (a/r)**(2l+4) Sum_{m=0}^l [ c(1, l+1, m+1)**2 + c(2, l+1, m+1)**2 ].`
+`S(l) = (l+1) (a/r)**(2l+4) Sum_{m=0}^l [ cilm(1, l+1, m+1)**2 + cilm(2, l+1, m+1)**2 ].`
 
 # Reference
 

--- a/src/fdoc/shmultiply.md
+++ b/src/fdoc/shmultiply.md
@@ -4,24 +4,24 @@ Multiply two functions and determine the spherical harmonic coefficients of the 
 
 # Usage
 
-call SHMultiply (`shout`, `sh1`, `lmax1`, `sh2`, `lmax2`, `precomp`, `norm`, `csphase`, `exitstatus`)
+call SHMultiply (`cilmout`, `cilm1`, `lmax1`, `cilm2`, `lmax2`, `precomp`, `norm`, `csphase`, `exitstatus`)
 
 # Parameters
 
-`shout` : output, real(dp), dimension (2, `lmax1`+`lmax2`+1, `lmax1`+`lmax2`+1)
-:   The real spherical harmonic coefficients corresponding to the multiplication of `sh1` and `sh2` in the space domain.
+`cilmout` : output, real(dp), dimension (2, `lmax1`+`lmax2`+1, `lmax1`+`lmax2`+1)
+:   The real spherical harmonic coefficients corresponding to the multiplication of `cilm1` and `cilm2` in the space domain.
 
-`sh1` : input, real(dp), dimension (2, `lmax1`+1, `lmax1`+1)
+`cilm1` : input, real(dp), dimension (2, `lmax1`+1, `lmax1`+1)
 :   The spherical harmonic coefficients of the first function.
 
 `lmax1` : input, integer
-:   The maximum spherical harmonic degree used in evaluting `sh1`.
+:   The maximum spherical harmonic degree used in evaluting `cilm1`.
 
-`sh2` : input, real(dp), dimension (2, `lmax2`+1, `lmax2`+1)
+`cilm2` : input, real(dp), dimension (2, `lmax2`+1, `lmax2`+1)
 :   The spherical harmonic coefficients of the second function.
 
 `lmax2` : input, integer
-:   The maximum spherical harmonic degree used in evaluting `sh2`.
+:   The maximum spherical harmonic degree used in evaluting `cilm2`.
 
 `precomp` : input, optional, integer, default = 0
 :   If 1, the array of Legendre functions `plx` will be precomputed on the Gauss-Legendre quadrature nodes.

--- a/src/fdoc/shmultitapermaskcse.md
+++ b/src/fdoc/shmultitapermaskcse.md
@@ -4,7 +4,7 @@ Perform a localized multitaper cross-spectral analysis using using arbitrary win
 
 # Usage
 
-call SHMultiTaperMaskCSE (`mtse`, `sd`, `sh1`, `lmax1`, `sh2`, `lmax2`, `tapers`, `lmaxt`, `k`, `taper_wt`, `norm`, `csphase`, `exitstatus`)
+call SHMultiTaperMaskCSE (`mtse`, `sd`, `cilm1`, `lmax1`, `cilm2`, `lmax2`, `tapers`, `lmaxt`, `k`, `taper_wt`, `norm`, `csphase`, `exitstatus`)
 
 # Parameters
 
@@ -14,17 +14,17 @@ call SHMultiTaperMaskCSE (`mtse`, `sd`, `sh1`, `lmax1`, `sh2`, `lmax2`, `tapers`
 `sd` : output, real(dp), dimension (`lmax`-`lmaxt`+1)
 :   The standard error of the localized multitaper cross-power spectral estimates. `lmax` is the smaller of `lmax1` and `lmax2`.
 
-`sh1` : input, real(dp), dimension (2, `lmax1`+1, `lmax1`+1)
+`cilm1` : input, real(dp), dimension (2, `lmax1`+1, `lmax1`+1)
 :   The spherical harmonic coefficients of the first function.
 
 `lmax1` : input, integer
-:   The spherical harmonic bandwidth of `sh1`.
+:   The spherical harmonic bandwidth of `cilm1`.
 
-`sh2` : input, real(dp), dimension (2, `lmax2`+1, `lmax2`+1)
+`cilm2` : input, real(dp), dimension (2, `lmax2`+1, `lmax2`+1)
 :   The spherical harmonic coefficients of the second function.
 
 `lmax2` : input, integer
-:   The spherical harmonic bandwidth of `sh2`.
+:   The spherical harmonic bandwidth of `cilm2`.
 
 `tapers` : input, real(dp), dimension ((`lmaxt`+1)**2, `k`)
 :   An array of the `k` windowing functions, arranged in columns, obtained from a call to `SHReturnTapersMap`. The spherical harmonic coefficients are packed according to the conventions in `SHCilmToVector`.
@@ -49,7 +49,7 @@ call SHMultiTaperMaskCSE (`mtse`, `sd`, `sh1`, `lmax1`, `sh2`, `lmax2`, `tapers`
 
 # Description
 
-`SHMultiTaperMaskCSE` will perform a localized multitaper cross-spectral analysis of two input functions expressed in spherical harmonics, `SH1` and `SH2`, using an arbitrary set of windows derived from a mask. The maximum degree of the localized multitaper power spectrum estimate is `lmax-lmaxt`, where `lmax` is the smaller of `lmax1` and `lmax2`. The matrix `tapers` contains the spherical harmonic coefficients of the windows and can be obtained by a call to `SHReturnTapersMap`. The coefficients of each window are stored in a single column, ordered according to the conventions used in `SHCilmToVector`.
+`SHMultiTaperMaskCSE` will perform a localized multitaper cross-spectral analysis of two input functions expressed in spherical harmonics, `cilm1` and `cilm2`, using an arbitrary set of windows derived from a mask. The maximum degree of the localized multitaper power spectrum estimate is `lmax-lmaxt`, where `lmax` is the smaller of `lmax1` and `lmax2`. The matrix `tapers` contains the spherical harmonic coefficients of the windows and can be obtained by a call to `SHReturnTapersMap`. The coefficients of each window are stored in a single column, ordered according to the conventions used in `SHCilmToVector`.
 
 If the optional array `taper_wt` is specified, then these weights will be used in calculating a weighted average of the individual `k` tapered estimates (`mtse`) and the corresponding standard error of the estimates (`sd`). If not present, the weights will all be assumed to be equal. When `taper_wt` is not specified, the mutltitaper spectral estimate for a given degree will be calculated as the average obtained from the `k` individual tapered estimates. The standard error of the multitaper estimate at degree l is simply the population standard deviation, `S = sqrt(sum (Si - mtse)^2 / (k-1))`, divided by sqrt(`k`). See Wieczorek and Simons (2007) for the relevant expressions when weighted estimates are used.
 

--- a/src/fdoc/shmultitapermaskse.md
+++ b/src/fdoc/shmultitapermaskse.md
@@ -4,7 +4,7 @@ Perform a localized multitaper spectral analysis using arbitrary windows derived
 
 # Usage
 
-call SHMultiTaperMaskSE (`mtse`, `sd`, `sh`, `lmax`, `tapers`, `lmaxt`, `k`, `taper_wt`, `norm`, `csphase`, `exitstatus`)
+call SHMultiTaperMaskSE (`mtse`, `sd`, `cilm`, `lmax`, `tapers`, `lmaxt`, `k`, `taper_wt`, `norm`, `csphase`, `exitstatus`)
 
 # Parameters
 
@@ -14,11 +14,11 @@ call SHMultiTaperMaskSE (`mtse`, `sd`, `sh`, `lmax`, `tapers`, `lmaxt`, `k`, `ta
 `sd` : output, real(dp), dimension (`lmax`-`lmaxt`+1)
 :   The standard error of the localized multitaper power spectral estimates.
 
-`sh` : input, real(dp), dimension (2, `lmax`+1, `lmax`+1)
+`cilm` : input, real(dp), dimension (2, `lmax`+1, `lmax`+1)
 :   The spherical harmonic coefficients of the function to be localized.
 
 `lmax` : input, integer
-:   The spherical harmonic bandwidth of `sh`.
+:   The spherical harmonic bandwidth of `cilm`.
 
 `tapers` : input, real(dp), dimension ((`lmaxt`+1)**2, `k`)
 :   An array of the `k` windowing functions, arranged in columns, obtained from a call to `SHReturnTapersMap`. The spherical harmonic coefficients are packed according to the conventions in `SHCilmToVector`.

--- a/src/fdoc/shmultitaperse.md
+++ b/src/fdoc/shmultitaperse.md
@@ -4,7 +4,7 @@ Perform a localized multitaper spectral analysis using spherical cap windows.
 
 # Usage
 
-call SHMultiTaperSE (`mtse`, `sd`, `sh`, `lmax`, `tapers`, `taper_order`, `lmaxt`, `k`, `alpha`, `lat`, `lon`, `taper_wt`, `norm`, `csphase`, `exitstatus`)
+call SHMultiTaperSE (`mtse`, `sd`, `cilm`, `lmax`, `tapers`, `taper_order`, `lmaxt`, `k`, `alpha`, `lat`, `lon`, `taper_wt`, `norm`, `csphase`, `exitstatus`)
 
 # Parameters
 
@@ -14,11 +14,11 @@ call SHMultiTaperSE (`mtse`, `sd`, `sh`, `lmax`, `tapers`, `taper_order`, `lmaxt
 `sd` : output, real(dp), dimension (`lmax`-`lmaxt`+1)
 :   The standard error of the localized multitaper power spectral estimates.
 
-`sh` : input, real(dp), dimension (2, `lmax`+1, `lmax`+1)
+`cilm` : input, real(dp), dimension (2, `lmax`+1, `lmax`+1)
 :   The spherical harmonic coefficients of the function to be localized.
 
 `lmax` : input, integer
-:   The spherical harmonic bandwidth of `sh`.
+:   The spherical harmonic bandwidth of `cilm`.
 
 `tapers` : input, real(dp), dimension (`lmaxt`+1, `k`)
 :   An array of the `k` windowing functions, arranged in columns, obtained from a call to `SHReturnTapers`. Each window has non-zero coefficients for a single angular order that is specified in the array `taper_order`.

--- a/src/fdoc/slepiancoeffs.md
+++ b/src/fdoc/slepiancoeffs.md
@@ -4,17 +4,17 @@ Determine the expansion coefficients of a function for a given set of input Slep
 
 # Usage
 
-call SlepianCoeffs(`falpha`, `galpha`, `flm`, `lmax`, `nmax`, `exitstatus`)
+call SlepianCoeffs(`falpha`, `galpha`, `film`, `lmax`, `nmax`, `exitstatus`)
 
 # Parameters
 
 `falpha` : output, real(dp), dimension (`nmax`)
-:   A vector containing the Slepian coefficients of the input function `flm`.
+:   A vector containing the Slepian coefficients of the input function `film`.
 
 `galpha` : input, real(dp), dimension ((`lmax`+1)**2, `nmax`)
 :   An array containing the spherical harmonic coefficients of the Slepian functions. Each column corresponds to a single function of which the spherical harmonic coefficients can be unpacked with `SHVectorToCilm`.
 
-`flm` : input, real(dp), dimension (2, `lmax`+1, `lmax`+1)
+`film` : input, real(dp), dimension (2, `lmax`+1, `lmax`+1)
 :   The spherical harmonic coefficients of the global function to be expanded in Slepian functions.
 
 `lmax` : input, integer
@@ -28,9 +28,9 @@ call SlepianCoeffs(`falpha`, `galpha`, `flm`, `lmax`, `nmax`, `exitstatus`)
 
 # Description
 
-`SlepianCoeffs` will compute the Slepian coefficients of a global input function `flm` given the Slepian functions `galpha`. The Slepian functions are determined by a call to either (1) `SHReturnTapers` and then `SHRotateTapers`, or (2) `SHReturnTapersMap`. Each row of `galpha` contains the (`lmax`+1)**2 spherical harmonic coefficients of a Slepian function that can be unpacked using `SHVectorToCilm`. The Slepian functions must be normalized to have unit power (that is the sum of the coefficients squared is 1), and the Slepian coefficients are calculated as
+`SlepianCoeffs` will compute the Slepian coefficients of a global input function `film` given the Slepian functions `galpha`. The Slepian functions are determined by a call to either (1) `SHReturnTapers` and then `SHRotateTapers`, or (2) `SHReturnTapersMap`. Each row of `galpha` contains the (`lmax`+1)**2 spherical harmonic coefficients of a Slepian function that can be unpacked using `SHVectorToCilm`. The Slepian functions must be normalized to have unit power (that is the sum of the coefficients squared is 1), and the Slepian coefficients are calculated as
 
-`f_alpha = sum_{lm}^{lmax} f_lm g(alpha)_lm`  
+`f_alpha = sum_{ilm}^{lmax} f_ilm g(alpha)_lm`  
 
 # See also
 

--- a/src/fdoc/slepiancoeffstosh.md
+++ b/src/fdoc/slepiancoeffstosh.md
@@ -4,11 +4,11 @@ Convert a function expressed in Slepian coefficients to spherical harmonic coeff
 
 # Usage
 
-call SlepianCoeffsToSH(`flm`, `falpha`, `galpha`, `lmax`, `nmax`, `exitstatus`)
+call SlepianCoeffsToSH(`film`, `falpha`, `galpha`, `lmax`, `nmax`, `exitstatus`)
 
 # Parameters
 
-`flm` : output, real(dp), dimension (2, `lmax`+1, `lmax`+1)
+`film` : output, real(dp), dimension (2, `lmax`+1, `lmax`+1)
 :   The spherical harmonic coefficients of the global function.
 
 `falpha` : input, real(dp), dimension (`nmax`)
@@ -28,9 +28,9 @@ call SlepianCoeffsToSH(`flm`, `falpha`, `galpha`, `lmax`, `nmax`, `exitstatus`)
 
 # Description
 
-`SlepianCoeffsToSH` will compute the spherical harmonic coefficients of a global function `flm` given the Slepian functions `galpha` and the corresponding Slepian coefficients `falpha`. The Slepian functions are determined by a call to either (1) `SHReturnTapers` and then `SHRotateTapers`, or (2) `SHReturnTapersMap`. Each row of `galpha` contains the (`lmax`+1)**2 spherical harmonic coefficients of a Slepian function that can be unpacked using `SHVectorToCilm`. The Slepian functions must be normalized to have unit power (that is the sum of the coefficients squared is 1), and the spherical harmonic coefficients are calculated as
+`SlepianCoeffsToSH` will compute the spherical harmonic coefficients of a global function `film` given the Slepian functions `galpha` and the corresponding Slepian coefficients `falpha`. The Slepian functions are determined by a call to either (1) `SHReturnTapers` and then `SHRotateTapers`, or (2) `SHReturnTapersMap`. Each row of `galpha` contains the (`lmax`+1)**2 spherical harmonic coefficients of a Slepian function that can be unpacked using `SHVectorToCilm`. The Slepian functions must be normalized to have unit power (that is the sum of the coefficients squared is 1), and the spherical harmonic coefficients are calculated as
 
-`f_lm = sum_{alpha}^{nmax} f_alpha g(alpha)_lm`  
+`f_ilm = sum_{alpha}^{nmax} f_alpha g(alpha)_lm`  
 
 # See also
 


### PR DESCRIPTION
Update binder environment.

In addition, the `SHTOOLS.f95` and fortran documentation have been modified to use a systematic "cilm" nomenclature for spherical harmonic variables. However, the original source code of these functions has not (yet) been updated to reflect these changes. This should pose no problems as none of these variables are optional.

These subroutines should eventually update the variable names to the new consistent nomenclature
```
SHPowerL
SHPowerDensityL
SHCrossPowerL
SHCrossPowerDensityL
SHPowerSpectrum
SHPowerSpectrumDensity
SHCrossPowerSpectrum
SHCrossPowerSpectrumDensity

SHPowerLC
SHPowerDensityLC
SHPowerDensityLC
SHCrossPowerLC
SHCrossPowerDensityLC
SHPowerSpectrumC
SHPowerSpectrumDensityC
SHCrossPowerSpectrumDensityC

SHAdmitCorr
SHLocalizedAdmitCorr
SHMultiTaperSE
SHMultiTaperCE
SHMultiply
SHMultiTaperMaskSE
SHMultiTaperMaskCSE
SHMagPowerSpectrum
SlepianCoeffs
SlepianCoeffsToSH
```