### PR TITLE
Missing Differential of mu

### DIFF
--- a/docs/pages/mydoc/complex-spherical-harmonics.md
+++ b/docs/pages/mydoc/complex-spherical-harmonics.md
@@ -163,7 +163,7 @@ Each of these normalizations has slightly different definitions for the normaliz
 ### Unnormalized
 
 | $$\displaystyle \bar{P}_{l}^m(\mu) =  P_{lm}\left(\mu\right)$$ |
-| $$\displaystyle \int_{-1}^{1} \bar{P}_{l}^m(\mu) \,\bar{P}_{l'}^m(\mu)= \frac{2}{(2l+1)} \frac{(l+m)!}{(l-m)!} \, \delta_{ll'}$$ |
+| $$\displaystyle \int_{-1}^{1} \bar{P}_{l}^m(\mu) \,\bar{P}_{l'}^m(\mu) \,d\mu= \frac{2}{(2l+1)} \frac{(l+m)!}{(l-m)!} \, \delta_{ll'}$$ |
 | $$\displaystyle \int_\Omega Y_{l}^{*m}(\theta,\phi) \,Y_{l'}^{m'}(\theta,\phi)\, d\Omega = \frac{4\pi}{(2l+1)} \frac{(l+m)!}{(l-m)!}\,  \delta_{ll'}\, \delta_{mm'}$$ |
 | $$\displaystyle S_{fg}\left(l\right) = \sum_{m=-l}^l \frac{(l+m)!}{(2l+1)(l-m)!} f_l^m \, g_l^{*m}$$ |
 


### PR DESCRIPTION
Missing differential of mu in orthogonality property of Associated Legendre polynomials in complex spherical harmonic documentation page.






**Reminders**

- [ ] Base all changes on the `develop` branch: the `master` branch is used only when releasing new versions.
- [ ] Run `make check` to ensure that the python code follows standard formatting conventions.
- [ ] If adding new features, update the docstring to provide all information that is required to use the feature.
