### PR TITLE
Update travis build and conda environment

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -73,7 +73,7 @@ Update the homebrew installation by editing the file `shtools.rb` in the homebre
 - [ ] Commit and push changes.
 
 ### Update conda-forge ###
-- [ ] Got to [pyshtools-feedstock](https://github.com/conda-forge/pyshtools-feedstock) and check that the `recipe/meta.yaml` file has been updated. This is usually done automatically by conda-forge's bot. If necessary, merge changes into the feedstock.
+- [ ] Go to [pyshtools-feedstock](https://github.com/conda-forge/pyshtools-feedstock) and check that the `recipe/meta.yaml` file has been updated. This is usually done automatically by conda-forge's bot. If necessary, merge changes into the feedstock.
 
 ### Update web documentation ###
 Update the web documentation at shtools.oca.eu.

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,26 +31,8 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda config --add channels conda-forge
   - conda update -q conda
-
-  - conda create -q -n test-environment
-        python=$PYTHON_VERSION
-        numpy
-        fftw>=3.3.8
-        liblapack>=3.8
-        openblas
-        gmt>=6.1.1
-        scipy>=0.14.0
-        matplotlib-base>=3.3
-        astropy
-        xarray
-        requests
-        cartopy>=0.18.0
-        pygmt>=0.2.0
-        pooch>=1.1
-        tqdm
-        jupyter
-        palettable>=3.3
-        pypandoc
+  - conda create -q -n test-environment python=$PYTHON_VERSION
+  - conda env update -q -n test -f environment.yml
   - conda activate test-environment
 
   # Conda info for debugging

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - conda config --add channels conda-forge
   - conda update -q conda
   - conda create -q -n test-environment python=$PYTHON_VERSION
-  - conda env update -q -n test -f environment.yml
+  - conda env update -q -n test-environment -f environment.yml
   - conda activate test-environment
 
   # Conda info for debugging

--- a/environment.yml
+++ b/environment.yml
@@ -2,11 +2,9 @@ name: pyshtools
 channels:
     - conda-forge
 dependencies:
-    - python=3.8
     - fftw>=3.3.8
     - liblapack>=3.8
     - openblas
-    - gmt>=6.1.1
     - numpy
     - scipy>=0.14.0
     - matplotlib-base>=3.3
@@ -16,9 +14,10 @@ dependencies:
     - pooch>=1.1
     - tqdm
     - cartopy>=0.18.0
+    - gmt>=6.1.1
     - pygmt>=0.2.0
     - palettable>=3.3
     - jupyter
     - pypandoc
-    - nb_conda_kernels
+    - flake8
     - pip


### PR DESCRIPTION
remove python version from environment.yml, and then specify this manually when creating the build matrix in Travis.