### PR TITLE
Small fixes

### DIFF
--- a/docs/pages/mydoc/python-datasets-constants.md
+++ b/docs/pages/mydoc/python-datasets-constants.md
@@ -22,9 +22,9 @@ table:nth-of-type(n) th:nth-of-type(2) {
 
 The *constants* subpackage defines physical constants related to the terrestrial planets and moons. Each constant is an instance of an [astropy](http://docs.astropy.org/en/stable/constants/index.html) `Constant` class, which has the attributes `name`, `value`, `uncertainty`, `unit`, and `reference`.
 
-The pyshtools constants are organized primarily by planet: Mercury, Venus, Earth, Moon, and Mars. Each planet has several attributes, such as the the mean planetary radius `r`, `mass`, and flattening `f`. To see all information about an individual constant, it is only necessary to use the print function:
+The pyshtools constants are organized primarily by planet: Mercury, Venus, Earth, Moon, and Mars. Each planet has several attributes, such as `mean_radius` (aliased as `r`), `mass`, and flattening `f`. To see all information about an individual constant, it is only necessary to use the print function:
 ```python
-In [1]: print(pysh.constants.Mars.r)
+In [1]: print(pysh.constants.Mars.mean_radius)
   Name   = Mean radius of Mars
   Value  = 3389500.0
   Uncertainty  = 0.0
@@ -34,7 +34,7 @@ In [1]: print(pysh.constants.Mars.r)
 To use the value of a constant in a calculation, it is only necessary to access its `value` attribute:
 
 ```python
-In [2]: 2 * pysh.constants.Mars.r.value
+In [2]: 2 * pysh.constants.Mars.mean_radius.value
 6779000.0
 ```
 Physical constants from the *Committee on Data for Science and Technology* are provided in the submodule `codata`. A few of these (such as `G` and `mu0`) are referenced in the main constants namespace.

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
     - tqdm
     - cartopy>=0.18.0
     - gmt>=6.1.1
-    - pygmt>=0.2.0
+    - pygmt>=0.3.0
     - palettable>=3.3
     - jupyter
     - pypandoc

--- a/examples/notebooks/grids-and-coefficients.ipynb
+++ b/examples/notebooks/grids-and-coefficients.ipynb
@@ -472,7 +472,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Calculating the spherical harmonic coefficients from a grid is as easy as expanding the coefficients onto a grid:"
+    "Transforming gridded data into spherical harmonic coefficients is as easy as transforming spherical harmonic coefficients into a grid. To do this, we use the `expand()` method of the `SHGrid` class instance, which is analogous to using the `expand()` method of the `SHCoeffs` class instance to generate a grid from a set of coefficients):"
    ]
   },
   {
@@ -623,7 +623,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -637,7 +637,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/examples/python/GravMag/TestGrav.py
+++ b/examples/python/GravMag/TestGrav.py
@@ -110,7 +110,7 @@ def TestGravGrad():
 
 def TestFilter():
     half = 80
-    r = constants.Moon.r.value
+    r = constants.Moon.mean_radius.value
     d = r - 40.e3
     deglist = np.arange(1, 200, 1)
     wl = np.zeros(len(deglist) + 1)
@@ -134,7 +134,8 @@ def TestMakeMagGrid():
     infile = '../../ExampleDataFiles/FSU_mars90.sh'
     clm, lmax, header = shio.shread(infile, header=True, skip=1)
     r0 = float(header[0]) * 1.e3
-    a = constants.Mars.r.value + 145.0e3  # radius to evaluate the field
+    a = constants.Mars.mean_radius.value + 145.0e3  # radius to evaluate the
+                                                    # field
 
     rad, theta, phi, total, pot = gravmag.MakeMagGridDH(
         clm, r0, lmax=719, a=a, f=constants.Mars.f.value, lmax_calc=90)

--- a/pyshtools/constants/Mars.py
+++ b/pyshtools/constants/Mars.py
@@ -30,7 +30,7 @@ mass = _Constant(
                          ),
     reference='Derived from gm_mars and G.')
 
-r = _Constant(
+mean_radius = _Constant(
     abbrev='r_mars',
     name='Mean radius of Mars',
     value=3389.500e3,
@@ -41,16 +41,18 @@ r = _Constant(
     '(Eds.), Treatise on Geophysics, 2nd ed., Vol. 10, pp. 153-193). '
     'Oxford, Elsevier-Pergamon, doi:10.1016/B978-0-444-53802-4.00169-X.')
 
+r = mean_radius
+
 density = _Constant(
     abbrev='density_mars',
     name='Mean density of Mars',
-    value=3 * mass.value / (_np.pi * 4 * r.value**3),
+    value=3 * mass.value / (_np.pi * 4 * mean_radius.value**3),
     unit='kg / m3',
     uncertainty=_np.sqrt((3 * mass.uncertainty /
-                         (_np.pi * 4 * r.value**3))**2
+                         (_np.pi * 4 * mean_radius.value**3))**2
                          + (3 * 3 * mass.value *
-                         r.uncertainty /
-                         (_np.pi * 4 * r.value**4))**2
+                         mean_radius.uncertainty /
+                         (_np.pi * 4 * mean_radius.value**4))**2
                          ),
     reference='Derived from mass_mars and r_mars.')
 
@@ -58,11 +60,11 @@ g0 = _Constant(
     abbrev='g0_mars',
     name='Mean surface gravity of Mars at mean planetary radius, '
     'ignoring rotation and tides',
-    value=gm.value / r.value**2,
+    value=gm.value / mean_radius.value**2,
     unit='m / s2',
-    uncertainty=_np.sqrt((gm.uncertainty / r.value**2)**2
-                         + (2 * gm.value * r.uncertainty
-                         / r.value**3)**2
+    uncertainty=_np.sqrt((gm.uncertainty / mean_radius.value**2)**2
+                         + (2 * gm.value * mean_radius.uncertainty
+                         / mean_radius.value**3)**2
                          ),
     reference='Derived from gm_mars and r_mars.')
 
@@ -125,4 +127,5 @@ u0 = _Constant(
     'the planet Mars. Earth, Moon, and Planets, 106, 1-13, '
     'doi:10.1007/s11038-009-9342-7.')
 
-__all__ = ['gm', 'mass', 'r', 'density', 'g0', 'omega', 'a', 'b', 'f', 'u0']
+__all__ = ['gm', 'mass', 'mean_radius', 'r', 'density', 'g0', 'omega', 'a',
+           'b', 'f', 'u0']

--- a/pyshtools/constants/Mercury.py
+++ b/pyshtools/constants/Mercury.py
@@ -32,7 +32,7 @@ mass = _Constant(
                          ),
     reference='Derived from gm_mercury and G.')
 
-r = _Constant(
+mean_radius = _Constant(
     abbrev='r_mercury',
     name='Mean radius of Mercury',
     value=2439.40197456433e3,
@@ -45,27 +45,29 @@ r = _Constant(
     '(2012). Gravity field and internal structure of Mercury from '
     'MESSENGER. Science, 336, 214-217, doi:10.1126/science.1218809.')
 
+r = mean_radius
+
 density = _Constant(
     abbrev='density_mercury',
     name='Mean density of Mercury',
-    value=3 * mass.value / (_np.pi * 4 * r.value**3),
+    value=3 * mass.value / (_np.pi * 4 * mean_radius.value**3),
     unit='kg / m3',
     uncertainty=_np.sqrt((3 * mass.uncertainty /
-                         (_np.pi * 4 * r.value**3))**2
+                         (_np.pi * 4 * mean_radius.value**3))**2
                          + (3 * 3 * mass.value *
-                         r.uncertainty /
-                         (_np.pi * 4 * r.value**4))**2
+                         mean_radius.uncertainty /
+                         (_np.pi * 4 * mean_radius.value**4))**2
                          ),
     reference='Derived from mass_mercury and r_mercury.')
 
 g0 = _Constant(
     abbrev='g0_mercury',
     name='Surface gravity of Mercury, ignoring rotation and tides',
-    value=gm.value / r.value**2,
+    value=gm.value / mean_radius.value**2,
     unit='m / s2',
-    uncertainty=_np.sqrt((gm.uncertainty / r.value**2)**2
-                         + (2 * gm.value * r.uncertainty
-                         / r.value**3)**2
+    uncertainty=_np.sqrt((gm.uncertainty / mean_radius.value**2)**2
+                         + (2 * gm.value * mean_radius.uncertainty
+                         / mean_radius.value**3)**2
                          ),
     reference='Derived from gm_mercury and r_mercury.')
 
@@ -93,4 +95,5 @@ omega_orbit = _Constant(
     'from MESSENGER observations after three years in orbit, J. Geophys. '
     'Res. Planets, 119, 2417-2436, doi:10.1002/2014JE004675.')
 
-__all__ = ['gm', 'mass', 'r', 'density', 'g0', 'omega', 'omega_orbit']
+__all__ = ['gm', 'mass', 'mean_radius', 'r', 'density', 'g0', 'omega',
+           'omega_orbit']

--- a/pyshtools/constants/Moon.py
+++ b/pyshtools/constants/Moon.py
@@ -34,7 +34,7 @@ mass = _Constant(
                          ),
     reference='Derived from gm_moon and G.')
 
-r = _Constant(
+mean_radius = _Constant(
     abbrev='r_moon',
     name='Mean radius of the Moon',
     value=1737151.0,
@@ -45,27 +45,29 @@ r = _Constant(
     'Treatise on Geophysics, 2nd ed., Vol. 10, pp. 153-193). Oxford, '
     'Elsevier-Pergamon, doi:10.1016/B978-0-444-53802-4.00169-X.')
 
+r = mean_radius
+
 density = _Constant(
     abbrev='density_moon',
     name='Mean density of the Moon',
-    value=3 * mass.value / (_np.pi * 4 * r.value**3),
+    value=3 * mass.value / (_np.pi * 4 * mean_radius.value**3),
     unit='kg / m3',
     uncertainty=_np.sqrt((3 * mass.uncertainty /
-                         (_np.pi * 4 * r.value**3))**2
+                         (_np.pi * 4 * mean_radius.value**3))**2
                          + (3 * 3 * mass.value *
-                         r.uncertainty /
-                         (_np.pi * 4 * r.value**4))**2
+                         mean_radius.uncertainty /
+                         (_np.pi * 4 * mean_radius.value**4))**2
                          ),
     reference='Derived from mass_moon and r_moon.')
 
 g0 = _Constant(
     abbrev='g0_moon',
     name='Surface gravity of the Moon, ignoring rotation and tides',
-    value=gm.value / r.value**2,
+    value=gm.value / mean_radius.value**2,
     unit='m / s2',
-    uncertainty=_np.sqrt((gm.uncertainty / r.value**2)**2
-                         + (2 * gm.value * r.uncertainty
-                         / r.value**3)**2
+    uncertainty=_np.sqrt((gm.uncertainty / mean_radius.value**2)**2
+                         + (2 * gm.value * mean_radius.uncertainty
+                         / mean_radius.value**3)**2
                          ),
     reference='Derived from gm_moon and r_moon.')
 
@@ -137,5 +139,5 @@ gamma = _Constant(
     'Lunar interior properties from the GRAIL mission, J. Geophys. Res. '
     'Planets, 119, 1546-1578, doi:10.1002/2013JE004559.')
 
-__all__ = ['gm', 'mass', 'r', 'density', 'g0', 'a_orbit', 'omega', 'i_solid',
-           'beta', 'gamma']
+__all__ = ['gm', 'mass', 'mean_radius', 'r', 'density', 'g0', 'a_orbit',
+           'omega', 'i_solid', 'beta', 'gamma']

--- a/pyshtools/constants/Venus.py
+++ b/pyshtools/constants/Venus.py
@@ -29,7 +29,7 @@ mass = _Constant(
                          ),
     reference='Derived from gm_venus and G.')
 
-r = _Constant(
+mean_radius = _Constant(
     abbrev='r_venus',
     name='Mean radius of Venus',
     value=6051.878e3,
@@ -40,27 +40,29 @@ r = _Constant(
     '(Eds.), Treatise on Geophysics, 2nd ed., Vol. 10, pp. 153-193). '
     'Oxford, Elsevier-Pergamon, doi:10.1016/B978-0-444-53802-4.00169-X.')
 
+r = mean_radius
+
 density = _Constant(
     abbrev='density_venus',
     name='Mean density of Venus',
-    value=3 * mass.value / (_np.pi * 4 * r.value**3),
+    value=3 * mass.value / (_np.pi * 4 * mean_radius.value**3),
     unit='kg / m3',
     uncertainty=_np.sqrt((3 * mass.uncertainty /
-                         (_np.pi * 4 * r.value**3))**2
+                         (_np.pi * 4 * mean_radius.value**3))**2
                          + (3 * 3 * mass.value *
-                         r.uncertainty /
-                         (_np.pi * 4 * r.value**4))**2
+                         mean_radius.uncertainty /
+                         (_np.pi * 4 * mean_radius.value**4))**2
                          ),
     reference='Derived from mass_venus and r_venus.')
 
 g0 = _Constant(
     abbrev='g0_venus',
     name='Surface gravity of Venus, ignoring rotation and tides',
-    value=gm.value / r.value**2,
+    value=gm.value / mean_radius.value**2,
     unit='m / s2',
-    uncertainty=_np.sqrt((gm.uncertainty / r.value**2)**2
-                         + (2 * gm.value * r.uncertainty
-                         / r.value**3)**2
+    uncertainty=_np.sqrt((gm.uncertainty / mean_radius.value**2)**2
+                         + (2 * gm.value * mean_radius.uncertainty
+                         / mean_radius.value**3)**2
                          ),
     reference='Derived from gm_venus and r_venus.')
 
@@ -75,4 +77,4 @@ omega = _Constant(
     'inertia of Venus (2021), Nature Astronomy, '
     'doi:10.1038/s41550-021-01339-7.')
 
-__all__ = ['gm', 'mass', 'r', 'gm', 'density', 'omega']
+__all__ = ['gm', 'mass', 'mean_radius', 'r', 'gm', 'density', 'omega']

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -2093,7 +2093,7 @@ class DHRealGrid(SHGrid):
             if colorbar is not None:
                 if shading is not None:
                     figure.colorbar(position=position, frame=cb_str,
-                                    I=shading_amplitude)
+                                    shading=shading_amplitude)
                 else:
                     figure.colorbar(position=position, frame=cb_str)
 

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -975,9 +975,9 @@ class SHGrid(object):
             ax3d = fig.add_subplot(1, 1, 1, projection='3d')
         else:
             fig = ax.get_figure()
-            geometry = ax.get_geometry()
+            subplotspec = ax.get_subplotspec()
             ax.remove()
-            ax3d = fig.add_subplot(*geometry, projection='3d')
+            ax3d = fig.add_subplot(subplotspec, projection='3d')
 
         if self.kind == 'real':
             data = self.data
@@ -1679,9 +1679,9 @@ class DHRealGrid(SHGrid):
         else:
             if projection is not None:
                 fig = ax.get_figure()
-                geometry = ax.get_geometry()
+                subplotspec = ax.get_subplotspec()
                 ax.remove()
-                axes = fig.add_subplot(*geometry, projection=projection)
+                axes = fig.add_subplot(subplotspec, projection=projection)
             else:
                 axes = ax
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,5 +7,5 @@ pyshp
 six
 shapely
 cartopy>=0.18.0
-pygmt>=0.2
+pygmt>=0.3
 flake8


### PR DESCRIPTION
* Replace deprecated matplotlib `get_geometry` with `get_subplotspec`.
* Replace pygmt option `I` with alias `shading` for colorbars (requires pygmt 0.3).
* Rename `constants` variables `r` to `mean_radius` (but keep `r` as an alias for backwards compatibility).

