### PR TITLE
Various updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,8 @@ install:
 	mkdir -pv $(DESTDIR)$(SYSINCPATH)
 	cp $(INCPATH)/*.h $(DESTDIR)$(SYSINCPATH)/
 	mkdir -pv $(DESTDIR)$(SYSSHAREPATH)/examples/shtools
-	cp -R examples/fortran/ $(DESTDIR)$(SYSSHAREPATH)/examples/shtools/
+	cp -R examples/fortran $(DESTDIR)$(SYSSHAREPATH)/examples/shtools/
+	cp -R examples/ExampleDataFiles $(DESTDIR)$(SYSSHAREPATH)/examples/shtools/
 	mkdir -pv $(DESTDIR)$(SYSSHAREPATH)/man/man1
 	cp -R man/man1/ $(DESTDIR)$(SYSSHAREPATH)/man/man1/
 	@echo

--- a/docs/pages/mydoc/faq.md
+++ b/docs/pages/mydoc/faq.md
@@ -36,11 +36,15 @@ It is pronounced S-H-Tools.
 
 Please see [this page](how-to-contribute.html).
 
-## Can I use the SHTOOLS library with C, F77, and Matlab?
+## Can I use the SHTOOLS library with C, Python, Julia, F77 or Matlab?
 
-A C-interface to the Fortran-95 SHTOOLS library does exist. However, it is currently a work in progress and is not well documented. A working C example program can be found in the directory `examples/cpp`, and the required header file can be found at `includes/shtools.h`.
+A C-interface to the Fortran-95 SHTOOLS library is distributed with this archive. However, it is currently a work in progress and is not documented in the current version. A working C example program can be found in the directory `examples/cpp`, and the required header file can be found at `includes/shtools.h`.
 
-As for Fortran 77 and Matlab, we would be happy to add instructions on how to interface with these (or other) languages if anyone provides them to us.
+A Python interface to the SHTOOLS functions is provided in the [pyshtools](https://shtools.github.io/SHTOOLS/index.html) package. In addition to wrapping the Fortran-95 functions, this package provides a high-level interface for interacting with spherical harmonic coefficients and plotting global gridded data.
+
+A basic Julia package that wraps the SHTOOLS functions can be found [here](https://github.com/eschnett/SHTOOLS.jl).
+
+As for Fortran 77 and Matlab, please let us know if you get this to work!
 
 ## Which FFT libraries work with SHTOOLS?
 
@@ -61,7 +65,7 @@ pip install git+https://github.com/SHTOOLS/SHTOOLS.git@python2.7
 
 No.
 
-## I don't understand Fortran and Python. Will you explain how to modify the example codes?
+## I don't understand spherical harmonics or programming. Will you explain how to modify the example codes?
 
 No.
 
@@ -69,7 +73,7 @@ No.
 
 If you are using the Fortran version of SHTOOLS, the output is typically in the form of an ASCII or binary raster file. These can be read by any standard graphics package, such as the free unix-based command line software [GMT](https://www.generic-mapping-tools.org/).
 
-If you are using the Python version of SHTOOLS, the classes for working with spherical harmonic coefficients and grids contain methods for making publication quality graphics that make use of the `matplotlib` and `pygmt` packages.
+If you are using the Python version of SHTOOLS, the classes for working with spherical harmonic coefficients and grids contain methods for making publication quality graphics that make use of the `matplotlib`, `pygmt`, and `Cartopy` packages.
 
 ## Who maintains SHTOOLS?
 

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
     - numpy
     - scipy>=0.14.0
     - matplotlib-base>=3.3
-    - astropy
+    - astropy>=4.0
     - xarray
     - requests
     - pooch>=1.1

--- a/examples/notebooks/grids-and-coefficients.ipynb
+++ b/examples/notebooks/grids-and-coefficients.ipynb
@@ -235,11 +235,11 @@
     }
    ],
    "source": [
-    "fig, ax = clm.plot_spectrum(legend='Orthonormalized',\n",
+    "fig, ax = clm.plot_spectrum(legend='4$\\pi$ normalized',\n",
     "                            show=False)\n",
     "clm_ortho.plot_spectrum(ax=ax,\n",
     "                        linestyle='dashed',\n",
-    "                        legend='4$\\pi$ normalized')\n",
+    "                        legend='Orthonormalized')\n",
     "ax.plot(clm.degrees(), power, '-k')\n",
     "limits = ax.set_xlim(0, 100)"
    ]

--- a/pyshtools/constants/Venus.py
+++ b/pyshtools/constants/Venus.py
@@ -67,11 +67,12 @@ g0 = _Constant(
 omega = _Constant(
     abbrev='omega_venus',
     name='Angular spin rate of Venus',
-    value=-2 * _np.pi / (243.0200 * 24 * 60 * 60),
+    value=-2 * _np.pi / (243.0226 * 24 * 60 * 60),
     unit='rad / s',
-    uncertainty=0.0002 * 2 * _np.pi / (243.0200**2 * 24 * 60 * 60),
-    reference='MGNP180U: Konopliv A. S., W. B. Banerdt, and W. L. Sjogren '
-    '(1999) Venus gravity: 180th degree and order model. Icarus 139: 3-18.'
-    'doi:10.1006/icar.1999.6086.')
+    uncertainty=0.0013 * 2 * _np.pi / (243.0226**2 * 24 * 60 * 60),
+    reference='Margot, J.-L., D. B. Campbell, J. D. Giorgini, J. S. Jao, '
+    'L. G. Snedeker, F. D. Ghigo and A. Bonsall, Spin state and moment of '
+    'inertia of Venus (2021), Nature Astronomy, '
+    'doi:10.1038/s41550-021-01339-7.')
 
 __all__ = ['gm', 'mass', 'r', 'gm', 'density', 'omega']

--- a/pyshtools/datasets/Ceres.py
+++ b/pyshtools/datasets/Ceres.py
@@ -38,7 +38,7 @@ def CERES18D(lmax=18):
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
                                    r0_index=0, gm_index=1, errors=True,
-                                   name='CERES18D')
+                                   name='CERES18D', encoding='utf-8')
 
 
 __all__ = ['CERES18D']

--- a/pyshtools/datasets/Earth/Earth2012/__init__.py
+++ b/pyshtools/datasets/Earth/Earth2012/__init__.py
@@ -48,7 +48,7 @@ def shape_air(lmax=2160):
         path=_os_cache('pyshtools'),
     )
     return _SHCoeffs.from_file(fname, lmax=lmax, name='Earth2020.shape_air',
-                               units='m')
+                               units='m', encoding='utf-8')
 
 
 def shape_bathy(lmax=2160):
@@ -75,7 +75,7 @@ def shape_bathy(lmax=2160):
         path=_os_cache('pyshtools'),
     )
     return _SHCoeffs.from_file(fname, lmax=lmax, name='Earth2012.shape_bathy',
-                               units='m')
+                               units='m', encoding='utf-8')
 
 
 def shape_bathy_bed(lmax=2160):
@@ -104,7 +104,8 @@ def shape_bathy_bed(lmax=2160):
         path=_os_cache('pyshtools'),
     )
     return _SHCoeffs.from_file(fname, lmax=lmax,
-                               name='Earth2012.shape_bathy_bed', units='m')
+                               name='Earth2012.shape_bathy_bed', units='m',
+                               encoding='utf-8')
 
 
 def shape_ret(lmax=2160):
@@ -131,7 +132,7 @@ def shape_ret(lmax=2160):
         path=_os_cache('pyshtools'),
     )
     return _SHCoeffs.from_file(fname, lmax=lmax, name='Earth2012.shape_ret',
-                               units='m')
+                               units='m', encoding='utf-8')
 
 
 def topo_air(lmax=2160):
@@ -159,7 +160,7 @@ def topo_air(lmax=2160):
         path=_os_cache('pyshtools'),
     )
     return _SHCoeffs.from_file(fname, lmax=lmax, name='Earth2012.topo_air',
-                               units='m')
+                               units='m', encoding='utf-8')
 
 
 def topo_bathy(lmax=2160):
@@ -188,7 +189,7 @@ def topo_bathy(lmax=2160):
         path=_os_cache('pyshtools'),
     )
     return _SHCoeffs.from_file(fname, lmax=lmax, name='Earth2012.topo_bathy',
-                               units='m')
+                               units='m', encoding='utf-8')
 
 
 def topo_bathy_bed(lmax=2160):
@@ -218,7 +219,8 @@ def topo_bathy_bed(lmax=2160):
         path=_os_cache('pyshtools'),
     )
     return _SHCoeffs.from_file(fname, lmax=lmax,
-                               name='Earth2012.topo_bathy_bed', units='m')
+                               name='Earth2012.topo_bathy_bed', units='m',
+                               encoding='utf-8')
 
 
 def ret(lmax=2160):
@@ -245,7 +247,7 @@ def ret(lmax=2160):
         path=_os_cache('pyshtools'),
     )
     return _SHCoeffs.from_file(fname, lmax=lmax, name='Earth2012.ret',
-                               units='m')
+                               units='m', encoding='utf-8')
 
 
 __all__ = ['shape_air', 'shape_bathy', 'shape_bathy_bed', 'shape_ret',

--- a/pyshtools/datasets/Earth/__init__.py
+++ b/pyshtools/datasets/Earth/__init__.py
@@ -62,7 +62,8 @@ def EGM2008(lmax=2190):
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, format='icgem',
                                    errors='calibrated',
-                                   omega=_egm2008.omega.value, name='EGM2008')
+                                   omega=_egm2008.omega.value, name='EGM2008',
+                                   encoding='utf-8')
 
 
 def EIGEN_6C4(lmax=2190):
@@ -123,7 +124,8 @@ def GGM05C(lmax=360):
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, format='icgem',
                                    errors='calibrated',
-                                   omega=_egm2008.omega.value, name='GGM05C')
+                                   omega=_egm2008.omega.value, name='GGM05C',
+                                   encoding='utf-8')
 
 
 def GOCO06S(lmax=300):
@@ -152,7 +154,7 @@ def GOCO06S(lmax=300):
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, format='icgem',
                                    errors='formal', omega=_egm2008.omega.value,
-                                   name='GOCO06S')
+                                   name='GOCO06S', encoding='utf-8')
 
 
 def EIGEN_GRGS_RL04_MEAN_FIELD(epoch=None, lmax=300):
@@ -185,7 +187,8 @@ def EIGEN_GRGS_RL04_MEAN_FIELD(epoch=None, lmax=300):
     return _SHGravCoeffs.from_file(fname, lmax=lmax, format='icgem',
                                    errors='formal', omega=_egm2008.omega.value,
                                    epoch=epoch,
-                                   name='EIGEN_GRGS_RL04_MEAN_FIELD')
+                                   name='EIGEN_GRGS_RL04_MEAN_FIELD',
+                                   encoding='utf-8')
 
 
 def XGM2019E(lmax=2190):
@@ -214,7 +217,7 @@ def XGM2019E(lmax=2190):
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, format='icgem',
                                    errors='formal', omega=_egm2008.omega.value,
-                                   name='XGM2019E')
+                                   name='XGM2019E', encoding='utf-8')
 
 
 def IGRF_13(lmax=13, year=2020.):
@@ -247,7 +250,7 @@ def IGRF_13(lmax=13, year=2020.):
     )
     return _SHMagCoeffs.from_file(fname, format='igrf', r0=6371.2e3,
                                   lmax=lmax, year=year, file_units='nT',
-                                  name='IGRF_13', units='nT')
+                                  name='IGRF_13', units='nT', encoding='utf-8')
 
 
 def NGDC_720_V3(lmax=740):
@@ -278,7 +281,8 @@ def NGDC_720_V3(lmax=740):
     )
     return _SHMagCoeffs.from_file(fname, r0=6371.2e3, lmax=lmax, skip=14,
                                   header=False, file_units='nT',
-                                  name='NGDC_720_V3', units='nT')
+                                  name='NGDC_720_V3', units='nT',
+                                  encoding='utf-8')
 
 
 def WDMAM2_800(lmax=800):
@@ -307,7 +311,7 @@ def WDMAM2_800(lmax=800):
     )
     return _SHMagCoeffs.from_file(fname, r0=6371.2e3, lmax=lmax, header=False,
                                   file_units='nT', name='WDMAM2_800',
-                                  units='nT')
+                                  units='nT', encoding='utf-8')
 
 
 def SWARM_MLI_2D_0501(lmax=133):
@@ -338,7 +342,8 @@ def SWARM_MLI_2D_0501(lmax=133):
     return _SHMagCoeffs.from_file(fname[0], format='dov', r0=6371.2e3,
                                   r0_index=None, lmax=lmax, header=True,
                                   header2=True, skip=3, file_units='nT',
-                                  name='SWARM_MLI_2D_0501', units='nT')
+                                  name='SWARM_MLI_2D_0501', units='nT',
+                                  encoding='utf-8')
 
 
 __all__ = ['Earth2012', 'Earth2014', 'EGM2008', 'EIGEN_6C4',

--- a/pyshtools/datasets/Mars.py
+++ b/pyshtools/datasets/Mars.py
@@ -49,7 +49,7 @@ def MarsTopo2600(lmax=2600):
         path=_os_cache('pyshtools'),
     )
     return _SHCoeffs.from_file(fname, lmax=lmax, name='MarsTopo2600',
-                               units='m')
+                               units='m', encoding='utf-8')
 
 
 def GMM3(lmax=120):
@@ -78,7 +78,8 @@ def GMM3(lmax=120):
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
                                    r0_index=0, gm_index=1, errors=True,
-                                   omega=_omega.value, name='GMM3')
+                                   omega=_omega.value, name='GMM3',
+                                   encoding='utf-8')
 
 
 def GMM3_RM1_1E0(lmax=150):
@@ -108,7 +109,8 @@ def GMM3_RM1_1E0(lmax=150):
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='m',
                                    r0_index=1, gm_index=0, errors=False,
-                                   omega=_omega.value, name='GMM3_RM1_1E0')
+                                   omega=_omega.value, name='GMM3_RM1_1E0',
+                                   encoding='utf-8')
 
 
 def MRO120D(lmax=120):
@@ -136,7 +138,8 @@ def MRO120D(lmax=120):
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
                                    r0_index=0, gm_index=1, errors=True,
-                                   omega=_omega.value, name='MRO120D')
+                                   omega=_omega.value, name='MRO120D',
+                                   encoding='utf-8')
 
 
 def Langlais2019(lmax=134):
@@ -165,7 +168,8 @@ def Langlais2019(lmax=134):
     )
     return _SHMagCoeffs.from_file(fname, lmax=lmax, skip=4, r0=3393.5e3,
                                   header=False, file_units='nT',
-                                  name='Langlais2019', units='nT')
+                                  name='Langlais2019', units='nT',
+                                  encoding='utf-8')
 
 
 def Morschhauser2014(lmax=110):
@@ -193,7 +197,8 @@ def Morschhauser2014(lmax=110):
     )
     return _SHMagCoeffs.from_file(fname, r0=3393.5e3, skip=3, header=False,
                                   format='dov', file_units='nT',
-                                  name='Morschhauser2014', units='nT')
+                                  name='Morschhauser2014', units='nT',
+                                  encoding='utf-8')
 
 
 __all__ = ['MarsTopo2600', 'GMM3', 'GMM3_RM1_1E0', 'MRO120D', 'Langlais2019',

--- a/pyshtools/datasets/Mercury.py
+++ b/pyshtools/datasets/Mercury.py
@@ -43,7 +43,8 @@ def GTMES150(lmax=150):
         path=_os_cache('pyshtools'),
     )
     temp = _SHCoeffs.from_file(
-        fname, lmax=lmax, header=True, errors=True, name='GTMES150', units='m')
+        fname, lmax=lmax, header=True, errors=True, name='GTMES150', units='m',
+        encoding='utf-8')
     temp.coeffs *= 1000.
     temp.errors *= 1000.
     return temp
@@ -75,7 +76,7 @@ def JGMESS160A(lmax=160):
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
                                    errors=True, omega=_omega.value,
-                                   name='JGMESS160A')
+                                   name='JGMESS160A', encoding='utf-8')
 
 
 def JGMESS160A_ACCEL(lmax=160):
@@ -105,7 +106,7 @@ def JGMESS160A_ACCEL(lmax=160):
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
                                    errors=True, omega=_omega.value,
-                                   name='JGMESS160A_ACCEL')
+                                   name='JGMESS160A_ACCEL', encoding='utf-8')
 
 
 def JGMESS160A_TOPOSIG(lmax=160):
@@ -135,7 +136,7 @@ def JGMESS160A_TOPOSIG(lmax=160):
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
                                    errors=True, omega=_omega.value,
-                                   name='JGMESS160A_TOPOSIG')
+                                   name='JGMESS160A_TOPOSIG', encoding='utf-8')
 
 
 def GGMES100V08(lmax=100):
@@ -165,7 +166,7 @@ def GGMES100V08(lmax=100):
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
                                    errors=True, omega=_omega.value,
-                                   name='GGMES100V08')
+                                   name='GGMES100V08', encoding='utf-8')
 
 
 __all__ = ['GTMES150', 'JGMESS160A', 'JGMESS160A_ACCEL', 'JGMESS160A_TOPOSIG',

--- a/pyshtools/datasets/Moon.py
+++ b/pyshtools/datasets/Moon.py
@@ -51,7 +51,7 @@ def MoonTopo2600p(lmax=2600):
         path=_os_cache('pyshtools'),
     )
     return _SHCoeffs.from_file(fname, lmax=lmax, name='MoonTopo2600p',
-                               units='m')
+                               units='m', encoding='utf-8')
 
 
 def T2015_449(lmax=449):
@@ -84,7 +84,8 @@ def T2015_449(lmax=449):
         path=_os_cache('pyshtools'),
     )
     return _SHMagCoeffs.from_file(fname, lmax=lmax, header=True,
-                                  file_units='T', name='T2015_449', units='nT')
+                                  file_units='T', name='T2015_449', units='nT',
+                                  encoding='utf-8')
 
 
 def Ravat2020(lmax=450):
@@ -113,7 +114,8 @@ def Ravat2020(lmax=450):
         path=_os_cache('pyshtools'),
     )
     return _SHMagCoeffs.from_file(fname, lmax=lmax, header=True, skip=8,
-                                  header_units='km', name='Ravat2020')
+                                  header_units='km', name='Ravat2020',
+                                  encoding='utf-8')
 
 
 def GRGM900C(lmax=900):
@@ -143,7 +145,7 @@ def GRGM900C(lmax=900):
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
                                    errors=True, omega=_omega.value,
-                                   name='GRGM900C')
+                                   name='GRGM900C', encoding='utf-8')
 
 
 def GRGM1200B(lmax=1200):
@@ -174,7 +176,8 @@ def GRGM1200B(lmax=1200):
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='m',
                                    r0_index=1, gm_index=0, errors=True,
-                                   omega=_omega.value, name='GRGM1200B')
+                                   omega=_omega.value, name='GRGM1200B',
+                                   encoding='utf-8')
 
 
 def GRGM1200B_RM1_1E0(lmax=1200):
@@ -207,7 +210,7 @@ def GRGM1200B_RM1_1E0(lmax=1200):
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='m',
                                    r0_index=1, gm_index=0, errors=True,
                                    omega=_omega.value,
-                                   name='GRGM1200B_RM1_1E0')
+                                   name='GRGM1200B_RM1_1E0', encoding='utf-8')
 
 
 def GL0900D(lmax=900):
@@ -237,7 +240,7 @@ def GL0900D(lmax=900):
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
                                    errors=True, omega=_omega.value,
-                                   name='GL0900D')
+                                   name='GL0900D', encoding='utf-8')
 
 
 def GL1500E(lmax=1500):
@@ -267,7 +270,7 @@ def GL1500E(lmax=1500):
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
                                    errors=True, omega=_omega.value,
-                                   name='GL1500E')
+                                   name='GL1500E', encoding='utf-8')
 
 
 __all__ = ['MoonTopo2600p', 'T2015_449', 'Ravat2020', 'GRGM900C', 'GRGM1200B',

--- a/pyshtools/datasets/Venus.py
+++ b/pyshtools/datasets/Venus.py
@@ -40,7 +40,7 @@ def VenusTopo719(lmax=719):
         path=_os_cache('pyshtools'),
     )
     return _SHCoeffs.from_file(fname, lmax=lmax, name='VenusTopo719',
-                               units='m')
+                               units='m', encoding='utf-8')
 
 
 def MGNP180U(lmax=180):
@@ -67,7 +67,7 @@ def MGNP180U(lmax=180):
     return _SHGravCoeffs.from_file(fname, lmax=lmax, skip=236, header=True,
                                    r0_index=1, gm_index=2, header_units='km',
                                    errors=True, omega=_omega.value,
-                                   name='MGNP180U')
+                                   name='MGNP180U', encoding='utf-8')
 
 
 __all__ = ['VenusTopo719', 'MGNP180U']

--- a/pyshtools/datasets/Vesta.py
+++ b/pyshtools/datasets/Vesta.py
@@ -38,7 +38,7 @@ def VESTA20H(lmax=20):
     )
     return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
                                    r0_index=0, gm_index=1, errors=True,
-                                   name='VESTA20H')
+                                   name='VESTA20H', encoding='utf-8')
 
 
 __all__ = ['VESTA20H']

--- a/pyshtools/shclasses/shcoeffs.py
+++ b/pyshtools/shclasses/shcoeffs.py
@@ -336,7 +336,7 @@ class SHCoeffs(object):
     def from_file(self, fname, lmax=None, format='shtools', kind='real',
                   errors=None, error_kind=None, normalization='4pi', skip=0,
                   header=False, header2=False, csphase=1, name=None,
-                  units=None, **kwargs):
+                  units=None, encoding=None, **kwargs):
         """
         Initialize the class with spherical harmonic coefficients from a file.
 
@@ -344,7 +344,7 @@ class SHCoeffs(object):
         -----
         x = SHCoeffs.from_file(filename, [format='shtools' or 'dov', lmax,
                                errors, error_kind, normalization, csphase,
-                               skip, header, header2, name, units])
+                               skip, header, header2, name, units, encoding])
         x = SHCoeffs.from_file(filename, format='bshc', [lmax, normalization,
                                csphase, name, units])
         x = SHCoeffs.from_file(filename, format='npy', [lmax, normalization,
@@ -396,6 +396,9 @@ class SHCoeffs(object):
             The name of the dataset.
         units : str, optional, default = None
             The units of the spherical harmonic coefficients.
+        encoding : str, optional, default = None
+            Encoding of the input file when format is 'shtools' or 'dov'. The
+            default is to use the system default.
         **kwargs : keyword argument list, optional for format = 'npy'
             Keyword arguments of numpy.load() when format is 'npy'.
 
@@ -455,26 +458,29 @@ class SHCoeffs(object):
                         coeffs, error_coeffs, lmaxout, header_list, \
                             header2_list = read_func(fname, lmax=lmax,
                                                      skip=skip, header=True,
-                                                     header2=True, error=True)
+                                                     header2=True, error=True,
+                                                     encoding=encoding)
                     else:
                         coeffs, error_coeffs, lmaxout, header_list = read_func(
                             fname, lmax=lmax, skip=skip, header=True,
-                            error=True)
+                            error=True, encoding=encoding)
                 else:
                     if header2:
                         coeffs, lmaxout, header_list, header2_list = read_func(
                             fname, lmax=lmax, skip=skip, header=True,
-                            header2=True)
+                            header2=True, encoding=encoding)
                     else:
                         coeffs, lmaxout, header_list = read_func(
-                            fname, lmax=lmax, skip=skip, header=True)
+                            fname, lmax=lmax, skip=skip, header=True,
+                            encoding=encoding)
             else:
                 if errors:
-                    coeffs, error_coeffs, lmaxout = read_func(fname, lmax=lmax,
-                                                              skip=skip,
-                                                              error=True)
+                    coeffs, error_coeffs, lmaxout = read_func(
+                        fname, lmax=lmax, skip=skip, error=True,
+                        encoding=encoding)
                 else:
-                    coeffs, lmaxout = read_func(fname, lmax=lmax, skip=skip)
+                    coeffs, lmaxout = read_func(fname, lmax=lmax, skip=skip,
+                                                encoding=encoding)
 
             if errors is True and error_kind is None:
                 error_kind = 'unspecified'
@@ -923,14 +929,16 @@ class SHCoeffs(object):
 
     # ---- IO Routines
     def to_file(self, filename, format='shtools', header=None, header2=None,
-                errors=True, lmax=None, **kwargs):
+                errors=True, lmax=None, encoding=None, **kwargs):
         """
         Save raw spherical harmonic coefficients to a file.
 
         Usage
         -----
-        x.to_file(filename, [format='shtools', header, header2, errors, lmax])
-        x.to_file(filename, format='dov', [header, header2, errors, lmax])
+        x.to_file(filename, [format='shtools', header, header2, errors, lmax,
+                             encoding])
+        x.to_file(filename, format='dov', [header, header2, errors, lmax,
+                                           encoding])
         x.to_file(filename, format='bshc', [lmax])
         x.to_file(filename, format='npy', [**kwargs])
 
@@ -952,6 +960,9 @@ class SHCoeffs(object):
             files only).
         lmax : int, optional, default = self.lmax
             The maximum spherical harmonic degree to write to the file.
+        encoding : str, optional, default = None
+            Encoding of the output file when format is 'shtools' or 'dov'. The
+            default is to use the system default.
         **kwargs : keyword argument list, optional for format = 'npy'
             Keyword arguments of numpy.save().
 
@@ -1001,18 +1012,22 @@ class SHCoeffs(object):
         if format.lower() == 'shtools':
             if errors:
                 _shwrite(filebase, self.coeffs, errors=self.errors,
-                         header=header, header2=header2, lmax=lmax)
+                         header=header, header2=header2, lmax=lmax,
+                         encoding=encoding)
             else:
                 _shwrite(filebase, self.coeffs, errors=None,
-                         header=header, header2=header2, lmax=lmax)
+                         header=header, header2=header2, lmax=lmax,
+                         encoding=encoding)
 
         elif format.lower() == 'dov':
             if errors:
                 _write_dov(filebase, self.coeffs, errors=self.errors,
-                           header=header, header2=header2, lmax=lmax)
+                           header=header, header2=header2, lmax=lmax,
+                           encoding=encoding)
             else:
                 _write_dov(filebase, self.coeffs, errors=None,
-                           header=header, header2=header2, lmax=lmax)
+                           header=header, header2=header2, lmax=lmax,
+                           encoding=encoding)
 
         elif format.lower() == 'bshc':
             _write_bshc(filebase, self.coeffs, lmax=lmax)

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -482,7 +482,7 @@ class SHGravCoeffs(object):
             for 'icgem' v2.0 formatted files.
         encoding : str, optional, default = None
             Encoding of the input file for 'icgem' files. Try to use
-            'iso-8859-1' if the default (UTF-8) fails.
+            'iso-8859-1' if UTF-8 fails.
         **kwargs : keyword argument list, optional for format = 'npy'
             Keyword arguments of numpy.load() when format is 'npy'.
 

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -392,7 +392,7 @@ class SHGravCoeffs(object):
                                    r0, omega, lmax, normalization, csphase,
                                    skip, header, header2, errors, error_kind,
                                    gm_index, r0_index, omega_index,
-                                   header_units, set_degree0, name])
+                                   header_units, set_degree0, name, encoding])
         x = SHGravCoeffs.from_file(filename, format='icgem', [lmax, omega,
                                    normalization, csphase, errors, set_degree0,
                                    name, name, epoch, encoding])
@@ -481,8 +481,8 @@ class SHGravCoeffs(object):
             the reference epoch t0 of the model will be used. Epoch is required
             for 'icgem' v2.0 formatted files.
         encoding : str, optional, default = None
-            Encoding of the input file for 'icgem' files. Try to use
-            'iso-8859-1' if UTF-8 fails.
+            Encoding of the input file when format is 'shtools', 'dov' or
+            'icgem'. The default is to use the system default.
         **kwargs : keyword argument list, optional for format = 'npy'
             Keyword arguments of numpy.load() when format is 'npy'.
 
@@ -567,19 +567,21 @@ class SHGravCoeffs(object):
                             header2_list = read_func(fname, lmax=lmax,
                                                      skip=skip, header=True,
                                                      header2=True,
-                                                     error=True)
+                                                     error=True,
+                                                     encoding=encoding)
                     else:
                         coeffs, error_coeffs, lmaxout, header_list = read_func(
                             fname, lmax=lmax, skip=skip, header=True,
-                            error=True)
+                            error=True, encoding=encoding)
                 else:
                     if header2:
                         coeffs, lmaxout, header_list, header2_list = read_func(
                             fname, lmax=lmax, skip=skip, header=True,
-                            header2=True)
+                            header2=True, encoding=encoding)
                     else:
                         coeffs, lmaxout, header_list = read_func(
-                            fname, lmax=lmax, skip=skip, header=True)
+                            fname, lmax=lmax, skip=skip, header=True,
+                            encoding=encoding)
 
                 if r0_index is not None:
                     if header2:
@@ -603,9 +605,11 @@ class SHGravCoeffs(object):
             else:
                 if errors is True:
                     coeffs, error_coeffs, lmaxout = read_func(
-                        fname, lmax=lmax, error=True, skip=skip)
+                        fname, lmax=lmax, error=True, skip=skip,
+                        encoding=encoding)
                 else:
-                    coeffs, lmaxout = read_func(fname, lmax=lmax, skip=skip)
+                    coeffs, lmaxout = read_func(fname, lmax=lmax, skip=skip,
+                                                encoding=encoding)
 
             if errors is True and error_kind is None:
                 error_kind = 'unspecified'
@@ -1239,17 +1243,18 @@ class SHGravCoeffs(object):
 
     # ---- IO routines ----
     def to_file(self, filename, format='shtools', header=None, errors=True,
-                lmax=None, modelname=None, tide_system='unknown', **kwargs):
+                lmax=None, modelname=None, tide_system='unknown',
+                encoding=None, **kwargs):
         """
         Save spherical harmonic coefficients to a file.
 
         Usage
         -----
-        x.to_file(filename, [format='shtools', header, errors, lmax])
-        x.to_file(filename, format='dov', [header, errors, lmax])
+        x.to_file(filename, [format='shtools', header, errors, lmax, encoding])
+        x.to_file(filename, format='dov', [header, errors, lmax, encoding])
         x.to_file(filename, format='bshc', [lmax])
         x.to_file(filename, format='icgem', [header, errors, lmax, modelname,
-                                             tide_system])
+                                             tide_system, encoding])
         x.to_file(filename, format='npy', [**kwargs])
 
         Parameters
@@ -1272,6 +1277,9 @@ class SHGravCoeffs(object):
         tide_system : str, optional, default = 'unknown'
             The tide system for 'icgem' formatted files: 'zero_tide',
             'tide_free', or 'unknown'.
+        encoding : str, optional, default = None
+            Encoding of the output file when format is 'shtools', 'dov' or
+            'icgem'. The default is to use the system default.
         **kwargs : keyword argument list, optional for format = 'npy'
             Keyword arguments of numpy.save().
 
@@ -1352,10 +1360,12 @@ class SHGravCoeffs(object):
 
             if errors:
                 write_func(filebase, self.coeffs, errors=self.errors,
-                           header=header, header2=header2, lmax=lmax)
+                           header=header, header2=header2, lmax=lmax,
+                           encoding=encoding)
             else:
                 write_func(filebase, self.coeffs, errors=None,
-                           header=header, header2=header2, lmax=lmax)
+                           header=header, header2=header2, lmax=lmax,
+                           encoding=encoding)
 
         elif format.lower() == 'bshc':
             _write_bshc(filebase, self.coeffs, lmax=lmax)
@@ -1367,13 +1377,15 @@ class SHGravCoeffs(object):
                                  gm=self.gm, r0=self.r0,
                                  error_kind=self.error_kind,
                                  tide_system=tide_system,
-                                 normalization=self.normalization)
+                                 normalization=self.normalization,
+                                 encoding=encoding)
             else:
                 _write_icgem_gfc(filebase, self.coeffs, header=header,
                                  lmax=lmax, modelname=modelname,
                                  gm=self.gm, r0=self.r0,
                                  tide_system=tide_system,
-                                 normalization=self.normalization)
+                                 normalization=self.normalization,
+                                 encoding=encoding)
 
         elif format.lower() == 'npy':
             _np.save(filename, self.coeffs, **kwargs)

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -1191,6 +1191,8 @@ class SHGrid(object):
                 raise ValueError('Map projections are supported only for '
                                  'DH grid types.')
 
+        if ticks is None:
+            ticks = ''
         if tick_interval is None:
             tick_interval = [None, None]
         if minor_tick_interval is None:

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -336,7 +336,7 @@ class SHMagCoeffs(object):
                   normalization='schmidt', skip=0, header=True, header2=False,
                   errors=None, error_kind=None, csphase=1, r0_index=0,
                   header_units='m', file_units='nT', name=None, units='nT',
-                  year=None, **kwargs):
+                  year=None, encoding=None, **kwargs):
         """
         Initialize the class with spherical harmonic coefficients from a file.
 
@@ -345,10 +345,11 @@ class SHMagCoeffs(object):
         x = SHMagCoeffs.from_file(filename, [format='shtools' or 'dov', r0,
                                   lmax, normalization, csphase, skip, header,
                                   header2, errors, error_kind, r0_index,
-                                  header_units, file_units, name, units, year])
+                                  header_units, file_units, name, units, year,
+                                  encoding])
         x = SHMagCoeffs.from_file(filename, format='igrf', r0, year, [lmax,
                                   normalization, csphase, file_units, name,
-                                  units])
+                                  units, encoding])
         x = SHMagCoeffs.from_file(filename, format='bshc', r0, [lmax,
                                   normalization, csphase, file_units, name,
                                   units, year])
@@ -419,6 +420,9 @@ class SHMagCoeffs(object):
             formatted files.
         year : float, default = None.
             The year to compute the coefficients for 'igrf' formatted files.
+        encoding : str, optional, default = None
+            Encoding of the input file when format is 'shtools', 'dov' or
+            'igrf'. The default is to use the system default.
         **kwargs : keyword argument list, optional for format = 'npy'
             Keyword arguments of numpy.load() when format is 'npy'.
 
@@ -507,19 +511,21 @@ class SHMagCoeffs(object):
                         coeffs, error_coeffs, lmaxout, header_list, \
                             header2_list = read_func(fname, lmax=lmax,
                                                      skip=skip, header=True,
-                                                     header2=True, error=True)
+                                                     header2=True, error=True,
+                                                     encoding=encoding)
                     else:
                         coeffs, error_coeffs, lmaxout, header_list = read_func(
                             fname, lmax=lmax, skip=skip, header=True,
-                            error=True)
+                            error=True, encoding=encoding)
                 else:
                     if header2:
                         coeffs, lmaxout, header_list, header2_list = read_func(
                             fname, lmax=lmax, skip=skip, header=True,
-                            header2=True)
+                            header2=True, encoding=encoding)
                     else:
                         coeffs, lmaxout, header_list = read_func(
-                            fname, lmax=lmax, skip=skip, header=True)
+                            fname, lmax=lmax, skip=skip, header=True,
+                            encoding=encoding)
 
                 if r0_index is not None:
                     if header2:
@@ -532,9 +538,11 @@ class SHMagCoeffs(object):
             else:
                 if errors is True:
                     coeffs, error_coeffs, lmaxout = read_func(
-                        fname, lmax=lmax, error=True, skip=skip)
+                        fname, lmax=lmax, error=True, skip=skip,
+                        encoding=encoding)
                 else:
-                    coeffs, lmaxout = read_func(fname, lmax=lmax, skip=skip)
+                    coeffs, lmaxout = read_func(fname, lmax=lmax, skip=skip,
+                                                encoding=encoding)
 
             if errors is True and error_kind is None:
                 error_kind = 'unspecified'
@@ -550,7 +558,7 @@ class SHMagCoeffs(object):
                 raise ValueError('For igrf files, r0 must be specified.')
             if year is None:
                 raise ValueError('For igrf files, year must be specified.')
-            coeffs = _read_igrf(fname, year=year)
+            coeffs = _read_igrf(fname, year=year, encoding=encoding)
             lmaxout = coeffs.shape[1] - 1
             if lmax is not None:
                 if lmax < lmaxout:
@@ -929,14 +937,14 @@ class SHMagCoeffs(object):
 
     # ---- IO routines ----
     def to_file(self, filename, format='shtools', header=None, errors=True,
-                lmax=None, **kwargs):
+                lmax=None, encoding=None, **kwargs):
         """
         Save spherical harmonic coefficients to a file.
 
         Usage
         -----
-        x.to_file(filename, [format='shtools', header, errors])
-        x.to_file(filename, format='dov', [header, errors])
+        x.to_file(filename, [format='shtools', header, errors, encoding])
+        x.to_file(filename, format='dov', [header, errors, encoding])
         x.to_file(filename, format='bshc', [lmax])
         x.to_file(filename, format='npy', [**kwargs])
 
@@ -955,6 +963,9 @@ class SHMagCoeffs(object):
             formatted files only).
         lmax : int, optional, default = self.lmax
             The maximum spherical harmonic degree to write to the file.
+        encoding : str, optional, default = None
+            Encoding of the output file when format is 'shtools' or 'dov'. The
+            default is to use the system default.
         **kwargs : keyword argument list, optional for format = 'npy'
             Keyword arguments of numpy.save().
 
@@ -1025,10 +1036,12 @@ class SHMagCoeffs(object):
 
             if errors:
                 write_func(filebase, self.coeffs, errors=self.errors,
-                           header=header, header2=header2, lmax=lmax)
+                           header=header, header2=header2, lmax=lmax,
+                           encoding=encoding)
             else:
                 write_func(filebase, self.coeffs, errors=None,
-                           header=header, header2=header2, lmax=lmax)
+                           header=header, header2=header2, lmax=lmax,
+                           encoding=encoding)
 
         elif format.lower() == 'bshc':
             _write_bshc(filebase, self.coeffs, lmax=lmax)

--- a/pyshtools/shio/dov.py
+++ b/pyshtools/shio/dov.py
@@ -12,7 +12,7 @@ import shutil as _shutil
 
 
 def read_dov(filename, lmax=None, error=False, header=False, header2=False,
-             skip=0):
+             skip=0, encoding=None):
     """
     Read spherical harmonic coefficients from a text file formatted as
     [degree, order, value].
@@ -20,7 +20,8 @@ def read_dov(filename, lmax=None, error=False, header=False, header2=False,
     Usage
     -----
     coeffs, [errors], lmaxout, [header], [header2] = read_dov(
-        filename, [error=True, header=True, header2=True, lmax, skip])
+        filename, [error=True, header=True, header2=True, lmax, skip,
+        encoding])
 
     Returns
     -------
@@ -58,6 +59,8 @@ def read_dov(filename, lmax=None, error=False, header=False, header2=False,
         the start of the spherical harmonic coefficients.
     skip : int, optional, default = 0
         The number of lines to skip before parsing the file.
+    encoding : str, optional, default = None
+        Encoding of the input file. The default is to use the system default.
 
     Notes
     -----
@@ -171,15 +174,17 @@ def read_dov(filename, lmax=None, error=False, header=False, header2=False,
     # open file, skip lines, read header, determine lstart, and then read
     # coefficients one line at a time
     if _isurl(filename):
+        if encoding is not None:
+            _response.encoding = encoding
         f = _io.StringIO(_response.text)
         if filename[-4:] == '.zip':
-            f = _io.TextIOWrapper(zf.open(zf.namelist()[0]))
+            f = _io.TextIOWrapper(zf.open(zf.namelist()[0]), encoding=encoding)
     elif filename[-3:] == '.gz':
-        f = _gzip.open(filename, mode='rt')
+        f = _gzip.open(filename, mode='rt', encoding=encoding)
     elif filename[-4:] == '.zip':
-        f = _io.TextIOWrapper(zf.open(zf.namelist()[0]))
+        f = _io.TextIOWrapper(zf.open(zf.namelist()[0]), encoding=encoding)
     else:
-        f = open(filename, 'r')
+        f = open(filename, 'r', encoding=encoding)
 
     with f:
         if skip != 0:
@@ -340,14 +345,14 @@ def read_dov(filename, lmax=None, error=False, header=False, header2=False,
 
 
 def write_dov(filename, coeffs, errors=None, header=None, header2=None,
-              lmax=None):
+              lmax=None, encoding=None):
     """
     Write spherical harmonic coefficients to a text file formatted as
     [degree, order, value].
 
     Usage
     -----
-    write_dov(filename, coeffs, [errors, header, header2, lmax])
+    write_dov(filename, coeffs, [errors, header, header2, lmax, encoding])
 
     Parameters
     ----------
@@ -367,6 +372,8 @@ def write_dov(filename, coeffs, errors=None, header=None, header2=None,
         coefficients.
     lmax : int, optional, default = None
         The maximum spherical harmonic degree to write to the file.
+    encoding : str, optional, default = None
+        Encoding of the output file. The default is to use the system default.
 
     Notes
     -----
@@ -407,7 +414,7 @@ def write_dov(filename, coeffs, errors=None, header=None, header2=None,
     else:
         filebase = filename
 
-    with open(filebase, mode='w') as file:
+    with open(filebase, mode='w', encoding=encoding) as file:
         if header is not None:
             file.write(header + '\n')
         if header2 is not None:

--- a/pyshtools/shio/icgem.py
+++ b/pyshtools/shio/icgem.py
@@ -53,8 +53,7 @@ def read_icgem_gfc(filename, errors=None, lmax=None, epoch=None,
         If the format of the file is 'icgem2.0' then the epoch must be
         specified.
     encoding : str, optional
-        Encoding of the input file. Try to use 'iso-8859-1' if the default
-        (UTF-8) fails.
+        Encoding of the input file. Try to use 'iso-8859-1' if UTF-8 fails.
     """
     header = {}
     header_keys = ['modelname', 'product_type', 'earth_gravity_constant',

--- a/pyshtools/shio/icgem.py
+++ b/pyshtools/shio/icgem.py
@@ -52,8 +52,8 @@ def read_icgem_gfc(filename, errors=None, lmax=None, epoch=None,
         format. If None then the reference epoch t0 of the model will be used.
         If the format of the file is 'icgem2.0' then the epoch must be
         specified.
-    encoding : str, optional
-        Encoding of the input file. Try to use 'iso-8859-1' if UTF-8 fails.
+    encoding : str, optional, default = None
+        Encoding of the input file. The default is to use the system default.
     """
     header = {}
     header_keys = ['modelname', 'product_type', 'earth_gravity_constant',
@@ -70,18 +70,20 @@ def read_icgem_gfc(filename, errors=None, lmax=None, epoch=None,
                 raise Exception('read_icgem_gfc can only process zip archives '
                                 'that contain a single file. Archive '
                                 'contents:\n{}'.format(zf.namelist()))
-            f = _io.TextIOWrapper(zf.open(zf.namelist()[0]))
+            f = _io.TextIOWrapper(zf.open(zf.namelist()[0]), encoding=encoding)
         else:
+            if encoding is not None:
+                _response.encoding = encoding
             f = _io.StringIO(_response.text)
     elif filename[-3:] == '.gz':
-        f = _gzip.open(filename, mode='rt')
+        f = _gzip.open(filename, mode='rt', encoding=encoding)
     elif filename[-4:] == '.zip':
         zf = _zipfile.ZipFile(filename, 'r')
         if len(zf.namelist()) > 1:
             raise Exception('read_icgem_gfc can only process zip archives '
                             'that contain a single file. Archive contents: \n'
                             '{}'.format(zf.namelist()))
-        f = _io.TextIOWrapper(zf.open(zf.namelist()[0]))
+        f = _io.TextIOWrapper(zf.open(zf.namelist()[0]), encoding=encoding)
     else:
         f = open(filename, 'r', encoding=encoding)
 
@@ -210,7 +212,8 @@ def read_icgem_gfc(filename, errors=None, lmax=None, epoch=None,
 def write_icgem_gfc(filename, coeffs, errors=None, header=None, lmax=None,
                     modelname=None, product_type='gravity_field',
                     earth_gm=None, gm=None, r0=None, error_kind=None,
-                    tide_system='unknown', normalization='4pi', format=None):
+                    tide_system='unknown', normalization='4pi', format=None,
+                    encoding=None):
     """
     Write real spherical harmonic gravity coefficients to an ICGEM formatted
     file.
@@ -218,7 +221,8 @@ def write_icgem_gfc(filename, coeffs, errors=None, header=None, lmax=None,
     Usage
     -----
     write_icgem_gfc(filename, coeffs, [errors, header, lmax, modelname, gm, r0,
-        product_type, earth_gm, error_kind, tide_system, normalization, format)
+        product_type, earth_gm, error_kind, tide_system, normalization, format,
+        encoding)
 
     Parameters
     ----------
@@ -246,7 +250,7 @@ def write_icgem_gfc(filename, coeffs, errors=None, header=None, lmax=None,
     r0 : float
         Reference radius of the model, in meters.
     error_kind : str, optional, default = None
-        Which errors to read. Can be either 'unknown', 'calibrated', or
+        Which errors to write. Can be either 'unknown', 'calibrated', or
         'formal'.
     tide_system : str, optional, default = 'unknown'
         The tide system: 'zero_tide', 'tide_free', or 'unknown'.
@@ -255,6 +259,8 @@ def write_icgem_gfc(filename, coeffs, errors=None, header=None, lmax=None,
         or 'unnorm'.
     format : str, optional, default = None
         The format of the ICGEM spherical harmonic coefficients.
+    encoding : str, optional, default = None
+        Encoding of the output file. The default is to use the system default.
     """
     valid_err = ('unknown', 'calibrated', 'formal', 'calibrated_and_formal')
     valid_tide = ('zero_tide', 'tide_free', 'unknown')
@@ -283,7 +289,7 @@ def write_icgem_gfc(filename, coeffs, errors=None, header=None, lmax=None,
     else:
         filebase = filename
 
-    with open(filebase, mode='w') as file:
+    with open(filebase, mode='w', encoding=encoding) as file:
         if header is not None:
             file.write(header + '\n')
 

--- a/pyshtools/shio/read_igrf.py
+++ b/pyshtools/shio/read_igrf.py
@@ -9,7 +9,7 @@ import numpy as _np
 import requests as _requests
 
 
-def read_igrf(filename, year=2020.):
+def read_igrf(filename, year=2020., encoding=None):
     """
     Read IGRF real spherical harmonic coefficients, and return the magnetic
     potential coefficients for the specified year.
@@ -32,6 +32,8 @@ def read_igrf(filename, year=2020.):
         '.zip', the file will be uncompressed before parsing.
     year : float, optional, default = 2020.
         The year to compute the coefficients.
+    encoding : str, optional, default = None
+        Encoding of the input file. The default is to use the system default.
 
     Notes
     -----
@@ -57,20 +59,22 @@ def read_igrf(filename, year=2020.):
                 raise Exception('read_igrf can only process zip archives '
                                 'that contain a single file. Archive '
                                 'contents:\n{}'.format(zf.namelist()))
-            f = io.TextIOWrapper(zf.open(zf.namelist()[0]))
+            f = io.TextIOWrapper(zf.open(zf.namelist()[0]), encoding=encoding)
         else:
+            if encoding is not None:
+                _response.encoding = encoding
             f = io.StringIO(_response.text)
     elif filename[-3:] == '.gz':
-        f = gzip.open(filename, mode='rt')
+        f = gzip.open(filename, mode='rt', encoding=encoding)
     elif filename[-4:] == '.zip':
         zf = zipfile.ZipFile(filename, 'r')
         if len(zf.namelist()) > 1:
             raise Exception('read_igrf can only process zip archives '
                             'that contain a single file. Archive contents: \n'
                             '{}'.format(zf.namelist()))
-        f = io.TextIOWrapper(zf.open(zf.namelist()[0]))
+        f = io.TextIOWrapper(zf.open(zf.namelist()[0]), encoding=encoding)
     else:
-        f = open(filename, 'r')
+        f = open(filename, 'r', encoding=encoding)
 
     with f:
         lines = f.readlines()

--- a/pyshtools/shio/shtools.py
+++ b/pyshtools/shio/shtools.py
@@ -12,14 +12,15 @@ import shutil as _shutil
 
 
 def shread(filename, lmax=None, error=False, header=False, header2=False,
-           skip=0):
+           skip=0, encoding=None):
     """
     Read shtools-formatted spherical harmonic coefficients from a text file.
 
     Usage
     -----
     coeffs, [errors], lmaxout, [header], [header2] = shread(
-        filename, [error=True, header=True, header2=True, lmax, skip])
+        filename, [error=True, header=True, header2=True, lmax, skip,
+        encoding])
 
     Returns
     -------
@@ -57,6 +58,8 @@ def shread(filename, lmax=None, error=False, header=False, header2=False,
         the start of the spherical harmonic coefficients.
     skip : int, optional, default = 0
         The number of lines to skip before parsing the file.
+    encoding : str, optional, default = None
+        Encoding of the input file. The default is to use the system default.
 
     Notes
     -----
@@ -170,15 +173,17 @@ def shread(filename, lmax=None, error=False, header=False, header2=False,
     # open file, skip lines, read header, determine lstart, and then read
     # coefficients one line at a time
     if _isurl(filename):
+        if encoding is not None:
+            _response.encoding = encoding
         f = _io.StringIO(_response.text)
         if filename[-4:] == '.zip':
-            f = _io.TextIOWrapper(zf.open(zf.namelist()[0]))
+            f = _io.TextIOWrapper(zf.open(zf.namelist()[0]), encoding=encoding)
     elif filename[-3:] == '.gz':
-        f = _gzip.open(filename, mode='rt')
+        f = _gzip.open(filename, mode='rt', encoding=encoding)
     elif filename[-4:] == '.zip':
-        f = _io.TextIOWrapper(zf.open(zf.namelist()[0]))
+        f = _io.TextIOWrapper(zf.open(zf.namelist()[0]), encoding=encoding)
     else:
-        f = open(filename, 'r')
+        f = open(filename, 'r', encoding=encoding)
 
     with f:
         if skip != 0:
@@ -317,13 +322,13 @@ def shread(filename, lmax=None, error=False, header=False, header2=False,
 
 
 def shwrite(filename, coeffs, errors=None, header=None, header2=None,
-            lmax=None):
+            lmax=None, encoding=None):
     """
     Write shtools-formatted spherical harmonic coefficients to a text file.
 
     Usage
     -----
-    shwrite(filename, coeffs, [errors, header, header2, lmax])
+    shwrite(filename, coeffs, [errors, header, header2, lmax, encoding])
 
     Parameters
     ----------
@@ -343,6 +348,8 @@ def shwrite(filename, coeffs, errors=None, header=None, header2=None,
         coefficients.
     lmax : int, optional, default = None
         The maximum spherical harmonic degree to write to the file.
+    encoding : str, optional, default = None
+        Encoding of the output file. The default is to use the system default.
 
     Notes
     -----
@@ -380,7 +387,7 @@ def shwrite(filename, coeffs, errors=None, header=None, header2=None,
     else:
         filebase = filename
 
-    with open(filebase, mode='w') as file:
+    with open(filebase, mode='w', encoding=encoding) as file:
         if header is not None:
             file.write(header + '\n')
         if header2 is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 scipy>=0.14.0
 matplotlib>=3.3
-astropy
+astropy>=4.0
 xarray
 requests
 pooch>=1.1

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ INSTALL_REQUIRES = [
     'numpy>=' + str(numpy.__version__),
     'scipy>=0.14.0',
     'matplotlib>=3.3',
-    'astropy',
+    'astropy>=4.0',
     'xarray',
     'requests',
     'pooch>=1.1',


### PR DESCRIPTION
* Update `makefile install` to include example data files, and to place in the correct directories for homebrew.
* Update dependencies, including `astropy>=4.0`.
* Add the option `encoding` for all routines and methods that read or write text-based spherical harmonic files.
* Hard coded all datasets to use `utf-8` in order to avoid problems with the XGM2019E dataset that has a character that can not be decoded by the GBK encoding that is the default in some Chinese installations.
* Update Venus rotation period using data from Margot et al. (2021).


