### PR TITLE
Change default behavior of MakeGradientDH and SHCoeffs.gradient

### DIFF
--- a/pyshtools/shclasses/shcoeffs.py
+++ b/pyshtools/shclasses/shcoeffs.py
@@ -2171,7 +2171,7 @@ class SHCoeffs(object):
 
     # ---- Compute the horizontal gradient ----
     def gradient(self, grid='DH2', lmax=None, lmax_calc=None, units=None,
-                 extend=True):
+                 extend=True, radius=None):
         """
         Compute the horizontal gradient of the function and return an
         SHGradient class instance.
@@ -2200,11 +2200,10 @@ class SHCoeffs(object):
         extend : bool, optional, default = True
             If True, compute the longitudinal band for 360 E (DH and GLQ grids)
             and the latitudinal band for 90 S (DH grids only).
+        radius : float, optional, default = 1.0
+            The radius of the sphere used when computing the gradient of the
+            function.
 
-        Notes
-        -----
-        The gradient is evaluated using the radius given by the degree 0
-        coefficient of the function.
         """
         if lmax is None:
             lmax = self.lmax
@@ -2218,11 +2217,11 @@ class SHCoeffs(object):
         if grid.upper() in ('DH', 'DH1'):
             gradientout = self._gradientDH(sampling=1, lmax=lmax,
                                            lmax_calc=lmax_calc, units=units,
-                                           extend=extend)
+                                           extend=extend, radius=radius)
         elif grid.upper() == 'DH2':
             gradientout = self._gradientDH(sampling=2, lmax=lmax,
                                            lmax_calc=lmax_calc, units=units,
-                                           extend=extend)
+                                           extend=extend, radius=radius)
         elif grid.upper() == 'GLQ':
             raise NotImplementedError('gradient() does not support the use '
                                       'of GLQ grids.')
@@ -4074,13 +4073,14 @@ class SHRealCoeffs(SHCoeffs):
                              'ndarray, or list. Input types are {:s} and {:s}.'
                              .format(repr(type(lat)), repr(type(lon))))
 
-    def _gradientDH(self, sampling, lmax, lmax_calc, units, extend):
+    def _gradientDH(self, sampling, lmax, lmax_calc, units, extend, radius):
         """Evaluate the gradient on a Driscoll and Healy (1994) grid."""
         from .shgradient import SHGradient
 
         theta, phi = _shtools.MakeGradientDH(
             self.to_array(normalization='4pi', csphase=1, errors=False),
-            sampling=sampling, lmax=lmax, lmax_calc=lmax_calc, extend=extend)
+            sampling=sampling, lmax=lmax, lmax_calc=lmax_calc, extend=extend,
+            radius=radius)
 
         return SHGradient(theta, phi, lmax, lmax_calc, units=units)
 

--- a/src/MakeGradientDH.f95
+++ b/src/MakeGradientDH.f95
@@ -1,16 +1,17 @@
 subroutine MakeGradientDH(cilm, lmax, theta_grid, phi_grid, n, sampling, &
-                          lmax_calc, extend, exitstatus)
+                          lmax_calc, extend, radius, exitstatus)
 !------------------------------------------------------------------------------
 !
 !   Given the spherical harmonic coefficients CILM of a scalar function defined
 !   on the sphere, this subroutine will compute the horizontal gradient of the
-!   function, and return 2D Driscol and Healy sampled grids for the theta and
-!   phi vector components. The gradient is given by the formula:
+!   function on the unit sphere, and return 2D Driscol and Healy sampled grids
+!   for the theta and phi vector components. The gradient is given by the
+!   formula:
 !
 !       Grad F = 1/r dF/theta theta-hat + 1/(r sin theta) dF/dphi phi-hat
 !
-!   where theta is colatitude and phi is longitude. The radius r is taken from
-!   the degree zero coefficient of the function CILM(1,1,1).
+!   where theta is colatitude and phi is longitude. The radius r is by default
+!   set to 1, but this can be modified by use of the optional parameter RADIUS.
 !
 !   The output grids contain N samples in latitude and longitude by default,
 !   but if the optional parameter SAMPLING is set to 2, the grids will contain
