### PR TITLE
move wrapper functions to backends module

### DIFF
--- a/docs/pages/mydoc/python-installing.md
+++ b/docs/pages/mydoc/python-installing.md
@@ -130,5 +130,6 @@ To make use of the 'ducc' backend for the spherical harmonic transforms, it will
 ```bash
 pip install pyshtools[ducc]  # installs ducc at the same time as pyshtools
 pip install ducc0>=0.15  # if pyshtools is already installed
+pip install ducc0>=0.15 -no-binary ducc0  # install ducc from source
 ```
-A conda version of *ducc0* exists, but it is not custom-built for the user's hardware and will therefore be roughly half as fast on most machines.
+Note: By installing *ducc0* from source, it might be possible to benefit from the use of AVX instructions which can improve execution speeds by a factor of about 2.

--- a/environment.yml
+++ b/environment.yml
@@ -19,5 +19,4 @@ dependencies:
     - pypandoc
     - flake8
     - pip
-    - pip:
-      - ducc0>=0.15
+    - ducc0>=0.15

--- a/pyshtools/backends/__init__.py
+++ b/pyshtools/backends/__init__.py
@@ -1,0 +1,34 @@
+"""
+backends
+
+This module defines functions for accessing and setting optional parameters of
+the backends used for the spherical harmonic transforms in pyshtools.
+
+Supported backends
+------------------
+shtools (default)            Spherical Harmonic Tools (Fortran 95), installed
+                             as part of pyshtools.
+ducc0                        Distinctly Useful Code Collection (C++17).
+
+Functions
+---------
+select_preferred_backend()   Set the preferred backend module and options.
+preferred_backend()          Return the name of the current preferred backend.
+preferred_backend_module()   Return a reference to the preferred backend
+                             module.
+backend_module()             Return a reference to the specified backend
+                             module.
+"""
+from .backends import select_preferred_backend
+from .backends import preferred_backend
+from .backends import preferred_backend_module
+from .backends import backend_module
+from . import ducc0_wrapper  # noqa: F401
+from .. import shtools  # noqa: F401
+
+del backends  # noqa: F821
+
+
+# ---- Define __all__ for use with: from pyshtools import * ----
+__all__ = ['select_preferred_backend', 'preferred_backend',
+           'preferred_backend_module', 'backend_module']

--- a/pyshtools/backends/backends.py
+++ b/pyshtools/backends/backends.py
@@ -21,7 +21,7 @@ backend_module()             Return a reference to the specified backend
 """
 
 # defaults
-from . import shtools as _preferred_backend_module
+from .. import shtools as _preferred_backend_module
 _preferred_backend = "shtools"
 
 
@@ -69,11 +69,11 @@ def backend_module(backend=None, nthreads=None):
     """
     backend = backend.lower()
     if backend == "shtools":
-        from . import shtools
+        from .. import shtools
 
         return shtools
     elif backend == "ducc":
-        from .wrappers import ducc0_wrapper
+        from . import ducc0_wrapper
         if not ducc0_wrapper.available():
             raise ImportError('"ducc" backend requested, but not installed.')
         if nthreads is not None:
@@ -108,7 +108,7 @@ def select_preferred_backend(backend="shtools", nthreads=None):
     backend = backend.lower()
     if backend == "shtools":
         _preferred_backend = backend
-        from . import shtools
+        from .. import shtools
 
         _preferred_backend_module = shtools
     elif backend == "ducc":
@@ -128,7 +128,7 @@ def select_preferred_backend(backend="shtools", nthreads=None):
                 "imported. Leaving backend unchanged."
             )
         _preferred_backend = backend
-        from .wrappers import ducc0_wrapper
+        from . import ducc0_wrapper
 
         _preferred_backend_module = ducc0_wrapper
         if nthreads is not None:

--- a/pyshtools/backends/ducc0_wrapper.py
+++ b/pyshtools/backends/ducc0_wrapper.py
@@ -269,7 +269,7 @@ def _prep_lmax(lmax, lmax_calc, cilm):
     if lmax_calc > lmax:
         raise RuntimeError(
             "lmax_calc ({}) must be less than or equal to lmax ({})"
-                .format(lmax_calc, lmax))
+            .format(lmax_calc, lmax))
     # lmax_calc need must not be higher than cilm.shape[1] - 1.
     lmax_calc = min(cilm.shape[1] - 1, lmax_calc)
     return lmax, lmax_calc, cilm[:, : lmax_calc + 1, : lmax_calc + 1]


### PR DESCRIPTION
* moved the ducc0_wrapper.py file to the backends module.
* use conda version of ducc0 in environment.yml. 
* Minor documentation changes
