### PR TITLE
Fix 2 bugs with complex spherical harmonic transforms

### DIFF
--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -2189,7 +2189,8 @@ class DHComplexGrid(SHGrid):
 
         cilm = _shtools.SHExpandDHC(self.data[:self.nlat-self.extend,
                                               :self.nlon-self.extend],
-                                    norm=norm, csphase=csphase, **kwargs)
+                                    norm=norm, csphase=csphase,
+                                    sampling=self.sampling, **kwargs)
         coeffs = SHCoeffs.from_array(cilm, normalization=normalization.lower(),
                                      csphase=csphase, units=self.units,
                                      copy=False)

--- a/src/SHExpandDHC.f95
+++ b/src/SHExpandDHC.f95
@@ -669,7 +669,7 @@ subroutine SHExpandDHC(grid, n, cilm, lmax, norm, sampling, csphase, &
                       / sqr(2*lmax_comp) * rescalem
             case(2);    pmm = phase * pmm / sqr(2*lmax_comp) * rescalem
             case(3);    pmm = phase * pmm * (2*lmax_comp-1) * rescalem
-    
+
         end select
 
         cilm(1,lmax_comp+1,lmax_comp+1) = cilm(1,lmax_comp+1,lmax_comp+1) &
@@ -677,7 +677,8 @@ subroutine SHExpandDHC(grid, n, cilm, lmax, norm, sampling, csphase, &
                                           fcoef2(lmax_comp+1))
         cilm(2,lmax_comp+1,lmax_comp+1) = cilm(2,lmax_comp+1,lmax_comp+1) &
                                           + pmm * (fcoef1(nlong-(lmax_comp-1))&
-                                          + fcoef2(nlong-(lmax_comp-1)))
+                                          + fcoef2(nlong-(lmax_comp-1)))&
+                                          * ((-1)**mod(lmax_comp,2))
                                           ! fsymsign = 1
 
     end do


### PR DESCRIPTION
This PR fixes 2 bugs related to complex spherical harmonic transforms.

The first regards the Fortran routine `SHExpandDHC` and hence affects both shtools and pyshtools. For complex grids, the **last** coefficient `coeffs[1, lmax, lmax]` was in error only when `lmax` was odd. The origin of this is a missing (-1)^m factor that should have been applied to a term.

The second regards the `SHGrid.expand()` routine for complex data with grid type `DH2`. The origin of this error is that the parameter `sampling=2` was not passed to the Fortran routine. The spherical harmonic coefficients for this case were all wrong, and this should have been obvious by simple inspection.

Fixes: https://github.com/SHTOOLS/SHTOOLS/issues/300