### PR TITLE
Make ducc the default backend

### DIFF
--- a/docs/pages/mydoc/backends.md
+++ b/docs/pages/mydoc/backends.md
@@ -24,8 +24,8 @@ The following software packages are supported as numerical backends to *pysthool
 
 | Class name | Description |
 | ---------- | ----------- |
-| [shtools](index-fortran.html) (default) | Spherical Harmonic Tools (Fortran 95, installed as part of pyshtools) |
-| [ducc](https://gitlab.mpcdf.mpg.de/mtr/ducc) | Distinctly Useful Code Collection (C++17) |
+| [shtools](index-fortran.html) (fallback) | Spherical Harmonic Tools (Fortran 95, installed as part of pyshtools) |
+| [ducc](https://gitlab.mpcdf.mpg.de/mtr/ducc) (default) | Distinctly Useful Code Collection (C++17) |
 
 The *shtools* package (written in Fortran 95) suppports all the functionality of *pyshtools*. Other packages only implement a subset of the *shtools* routines, and whenever an implementation of a function does not exist, the *shtools* function is used as a fallback.
 

--- a/docs/pages/mydoc/release-notes-v4.md
+++ b/docs/pages/mydoc/release-notes-v4.md
@@ -28,7 +28,7 @@ folder: mydoc
 * Fix bug with `SHGravCoeffs.admittance()` when using `function=geoid`.
 * Fix bug in python wrapper of the routine `MakeGrid2D` concerning the mandatory variable `interval`.
 * Add workaround to use pygmt with shading for versions >=0.4.
-* Convert all grids to `float` before using the `ducc0` backend.
+* Convert all grids to `float` before using the `ducc` backend.
 * `SHGeoid.to_netcdf()` now outputs double precision by default (consistent with the other grid classes).
 * Fix bug with `SHWindow.multitaper_cross_spectrum()` when using arbitrary localization regions.
 * Fix bug with the c-wrapper for `cMakeGradientDH` regarding the optional `radius` parameters.

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -16,5 +16,7 @@ dependencies:
     - pygmt>=0.3.0
     - palettable>=3.3
     - jupyter
+    - pypandoc
+    - flake8
     - pip
     - ducc0>=0.15

--- a/pyshtools/backends/__init__.py
+++ b/pyshtools/backends/__init__.py
@@ -6,9 +6,9 @@ the backends used for the spherical harmonic transforms in pyshtools.
 
 Supported backends
 ------------------
-shtools (default)            Spherical Harmonic Tools (Fortran 95), installed
+shtools (fallback)           Spherical Harmonic Tools (Fortran 95), installed
                              as part of pyshtools.
-ducc0                        Distinctly Useful Code Collection (C++17).
+ducc0 (default)              Distinctly Useful Code Collection (C++17).
 
 Functions
 ---------


### PR DESCRIPTION
ducc was set as the default backend in a previous PR, but this PR improves the handling of the case where ducc0 is not installed.