### PR TITLE
patched a floating point error-caused bug (arccos of value >= 1)

### DIFF
--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -362,8 +362,9 @@ class SHGrid(object):
             sinlat = _np.sin(lats[i])
             for j in range(0, temp.nlon):
                 dist = coslat * (x * coslon[j] + y * sinlon[j]) + z * sinlat
-                if dist <= costheta: # ie. _np.arccos(dist) <= theta 
+                if dist >= costheta: # ie. _np.arccos(dist) <= theta 
                     #since 0 <= theta <= pi/2 and 0 <= dist <= 1
+                    #so cos is decreasing
                     temp.data[i, j] = 1.
 
         return temp

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -360,7 +360,7 @@ class SHGrid(object):
             coslat = _np.cos(lats[i])
             sinlat = _np.sin(lats[i])
             for j in range(0, temp.nlon):
-                dist = min(coslat * (x * coslon[j] + y * sinlon[j]) + z * sinlat, 1.)
+                dist = coslat * (x * coslon[j] + y * sinlon[j]) + z * sinlat
                 if _np.arccos(dist) <= theta:
                     temp.data[i, j] = 1.
 

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -360,7 +360,7 @@ class SHGrid(object):
             coslat = _np.cos(lats[i])
             sinlat = _np.sin(lats[i])
             for j in range(0, temp.nlon):
-                dist = coslat * (x * coslon[j] + y * sinlon[j]) + z * sinlat
+                dist = min(coslat * (x * coslon[j] + y * sinlon[j]) + z * sinlat, 1.)
                 if _np.arccos(dist) <= theta:
                     temp.data[i, j] = 1.
 

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -356,12 +356,14 @@ class SHGrid(object):
 
         coslon = _np.cos(lons)
         sinlon = _np.sin(lons)
+        costheta = _np.cos(theta)
         for i in range(imin, imax+1):
             coslat = _np.cos(lats[i])
             sinlat = _np.sin(lats[i])
             for j in range(0, temp.nlon):
                 dist = coslat * (x * coslon[j] + y * sinlon[j]) + z * sinlat
-                if _np.arccos(dist) <= theta:
+                if dist <= costheta: # ie. _np.arccos(dist) <= theta 
+                    #since 0 <= theta <= pi/2 and 0 <= dist <= 1
                     temp.data[i, j] = 1.
 
         return temp


### PR DESCRIPTION
Hi !
I just encountered a small bug in the python code, so I wrote a simple fix, if you want to merge it

Basically on rare cases, in `shgrid.from_cap`, when calculating `dist`, floating-point calculation errors could give a result slightly superior to 1 (I had `1.0000000000000002`). In that case, the `arccos` at the following line will output `NaN`, and may raise an exception (if `numpy` is configured to do so, see [numpy.seterr](https://numpy.org/doc/stable/reference/generated/numpy.seterr.html) ).

So what I did was cap that value to `1.` (see the changelog)