@@ -41,6 +42,9 @@ subroutine MakeGradientDH(cilm, lmax, theta_grid, phi_grid, n, sampling, &
 !           extend      If 1, return a grid that contains an additional column
 !                       and row corresponding to 360 E longitude and 90 S
 !                       latitude, respectively.
+!           radius      The radius of the sphere used when computing the
+!                       gradient of the function. If not specified, the radius
+!                       will be set to 1.
 !
 !       OUT
 !           theta_grid  Gridded expansaion of the theta component of the
@@ -83,6 +87,7 @@ subroutine MakeGradientDH(cilm, lmax, theta_grid, phi_grid, n, sampling, &
     integer(int32), intent(out) :: n
     integer(int32), intent(in), optional :: sampling, lmax_calc, extend
     integer(int32), intent(out), optional :: exitstatus
+    real(dp), intent(in), optional :: radius
     integer(int32) :: l, m, i, l1, m1, lmax_comp, i_eq, i_s, astat(4), nlong, &
                       nlat_out, nlong_out, extend_grid
     real(dp) :: grid(4*lmax+4), pi, theta, scalef, rescalem, u, p, dpl, pmm, &
@@ -208,8 +213,12 @@ subroutine MakeGradientDH(cilm, lmax, theta_grid, phi_grid, n, sampling, &
 
     end if
 
-    r = cilm(1,1,1)  ! set the radius equal to the degree 0 term of the
-                     ! function.
+    if (present(radius)) then
+        r = radius
+    else
+        r = 1.0_dp
+    end if
+
     !--------------------------------------------------------------------------
     !
     !   Calculate recursion constants used in computing Legendre functions.

--- a/src/PythonWrapper.f95
+++ b/src/PythonWrapper.f95
@@ -2308,7 +2308,7 @@
     end subroutine pySHSCouplingMatrixCap
 
     subroutine pyMakeGradientDH(exitstatus,cilm,lmax,theta,phi,n,sampling,&
-                                lmax_calc,extend,phi_d0,phi_d1,cilm_d0,&
+                                lmax_calc,extend,radius,phi_d0,phi_d1,cilm_d0,&
                                 cilm_d1,cilm_d2,theta_d0,theta_d1)
         use shtools, only: MakeGradientDH
         use ftypes
@@ -2329,7 +2329,8 @@
         integer(int32),intent(in) :: sampling
         integer(int32),intent(in) :: lmax_calc
         integer(int32),intent(in) :: extend
+        real(dp),intent(in) :: radius
         call MakeGradientDH(cilm,lmax,theta,phi,n,sampling=sampling,&
-                            lmax_calc=lmax_calc,extend=extend,&
+                            lmax_calc=lmax_calc,extend=extend,radius=radius,&
                             exitstatus=exitstatus)
     end subroutine pyMakeGradientDH

--- a/src/SHTOOLS.f95
+++ b/src/SHTOOLS.f95
@@ -1164,13 +1164,14 @@ module SHTOOLS
         end subroutine SHSCouplingMatrixCap
 
         subroutine MakeGradientDH(cilm, lmax, theta, phi, n, sampling, &
-                                  lmax_calc, extend, exitstatus)
+                                  lmax_calc, extend, radius, exitstatus)
             use iso_fortran_env, only: int32, dp=>real64
             real(dp), intent(in) :: cilm(:,:,:)
             real(dp), intent(out) :: theta(:,:), phi(:,:)
             integer(int32), intent(in) :: lmax
             integer(int32), intent(out) :: n
             integer(int32), intent(in), optional :: sampling, lmax_calc, extend
+            real(dp), intent(in), optional :: radius
             integer(int32), intent(out), optional :: exitstatus
         end subroutine MakeGradientDH
 

--- a/src/fdoc/makegradientdh.md
+++ b/src/fdoc/makegradientdh.md
@@ -4,7 +4,7 @@ Compute the gradient of a scalar function and return grids of the two horizontal
 
 # Usage
 
-call MakeGradientDH (`cilm`, `lmax`, `theta`, `phi`, `n`, `sampling`, `lmax_calc`, `extend`, `exitstatus`)
+call MakeGradientDH (`cilm`, `lmax`, `theta`, `phi`, `n`, `sampling`, `lmax_calc`, `extend`, `radius`, `exitstatus`)
 
 # Parameters
 
@@ -32,6 +32,9 @@ call MakeGradientDH (`cilm`, `lmax`, `theta`, `phi`, `n`, `sampling`, `lmax_calc
 `extend` : input, optional, integer(int32), default = 0
 :   If 1, compute the longitudinal band for 360 E and the latitudinal band for 90 S. This increases each of the dimensions of the grids by 1.
 
+`radius` : input, optional, real(dp), default = 1.0
+:   The radius of the sphere used when computing the gradient of the function.
+
 `exitstatus` : output, optional, integer(int32)
 :   If present, instead of executing a STOP when an error is encountered, the variable exitstatus will be returned describing the error. 0 = No errors; 1 = Improper dimensions of input array; 2 = Improper bounds for input variable; 3 = Error allocating memory; 4 = File IO error.
 
@@ -41,7 +44,7 @@ call MakeGradientDH (`cilm`, `lmax`, `theta`, `phi`, `n`, `sampling`, `lmax_calc
 
 `Grad F = 1/r dF/theta theta-hat + 1/(r sin theta) dF/dphi phi-hat`.
 
-where theta is colatitude and phi is longitude. The radius r is taken from the degree zero coefficient of the input function.
+where theta is colatitude and phi is longitude. The radius r is by default set to 1, but this can be modified by use of the optional parameter `radius`.
 
 The default is to use an input grid that is equally sampled (`n` by `n`), but this can be changed to use an equally spaced grid (`n` by 2`n`) by the optional argument `sampling`. The redundant longitudinal band for 360 E and the latitudinal band for 90 S are excluded by default, but these can be computed by specifying the optional argument `extend`.
 

--- a/src/pydoc/pymakegradientdh.md
+++ b/src/pydoc/pymakegradientdh.md
@@ -5,7 +5,7 @@ Compute the gradient of a scalar function and return grids of the two horizontal
 # Usage
 
 ```python
-`theta`, `phi` = MakeGradientDH (`cilm`, [`lmax`, `sampling`, `lmax_calc`, `extend`])
+`theta`, `phi` = MakeGradientDH (`cilm`, [`lmax`, `sampling`, `lmax_calc`, `extend`, `radius`])
 ```
 
 # Returns
@@ -30,8 +30,12 @@ Compute the gradient of a scalar function and return grids of the two horizontal
 `lmax_calc` : optional, integer, default = `lmax`
 :   The maximum spherical harmonic degree used in evaluating the functions. This must be less than or equal to `lmax`.
 
-`extend` : input, optional, bool, default = False
+`extend` : optional, bool, default = False
 :   If True, compute the longitudinal band for 360 E and the latitudinal band for 90 S. This increases each of the dimensions of `griddh` by 1.
+
+`radius` : optional, float, default = 1.0
+:   The radius of the sphere used when computing the gradient of the function.
+
 
 # Description
 
@@ -39,7 +43,7 @@ Compute the gradient of a scalar function and return grids of the two horizontal
 
 `Grad F = 1/r dF/theta theta-hat + 1/(r sin theta) dF/dphi phi-hat`.
 
-where theta is colatitude and phi is longitude. The radius r is taken from the degree zero coefficient of the input function.
+where theta is colatitude and phi is longitude. The radius r is by default set to 1, but this can be modified by use of the optional parameter `radius`.
 
 The default is to use an input grid that is equally sampled (`n` by `n`), but this can be changed to use an equally spaced grid (`n` by 2`n`) by the optional argument `sampling`. The redundant longitudinal band for 360 E and the latitudinal band for 90 S are excluded by default, but these can be computed by specifying the optional argument `extend`.
 

--- a/src/pyshtools.pyf
+++ b/src/pyshtools.pyf
@@ -1848,7 +1848,7 @@ python module _SHTOOLS
             integer(int32),optional,intent(in),depend(galpha_order),intent(hide) :: galpha_order_d0 = len(galpha_order)
         end subroutine SHSCouplingMatrixCap
 
-        subroutine MakeGradientDH(exitstatus,cilm,lmax,theta,phi,n,sampling,lmax_calc,extend,phi_d0,phi_d1,cilm_d0,cilm_d1,cilm_d2,theta_d0,theta_d1)
+        subroutine MakeGradientDH(exitstatus,cilm,lmax,theta,phi,n,sampling,lmax_calc,extend,radius,phi_d0,phi_d1,cilm_d0,cilm_d1,cilm_d2,theta_d0,theta_d1)
             fortranname pymakegradientdh
             integer, parameter :: dp = selected_real_kind(p=15)
             integer, parameter :: int32 = selected_int_kind(9)
@@ -1861,6 +1861,7 @@ python module _SHTOOLS
             integer(int32),optional,intent(in) :: sampling = 2
             integer(int32),optional,intent(in),depend(lmax) :: lmax_calc = lmax
             integer(int32),optional,intent(in) :: extend = 0
+            real(dp),optional,intent(in) :: radius = 1.0
             integer(int32),intent(in),intent(hide),depend(lmax,extend),check(lmax>=0) :: phi_d0 = 2*(lmax+1)+extend
             integer(int32),intent(in),intent(hide),depend(sampling,lmax,extend) :: phi_d1 = sampling*2*(lmax+1)+extend
             integer(int32),optional,intent(in),depend(cilm),intent(hide) :: cilm_d0 = shape(cilm,0)


### PR DESCRIPTION
The default behavior of the Fortran routine MakeGradientDH and the python `SHCoeffs` method `gradient` has been modified. The original behavior was to compute the gradient on a sphere of radius `r`, where `r` was the degree 0 coeffieicient of the function. Though this makes sense for some functions (such as planetary topography), this is not useful for other functions (such as temperature).

The new behaviour is to compute the gradient on the unit sphere (r=1). This radius can be modified by supplying the optional argument `radius`.

The gradient function was introduced in v4.8 about 1 year ago.