### PR TITLE
Improve the reading of ICGEM formatted files

### DIFF
--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -382,7 +382,7 @@ class SHGravCoeffs(object):
                   header=True, header2=False, errors=None, error_kind=None,
                   csphase=1, r0_index=0, gm_index=1, omega_index=None,
                   header_units='m', set_degree0=True, name=None, epoch=None,
-                  encoding=None, **kwargs):
+                  encoding=None, quiet=False, **kwargs):
         """
         Initialize the class with spherical harmonic coefficients from a file.
 
@@ -395,7 +395,7 @@ class SHGravCoeffs(object):
                                    header_units, set_degree0, name, encoding])
         x = SHGravCoeffs.from_file(filename, format='icgem', [lmax, omega,
                                    normalization, csphase, errors, set_degree0,
-                                   name, name, epoch, encoding])
+                                   name, name, epoch, encoding, quiet])
         x = SHGravCoeffs.from_file(filename, format='bshc', gm, r0, [lmax,
                                    omega, normalization, csphase, set_degree0,
                                    name])
@@ -483,6 +483,9 @@ class SHGravCoeffs(object):
         encoding : str, optional, default = None
             Encoding of the input file when format is 'shtools', 'dov' or
             'icgem'. The default is to use the system default.
+        quiet : bool, default = False
+            If True, suppress warnings about undefined keywords when reading
+            ICGEM formatted files.
         **kwargs : keyword argument list, optional for format = 'npy'
             Keyword arguments of numpy.load() when format is 'npy'.
 
@@ -626,11 +629,12 @@ class SHGravCoeffs(object):
                 coeffs, gm, r0 = _read_icgem_gfc(filename=fname,
                                                  errors=None, lmax=lmax,
                                                  epoch=epoch,
-                                                 encoding=encoding)
+                                                 encoding=encoding,
+                                                 quiet=quiet)
             elif errors in valid_err:
                 coeffs, gm, r0, error_coeffs = _read_icgem_gfc(
                     filename=fname, errors=errors, lmax=lmax, epoch=epoch,
-                    encoding=encoding)
+                    encoding=encoding, quiet=quiet)
                 error_kind = errors
             else:
                 raise ValueError('errors must be among: {}. '

--- a/pyshtools/shio/icgem.py
+++ b/pyshtools/shio/icgem.py
@@ -67,7 +67,7 @@ def read_icgem_gfc(filename, errors=None, lmax=None, epoch=None,
     and the reference radius. If epoch is specified, the coefficients will make
     use of the time variable terms in order to compute and return the potential
     coefficients for the specified epoch. Otherwise, the coefficients will be
-    returned for the the reference epoch of the model.
+    returned for the reference epoch of the model.
 
     Valid keys in the header section include:
         modelname (not used)
@@ -131,7 +131,7 @@ def read_icgem_gfc(filename, errors=None, lmax=None, epoch=None,
 
         if header['product_type'] != 'gravity_field':
             raise ValueError(
-                'This function reads only gravity_field data product.')
+                'This routine reads only gravity_field data products.')
 
         is_v2 = False
         if 'format' in header and header['format'] == 'icgem2.0':
@@ -139,7 +139,7 @@ def read_icgem_gfc(filename, errors=None, lmax=None, epoch=None,
 
         if epoch is None and is_v2:
             raise ValueError(
-                'Epoch must be specified for the "icgem2.0" format.')
+                'epoch must be specified for the "icgem2.0" format.')
         elif epoch is not None:
             epoch = _yyyymmdd_to_year_fraction(epoch)
 
@@ -164,7 +164,7 @@ def read_icgem_gfc(filename, errors=None, lmax=None, epoch=None,
                 raise ValueError('This model has no errors.')
             elif errors not in valid_err[:-1]:
                 raise ValueError(
-                    'Errors can be either "unknown", "formal", "calibrated" '
+                    'errors can be either "unknown", "formal", "calibrated" '
                     'or None.')
             elif header['errors'] in valid_err and errors in valid_err[:-1]:
                 if (errors, header['errors']) == valid_err[2:]:
@@ -183,7 +183,7 @@ def read_icgem_gfc(filename, errors=None, lmax=None, epoch=None,
         # read coefficients
         for line in f:
             line = line.lower().strip().split()
-            for i in range(3, len(line)):
+            for i in range(1, len(line)):
                 line[i] = line[i].replace('d', 'e')
 
             l, m = int(line[1]), int(line[2])
@@ -206,7 +206,7 @@ def read_icgem_gfc(filename, errors=None, lmax=None, epoch=None,
                     t0i = _yyyymmdd_to_year_fraction(line[-2])
                     t1i = _yyyymmdd_to_year_fraction(line[-1])
                     if not t0i <= epoch < t1i:
-                        raise ValueError('Warning: epoch is not in the valid '
+                        raise ValueError('epoch is not in the valid '
                                          'time interval of the model.')
                 else:
                     t0i = _yyyymmdd_to_year_fraction(line[-1])
@@ -218,7 +218,7 @@ def read_icgem_gfc(filename, errors=None, lmax=None, epoch=None,
                     t0i = _yyyymmdd_to_year_fraction(line[-2])
                     t1i = _yyyymmdd_to_year_fraction(line[-1])
                     if not t0i <= epoch < t1i:
-                        raise ValueError('Warning: epoch is not in the valid '
+                        raise ValueError('epoch is not in the valid '
                                          'time interval of the model.')
                 trnd[:, l, m] = value_cs
             elif key in ('acos', 'asin'):
@@ -226,7 +226,7 @@ def read_icgem_gfc(filename, errors=None, lmax=None, epoch=None,
                     t0i = _yyyymmdd_to_year_fraction(line[-3])
                     t1i = _yyyymmdd_to_year_fraction(line[-2])
                     if not t0i <= epoch < t1i:
-                        raise ValueError('Warning: epoch is not in the valid '
+                        raise ValueError('epoch is not in the valid '
                                          'time interval of the model.')
 
                 period = float(line[-1])


### PR DESCRIPTION
This PR improves the reading of ICGEM formatted files of gravitational potential models:
* The time variable contribution was not computed when the coefficients had an associated `trnd` or `dot` term. This was because each `d` was replaced with an `e` for compatibility when parsing floating point numbers, but this modified the key of the line, which was then not recognized and ignored. This has been fixed by not making the string replacement for the first entry.
* When a line in the data section starts with an unknown key, a warning is printed to the screen, informing that the line will be ignored. This warning can be turned off by specifying `quiet=True`.
* For files formatted as `icgem2.0`, time variable terms were simply ignored if the specified epoch fell outside of the allowed range. Now, the routine will instead raise an error.
* Improved documentation is provided, describing the allowable keyword entries of the header and data section of the file.

Fixes: https://github.com/SHTOOLS/SHTOOLS/issues/299