### PR TITLE
Fix typographical error in PlmBar docs

### DIFF
--- a/src/PlmBar.f95
+++ b/src/PlmBar.f95
@@ -5,7 +5,7 @@ subroutine PlmBar(p, lmax, z, csphase, cnorm, exitstatus)
 !   functions up to degree lmax. The functions are initially scaled by
 !   10^280 sin^m in order to minimize the effects of underflow at large m
 !   near the poles (see Holmes and Featherstone 2002, J. Geodesy, 76, 279-299).
-!   On a maxOS system with a maximum allowable double precision value of
+!   On a macOS system with a maximum allowable double precision value of
 !   2.225073858507203E-308 the scaled portion of the algorithm will not overflow
 !   for degrees less than or equal to 2800.
 !


### PR DESCRIPTION
Just fixing a typo ... maxOS -> macOS