### PR TITLE
v4.7.1 maintenance release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,13 @@
+---
+name: Bug report
+about: Report a problem/bug to help us improve
+
+---
+
+**Description of the problem**
+
+
+
+
+
+**System information**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,6 @@
+---
+name: Feature request
+about: Request the addition of a new feature/functionality
+
+---
+

--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -1,0 +1,85 @@
+---
+name: SHTOOLS release checklist
+about: Checklist for a new SHTOOLS release.
+title: 'Release SHTOOLS x.x.x'
+labels: 'maintenance'
+assignees: ''
+
+---
+
+**Scheduled Date:** YYYY/MM/DD
+
+###Before release###
+Make all changes on the branch `develop`. Verify that the version numbers and other metadata are up to date in the following files:
+- [ ] `Makefile` : update shtools version number (for use with fortran man page documentation only; not required for maintenance releases x.x.>0)
+- [ ] `docs/_data/sidebars/mydoc_sidebar.yml` : update pyshtools version number for web documentation
+- [ ] `docs/_data/sidebars/fortran_sidebar.yml` : update shtools version number for web documentation
+- [ ] `docs/pages/mydoc/release-notes-v4.md` : update release notes
+- [ ] `docs/pages/mydoc/fortran-release-notes-v4.md` : update release notes
+- [ ] `requirements.txt` : update version numbers of the python dependencies, if necessary
+- [ ] `requirements-dev.txt` : update version numbers of the python developer dependencies, if necessary
+- [ ] `environment.yml` : update version numbers of the conda environment, if necesseary
+- [ ] `binder/environment.yml` : update version number of pyshtools and other dependencies
+- [ ] `fpm.toml` : update shtools version number
+
+Update the documentation files and man pages
+- [ ] `cd docs; bundle update; cd ..` : update the Gemfile for the jekyll web documentation
+- [ ] `make remove-doc` : this ensures that the correct version number will be written to the fortran man pages
+- [ ] `make doc` : make the fortran man pages, create markdown files from the python docstrings, and create web documentation
+
+###Release###
+- [ ] Commit all changes to the `develop` branch and then merge all changes to the `master` branch.
+- [ ] Go to [GitHub Release](https://github.com/SHTOOLS/SHTOOLS/releases), create a tag of the form `vX.X`, and draft a new release. After this is done, a zipped archive will be sent to [Zenodo](https://doi.org/10.5281/zenodo.592762), which will create a doi for citation.
+- [ ] Update the master branch on your personal repo, along with the newly created tag, using `git pull shtools master --tags`, where shtools is the name of the remote repo on github.
+
+###Update pypi###
+For the next steps to work, the file ```.pypirc``` with the username and password needs to be set (see [this link](https://packaging.python.org/guides/migrating-to-pypi-org/#uploading)). ```pandoc``` needs to be installed with either ```conda install -c conda-forge pypandoc``` or ```pip install pypandoc```, and ```twine``` neeeds to be installed by ```pip install twine```.
+- [ ] A pypi upload can only be done once for a given version. It is therefore recommended to test it first on pypitest.
+    ```
+    python3 setup.py sdist
+    gpg --detach-sign -a dist/pyshtools-x.x.tar.gz
+    twine upload dist/* -r pypitest
+    ```
+- [ ] Inspect the pypi page at https://test.pypi.org/project/pyshtools/x.x/ for errors in the project description or metadata. Then install pyshtools in a directory that is different from your local pyshtools repo, and run a couple of quick tests.
+    ```
+    pip3 uninstall pyshtools
+    pip3 install -i https://test.pypi.org/simple pyshtools --no-binary pyshtools
+    pip3 uninstall pyshtools
+    ```
+- [ ] Upload to pypi:
+    ```
+    python3 setup.py sdist
+    gpg --detach-sign -a dist/pyshtools-x.x.tar.gz
+    twine upload dist/* -r pypi
+    pip3 install pyshtools  # check that it works!
+    ```
+    As a sanity check, inspect the pypi project page at https://pypi.org/project/pyshtools/.
+
+###Build wheels###
+- [ ] Build wheels for linux, macOS and windows and upload to pypi. This is done using multibuild in combination with Travis and Appveyor.
+    ```
+    git clone https://github.com/shtools/build-shtools.git # only necessary the first time.
+    cd build-shtools
+    git submodule update --remote  # add the option --init the first time you use this command.
+    git commit -a -m "Update shtools and multibuild to master"
+    git push
+    ```
+- [ ] Inspect the pypi project page at https://pypi.org/project/pyshtools/ to ensure that the wheels were uploaded.
+
+###Update Homebrew###
+Update the homebrew installation by editing the file `shtools.rb` in the homebrew-shtools repo.
+- [ ] Change "url" to point to the new version (the link to the tar.gz archive can be found on the release page).
+- [ ] Update the sha256 hash of the tar.gz pypi upload (either from the pypi files, or by using `shasum -a 256 filename`).
+- [ ] Commit and push changes.
+
+###Update conda-forge###
+- [ ] Got to [pyshtools-feedstock](https://github.com/conda-forge/pyshtools-feedstock) and check that the `recipe/meta.yaml` file has been updated. This is usually done automatically by conda-forge's bot. If necessary, merge changes into the feedstock.
+
+###Update web documentation###
+Update the web documentation at shtools.oca.eu.
+- [ ] Push the branch `master` to the private repo at gitlab.oca.eu.
+- [ ] Execute `gitlab-runner run` locally to build and upload the web documentation.
+
+###Post release###
+- [ ] Build a new Binder image by running one of the tutorials.
+- [ ] Advertise on Twitter and Element/Matrix.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+
+
+
+
+
+**Reminders**
+
+- [ ] Base all changes on the `develop` branch: the `master` branch is used only when releasing new versions.
+- [ ] Run `make check` to ensure that the python code follows standard formatting conventions.
+- [ ] If adding new features, update the docstring to provide all information that is required to use the feature.

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
         openblas
         gmt>=6.1.1
         scipy>=0.14.0
-        matplotlib>=3.3
+        matplotlib-base>=3.3
         astropy
         xarray
         requests

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,3 +15,4 @@
 * Akihisa Hattori / [HattoriAkihisa](https://github.com/HattoriAkihisa)
 * Aaryaman Vasishta / [jammm](https://github.com/jammm)
 * Alex Kalinin / [alkalinin](https://github.com/alkalinin)
+* Armin Corbin / [rainbowsend](https://github.com/rainbowsend)

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ FDOCDIR = src/fdoc
 PYDOCDIR = src/pydoc
 SRCDIR = src
 LIBDIR = lib
-MODDIR = modules
+MODDIR = include
 FEXDIR = examples/fortran
 PEXDIR = examples/python
 NBDIR = examples/notebooks
@@ -276,11 +276,6 @@ install: fortran
 	cp -R examples/fortran/ $(DESTDIR)$(SYSSHAREPATH)/examples/shtools/
 	mkdir -pv $(DESTDIR)$(SYSSHAREPATH)/man/man1
 	cp -R man/man1/ $(DESTDIR)$(SYSSHAREPATH)/man/man1/
-	awk '{gsub("../../lib","$(PREFIX)/lib");print}' "examples/fortran/Makefile" > "temp.txt"
-	awk '{gsub("../../modules","$(PREFIX)/include");print}' "temp.txt" > "temp2.txt"
-	cp temp2.txt "$(DESTDIR)$(SYSSHAREPATH)/examples/shtools/Makefile"
-	rm temp.txt
-	rm temp2.txt
 	@echo
 	@echo "Compile your Fortran code with the following flags:"
 	@echo "---------------------------------------------------"
@@ -364,7 +359,7 @@ clean-libs:
 	@echo \*\*\* also execute \"pip uninstall pyshtools\".
 
 fortran-tests: fortran
-	@$(MAKE) -C $(FEXDIR) -f Makefile all F95="$(F95)" F95FLAGS="$(F95FLAGS)" LIBNAME="$(LIBNAME)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)"
+	@$(MAKE) -C $(FEXDIR) -f Makefile all F95="$(F95)" F95FLAGS="$(F95FLAGS)" LIBNAME="$(LIBNAME)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)" LIBPATH="$(LIBPATH)" MODFLAG="$(MODFLAG)"
 	@echo
 	@echo "--> Make of Fortran test suite successful"
 	@echo
@@ -373,7 +368,7 @@ fortran-tests: fortran
 	@echo "--> Ran all Fortran examples and tests"
 
 fortran-tests-no-timing: fortran
-	@$(MAKE) -C $(FEXDIR) -f Makefile all F95="$(F95)" F95FLAGS="$(F95FLAGS)" LIBNAME="$(LIBNAME)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)"
+	@$(MAKE) -C $(FEXDIR) -f Makefile all F95="$(F95)" F95FLAGS="$(F95FLAGS)" LIBNAME="$(LIBNAME)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)" LIBPATH="$(LIBPATH)" MODFLAG="$(MODFLAG)"
 	@echo
 	@echo "--> Make of Fortran test suite successful"
 	@echo
@@ -382,7 +377,7 @@ fortran-tests-no-timing: fortran
 	@echo "--> Ran all Fortran examples and tests"
 
 fortran-tests-mp: fortran-mp
-	@$(MAKE) -C $(FEXDIR) -f Makefile all F95="$(F95)" F95FLAGS="$(OPENMPFLAGS) $(F95FLAGS)" LIBNAME="$(LIBNAMEMP)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)"
+	@$(MAKE) -C $(FEXDIR) -f Makefile all F95="$(F95)" F95FLAGS="$(OPENMPFLAGS) $(F95FLAGS)" LIBNAME="$(LIBNAMEMP)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)" LIBPATH="$(LIBPATH)" MODFLAG="$(MODFLAG)"
 	@echo
 	@echo "--> Make of Fortran test suite successful"
 	@echo
@@ -391,7 +386,7 @@ fortran-tests-mp: fortran-mp
 	@echo "--> Ran all Fortran examples and tests"
 
 fortran-tests-no-timing-mp: fortran-mp
-	@$(MAKE) -C $(FEXDIR) -f Makefile all F95="$(F95)" F95FLAGS="$(OPENMPFLAGS) $(F95FLAGS)" LIBNAME="$(LIBNAMEMP)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)"
+	@$(MAKE) -C $(FEXDIR) -f Makefile all F95="$(F95)" F95FLAGS="$(OPENMPFLAGS) $(F95FLAGS)" LIBNAME="$(LIBNAMEMP)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)" LIBPATH="$(LIBPATH)" MODFLAG="$(MODFLAG)"
 	@echo
 	@echo "--> Make of Fortran test suite successful"
 	@echo
@@ -400,22 +395,22 @@ fortran-tests-no-timing-mp: fortran-mp
 	@echo "--> Ran all Fortran examples and tests"
 
 run-fortran-tests: fortran
-	@$(MAKE) -C $(FEXDIR) -f Makefile run-fortran-tests F95="$(F95)" F95FLAGS="$(F95FLAGS)" LIBNAME="$(LIBNAME)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)"
+	@$(MAKE) -C $(FEXDIR) -f Makefile run-fortran-tests F95="$(F95)" F95FLAGS="$(F95FLAGS)" LIBNAME="$(LIBNAME)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)" LIBPATH="$(LIBPATH)" MODFLAG="$(MODFLAG)"
 	@echo
 	@echo "--> Ran all Fortran examples and tests"
 
 run-fortran-tests-no-timing: fortran
-	@$(MAKE) -C $(FEXDIR) -f Makefile run-fortran-tests-no-timing F95="$(F95)" F95FLAGS="$(F95FLAGS)" LIBNAME="$(LIBNAME)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)"
+	@$(MAKE) -C $(FEXDIR) -f Makefile run-fortran-tests-no-timing F95="$(F95)" F95FLAGS="$(F95FLAGS)" LIBNAME="$(LIBNAME)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)" LIBPATH="$(LIBPATH)" MODFLAG="$(MODFLAG)"
 	@echo
 	@echo "--> Ran all Fortran examples and tests"
 
 run-fortran-tests-mp: fortran-mp
-	@$(MAKE) -C $(FEXDIR) -f Makefile run-fortran-tests LIBNAME="$(LIBNAMEMP)" F95="$(F95)" F95FLAGS="$(OPENMPFLAGS) $(F95FLAGS)" LIBNAME="$(LIBNAMEMP)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)"
+	@$(MAKE) -C $(FEXDIR) -f Makefile run-fortran-tests LIBNAME="$(LIBNAMEMP)" F95="$(F95)" F95FLAGS="$(OPENMPFLAGS) $(F95FLAGS)" LIBNAME="$(LIBNAMEMP)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)" LIBPATH="$(LIBPATH)" MODFLAG="$(MODFLAG)"
 	@echo
 	@echo "--> Ran all Fortran examples and tests"
 
 run-fortran-tests-no-timing-mp: fortran-mp
-	@$(MAKE) -C $(FEXDIR) -f Makefile run-fortran-tests-no-timing LIBNAME="$(LIBNAMEMP)" F95="$(F95)" F95FLAGS="$(OPENMPFLAGS) $(F95FLAGS)" LIBNAME="$(LIBNAMEMP)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)"
+	@$(MAKE) -C $(FEXDIR) -f Makefile run-fortran-tests-no-timing LIBNAME="$(LIBNAMEMP)" F95="$(F95)" F95FLAGS="$(OPENMPFLAGS) $(F95FLAGS)" LIBNAME="$(LIBNAMEMP)" FFTW="$(FFTW)" LAPACK="$(LAPACK)" BLAS="$(BLAS)" LIBPATH="$(LIBPATH)" MODFLAG="$(MODFLAG)"
 	@echo
 	@echo "--> Ran all Fortran examples and tests"
 

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@
 #
 ###############################################################################
 
+# The VERSION number is used only for generating the man pages
 VERSION = 4.7
 
 LIBNAME = SHTOOLS
@@ -134,7 +135,6 @@ JEKYLL = bundle exec jekyll
 FLAKE8 = flake8
 SHELL = /bin/sh
 PY3EXT = $(shell $(PYTHON) -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))' || echo nopy3)
-
 
 FDOCDIR = src/fdoc
 PYDOCDIR = src/pydoc
@@ -160,59 +160,61 @@ LAPACK_UNDERSCORE = 0
 
 FLAKE8_FILES = setup.py pyshtools examples/python
 
-ifeq ($(F95), f95)
-# Default Absoft f95 flags
-F95FLAGS ?= -m64 -O3 -YEXT_NAMES=LCS -YEXT_SFX=_ -fpic -speed_math=10
-#-march=host
-MODFLAG = -p $(MODPATH)
-SYSMODFLAG = -p $(SYSMODPATH)
-OPENMPFLAGS ?= -openmp
-BLAS ?= -lblas
-LAPACK ?= -llapack
-else ifeq ($(F95), gfortran)
-# Default gfortran flags
-F95FLAGS ?= -m64 -fPIC -O3 -std=f2003 -ffast-math
-# -march=native
-MODFLAG = -I$(MODPATH)
-SYSMODFLAG = -I$(SYSMODPATH)
-OPENMPFLAGS ?= -fopenmp
-BLAS ?= -lblas
-LAPACK ?= -llapack
-else ifeq ($(F95), ifort)
-# Default intel fortran flags
-F95FLAGS ?= -m64 -fpp -free -O3 -Tf
-MODFLAG = -I$(MODPATH)
-SYSMODFLAG = -I$(SYSMODPATH)
-OPENMPFLAGS ?= -qopenmp
-LAPACK ?= -mkl
-BLAS ?= 
-else ifeq ($(F95), g95)
-# Default g95 flags.
-F95FLAGS ?= -O3 -fno-second-underscore
-MODFLAG = -I$(MODPATH)
-SYSMODFLAG = -I$(SYSMODPATH)
-OPENMPFLAGS ?=
-BLAS ?= -lblas
-LAPACK ?= -llapack
-else ifeq ($(F95), pgf90)
-# Default pgf90 flags
-F95FLAGS ?= -fast 
-MODFLAG = -Imodpath
-SYSMODFLAG = -Imodpath
-OPENMPFLAGS ?=
-BLAS ?= -lblas
-LAPACK ?= -llapack
+# Set default compiler flags based on the name of the F95 compiler by searching
+# if the short name of the compiler is in $(F95).
+ifeq ($(findstring gfortran,$(F95)),gfortran)
+	# Default gfortran flags
+	F95FLAGS ?= -m64 -fPIC -O3 -std=f2003 -ffast-math
+	# -march=native
+	MODFLAG = -I$(MODPATH)
+	SYSMODFLAG = -I$(SYSMODPATH)
+	OPENMPFLAGS ?= -fopenmp
+	BLAS ?= -lblas
+	LAPACK ?= -llapack
+else ifeq ($(findstring f95,$(F95)),f95)
+	# Default Absoft f95 flags
+	F95FLAGS ?= -m64 -O3 -YEXT_NAMES=LCS -YEXT_SFX=_ -fpic -speed_math=10
+	#-march=host
+	MODFLAG = -p $(MODPATH)
+	SYSMODFLAG = -p $(SYSMODPATH)
+	OPENMPFLAGS ?= -openmp
+	BLAS ?= -lblas
+	LAPACK ?= -llapack
+else ifeq ($(findstring ifort,$(F95)),ifort)
+	# Default intel fortran flags
+	F95FLAGS ?= -m64 -fpp -free -O3 -Tf
+	MODFLAG = -I$(MODPATH)
+	SYSMODFLAG = -I$(SYSMODPATH)
+	OPENMPFLAGS ?= -qopenmp
+	LAPACK ?= -mkl
+	BLAS ?= 
+else ifeq ($(findstring g95,$(F95)),g95)
+	# Default g95 flags.
+	F95FLAGS ?= -O3 -fno-second-underscore
+	MODFLAG = -I$(MODPATH)
+	SYSMODFLAG = -I$(SYSMODPATH)
+	OPENMPFLAGS ?=
+	BLAS ?= -lblas
+	LAPACK ?= -llapack
+else ifeq ($(findstring pgf90,$(F95)),pgf90)
+	# Default pgf90 flags
+	F95FLAGS ?= -fast 
+	MODFLAG = -Imodpath
+	SYSMODFLAG = -Imodpath
+	OPENMPFLAGS ?=
+	BLAS ?= -lblas
+	LAPACK ?= -llapack
 else ifeq ($(origin F95FLAGS), undefined)
-F95FLAGS = -m64 -O3
-MODFLAG = -I$(MODPATH)
-SYSMODFLAG = -I$(SYSMODPATH)
-OPENMPFLAGS ?=
-BLAS ?= -lblas
-LAPACK ?= -llapack
+	F95FLAGS = -m64 -O3
+	MODFLAG = -I$(MODPATH)
+	SYSMODFLAG = -I$(SYSMODPATH)
+	OPENMPFLAGS ?=
+	BLAS ?= -lblas
+	LAPACK ?= -llapack
 endif
 
 ifeq ($(LAPACK_UNDERSCORE),1)
-LAPACK_FLAGS = -DLAPACK_UNDERSCORE
+	LAPACK_FLAGS = -DLAPACK_UNDERSCORE
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ fortran-mp:
 	@echo $(F95) $(MODFLAG) $(OPENMPFLAGS) $(F95FLAGS) -L$(LIBPATH) -l$(LIBNAMEMP) $(FFTW) $(LAPACK) $(BLAS)
 	@echo
 
-install: fortran
+install:
 	mkdir -pv $(DESTDIR)$(SYSLIBPATH)
 	cp $(LIBPATH)/lib$(LIBNAME).a $(DESTDIR)$(SYSLIBPATH)/lib$(LIBNAME).a
 	-cp $(LIBPATH)/lib$(LIBNAMEMP).a $(DESTDIR)$(SYSLIBPATH)/lib$(LIBNAMEMP).a

--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ spherical harmonic transforms, multitaper spectral analyses, expansions of funct
 ### INSTALLATION ###
 #### pyshtools (for Python) ####
 
-Binary install using pip or conda:
+Binary install using `pip` or `conda`:
 ```bash
 pip install pyshtools
 pip install --upgrade pyshtools  # to upgrade a pre-existing installation
 conda install -c conda-forge pyshtools  # Linux and macOS only
+conda update -c conda-forge pyshtools  # to upgrade a pre-existing installation
 ```
 
 Build from source:

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -4,6 +4,4 @@ channels:
 dependencies:
     - python=3.8
     - pyshtools>=4.7.0
-    - jupyter
     - palettable>=3.3
-

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,22 +3,7 @@ channels:
     - conda-forge
 dependencies:
     - python=3.8
-    - fftw>=3.3.8
-    - liblapack>=3.8
-    - openblas
-    - gmt>=6.1.1
     - pyshtools>=4.7.0
-    - numpy
-    - scipy>=0.14.0
-    - matplotlib>=3.3
-    - astropy
-    - xarray
-    - requests
-    - cartopy>=0.18.0
-    - pygmt>=0.2.0
-    - pooch>=1.1
-    - tqdm
     - jupyter
     - palettable>=3.3
-    - pypandoc
 

--- a/docs/pages/fortran/fortran-contributors.md
+++ b/docs/pages/fortran/fortran-contributors.md
@@ -23,3 +23,4 @@ folder: fortran
 * Akihisa Hattori / [HattoriAkihisa](https://github.com/HattoriAkihisa)
 * Aaryaman Vasishta / [jammm](https://github.com/jammm)
 * Alex Kalinin / [alkalinin](https://github.com/alkalinin)
+* Armin Corbin / [rainbowsend](https://github.com/rainbowsend)

--- a/docs/pages/mydoc/contributors.md
+++ b/docs/pages/mydoc/contributors.md
@@ -23,3 +23,4 @@ folder: mydoc
 * Akihisa Hattori / [HattoriAkihisa](https://github.com/HattoriAkihisa)
 * Aaryaman Vasishta / [jammm](https://github.com/jammm)
 * Alex Kalinin / [alkalinin](https://github.com/alkalinin)
+* Armin Corbin / [rainbowsend](https://github.com/rainbowsend)

--- a/docs/pages/mydoc/python-installing.md
+++ b/docs/pages/mydoc/python-installing.md
@@ -13,6 +13,7 @@ folder: mydoc
 The binary pre-compiled pyshtools library, with all required dependencies, can be installed with the conda package manager using the command:
 ```bash
 conda install -c conda-forge pyshtools  # Linux and macOS only
+conda update -c conda-forge pyshtools  # to upgrade a pre-existing installation
 ```
 The conda packages do not support Windows architectures at the present time.
 

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
     - gmt>=6.1.1
     - numpy
     - scipy>=0.14.0
-    - matplotlib>=3.3
+    - matplotlib-base>=3.3
     - astropy
     - xarray
     - requests

--- a/environment.yml
+++ b/environment.yml
@@ -21,3 +21,4 @@ dependencies:
     - jupyter
     - pypandoc
     - nb_conda_kernels
+    - pip

--- a/examples/fortran/Makefile
+++ b/examples/fortran/Makefile
@@ -12,6 +12,22 @@
 #   make clean
 #       Delete the compile executibles.
 #
+#
+#   NOTES
+#
+#   This Makefile is intended to be invoked by the main Makefile in the SHTOOLS
+#   repository. To use this Makefile independently, it is necessary to provide
+#   the following arguments:
+#
+#       F95 - name of the Fortran 95 compiler
+#       F95FLAGS - flags to use with the Fortran 95 compiler
+#       LIBNAME - name of the SHTOOLS library (without lib and .a)
+#       LIBPATH - path to the SHTOOLS library
+#       MODFLAG - flag used to identify the path of the compiled modules
+#       FFTW - all flags necessary to find and link to the FFTW library
+#       LAPACK - all flags necessary to find and link to the LAPACK library
+#       BLAS - all flags necessary to find and link to the BLAS library
+#
 ###############################################################################
 
 SHELL = /bin/sh

--- a/examples/fortran/Makefile
+++ b/examples/fortran/Makefile
@@ -14,15 +14,6 @@
 #
 ###############################################################################
 
-F95 = gfortran
-
-FFTW = -lfftw3 -lm
-
-LIBPATH = ../../lib
-MODPATH = ../../modules/
-
-LIBNAME = SHTOOLS
-
 SHELL = /bin/sh
 
 .PHONY: all clean run-fortran-tests
@@ -118,49 +109,6 @@ run-fortran-tests-no-timing: $(EXAMPLES)
 	@echo
 	@echo TEST-SHROTATE
 	cd SHRotate ; ./TestSHRotate < input.txt
-
-
-ifeq ($(F95),f95)
-F95FLAGS ?= -m64 -O3 -YEXT_NAMES=LCS -YEXT_SFX=_ -fpic
-MODFLAG = -p $(MODPATH)
-LAPACK ?= -llapack
-BLAS ?= -lblas
-endif
-
-ifeq ($(F95),gfortran)
-F95FLAGS ?= -m64 -fPIC -O3
-MODFLAG = -I$(MODPATH)
-LAPACK ?= -llapack
-BLAS ?= -lblas
-endif
-
-ifeq ($(F95),ifort)
-F95FLAGS ?= -m64 -fpp -free -O3 -Tf
-MODFLAG = -I$(MODPATH)
-LAPACK ?= -mkl
-BLAS ?=
-endif
-
-ifeq ($(F95),g95)
-F95FLAGS ?= -O3 -fno-second-underscore
-MODFLAG = -I$(MODPATH)
-LAPACK ?= -llapack
-BLAS ?= -lblas
-endif
-
-ifeq ($(F95),pgf90)
-F95FLAGS ?= -fast 
-MODFLAG = -Imodpath
-LAPACK ?= -llapack
-BLAS ?= -lblas
-endif
-
-ifeq ($(origin F95FLAGS), undefined)
-F95FLAGS = -m64 -O3
-MODFLAG = -I$(MODPATH)
-LAPACK ?= -llapack
-BLAS ?= -lblas
-endif
 
 
 clean:

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -1193,14 +1193,22 @@ class SHGrid(object):
             minor_tick_interval = [None, None]
         if axes_labelsize is None:
             axes_labelsize = _mpl.rcParams['axes.labelsize']
-            if axes_labelsize == 'medium':
-                axes_labelsize = _mpl.rcParams['font.size']
+            if type(axes_labelsize) == str:
+                axes_labelsize = _mpl.font_manager \
+                                 .FontProperties(size=axes_labelsize) \
+                                 .get_size_in_points()
         if tick_labelsize is None:
             tick_labelsize = _mpl.rcParams['xtick.labelsize']
-            if tick_labelsize == 'medium':
-                tick_labelsize = _mpl.rcParams['font.size']
+            if type(tick_labelsize) == str:
+                tick_labelsize = _mpl.font_manager \
+                                 .FontProperties(size=tick_labelsize) \
+                                 .get_size_in_points()
         if titlesize is None:
             titlesize = _mpl.rcParams['axes.titlesize']
+            if type(titlesize) == str:
+                titlesize = _mpl.font_manager \
+                                 .FontProperties(size=titlesize) \
+                                 .get_size_in_points()
         if self.kind == 'complex' and title is None:
             title = ['Real component', 'Imaginary component']
         if xlabel is True:
@@ -1428,14 +1436,22 @@ class SHGrid(object):
                                  .format(repr(colorbar)))
         if axes_labelsize is None:
             axes_labelsize = _mpl.rcParams['axes.labelsize']
-            if axes_labelsize == 'medium':
-                axes_labelsize = _mpl.rcParams['font.size']
+            if type(axes_labelsize) == str:
+                axes_labelsize = _mpl.font_manager \
+                                 .FontProperties(size=axes_labelsize) \
+                                 .get_size_in_points()
         if tick_labelsize is None:
             tick_labelsize = _mpl.rcParams['xtick.labelsize']
-            if tick_labelsize == 'medium':
-                tick_labelsize = _mpl.rcParams['font.size']
+            if type(tick_labelsize) == str:
+                tick_labelsize = _mpl.font_manager \
+                                 .FontProperties(size=tick_labelsize) \
+                                 .get_size_in_points()
         if titlesize is None:
             titlesize = _mpl.rcParams['axes.titlesize']
+            if type(titlesize) == str:
+                titlesize = _mpl.font_manager \
+                                 .FontProperties(size=titlesize) \
+                                 .get_size_in_points()
 
         figure = self._plot_pygmt(
             fig=fig, projection=projection, region=region, width=width,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ six
 shapely
 cartopy>=0.18.0
 pygmt>=0.2
+flake8

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,13 +8,8 @@
 #
 ###############################################################################
 
-F95 = gfortran
-
 SHELL = /bin/sh
 
-LIBNAME = SHTOOLS
-LIBPATH = ../lib
-MODPATH = ../modules
 PROG = $(LIBPATH)/lib$(LIBNAME).a
 
 LIBTOOL = libtool
@@ -72,7 +67,6 @@ SRCS0 = CilmPlus.f95 CilmMinus.f95 \
 
 OBJS0 := $(SRCS0:%.f95=%.o)
 
-
 SRCSLAPACK = EigValSym.F95 EigValVecSym.F95 EigValVecSymTri.F95 \
 	SHExpandLSQ.F95 SHMTDebias.F95 SHMTVarOpt.F95
 
@@ -122,7 +116,7 @@ clean-obs-mod:
 clean-prog-mod:
 	@-rm -f $(PROG)
 	@-rm -f $(MODPATH)/*.mod
-	
+
 %.mod: %.f95
 	$(F95) -c $(F95FLAGS) $<
 %.o: %.f95 SHTOOLS.mod

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,6 +6,12 @@
 #   make clean
 #       Remove the lib and module files in the LOCAL directory.
 #
+#
+#   Notes:
+#
+#   This Makefile is intended to be invoked by the main Makefile in the SHTOOLS
+#   repository.
+#
 ###############################################################################
 
 SHELL = /bin/sh
@@ -19,22 +25,6 @@ ARFLAGS = -r
 RLIB = ranlib
 RLIBFLAGS =
 LDFLAGS = -s
-
-ifeq ($(F95),f95)
-# Default Absoft Pro Fortran flags
-F95FLAGS ?= -m64 -O3 -YEXT_NAMES=LCS -YEXT_SFX=_ -fpic -speed_math=11 # -march=host
-else ifeq ($(F95),g95)
-# Default g95 flags.
-F95FLAGS ?= -O3 -fno-second-underscore
-else ifeq ($(F95),gfortran)
-# Default gfortran flags
-F95FLAGS ?= -m64 -fPIC -O3 -ffast-math
-else ifeq ($(F95),ifort)
-# Default intel fortran flags
-F95FLAGS ?= -m64 -fpp -free -O3 -Tf
-else ifeq ($(origin F95FLAGS), undefined)
-F95FLAGS = -m64 -O3
-endif
 
 SRCSMOD = ftypes.f95 SHTOOLS.f95 FFTW3.f95 PlanetsConstants.f95
 


### PR DESCRIPTION
Version 4.7.1

This maintenance release updates the makefiles so that they can be used correctly with homebrew-core and macports.

* Relative paths are removed in a few cases by explicitly passing variables such as `$(MODPATH)$` to all dependent sub-makefiles.
* Default variables are no longer set in the sub-makefiles, as these are not intended to be used independently. All variables are passed directly from the main Makefile.
* Renamed the directory `modules` to `include` to be consistent with macports and homebrew installations.
* The F95FLAGS are set by searching if the compiler name contains the "short" compiler name. This allows recognizing "gfortran-10" as being "gfortran".
* Added a `.github` folder with templates for issues and releases checklists.
* Converted matplotlib relative font sizes (such as 'large') to points when passing font sizes to the Cartopy and pygmt plotting routines.
* Minor changes to configuration files.