### PR TITLE
Update web documentation

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -6,3 +6,4 @@ gem 'github-pages', group: :jekyll_plugins
 
 # to publish without github page
 #gem "jekyll"
+gem "webrick", "~> 1.7"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
       octokit (~> 4.0)
       public_suffix (>= 3.0, < 5.0)
       typhoeus (~> 1.3)
-    html-pipeline (2.14.0)
+    html-pipeline (2.14.1)
       activesupport (>= 2)
       nokogiri (>= 1.4)
     http_parser.rb (0.8.0)
@@ -269,6 +269,7 @@ GEM
       unf_ext
     unf_ext (0.0.8.1)
     unicode-display_width (1.8.0)
+    webrick (1.7.0)
     zeitwerk (2.5.4)
 
 PLATFORMS
@@ -277,6 +278,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  webrick (~> 1.7)
 
 BUNDLED WITH
    2.3.7

--- a/docs/_data/sidebars/fortran_sidebar.yml
+++ b/docs/_data/sidebars/fortran_sidebar.yml
@@ -116,6 +116,10 @@ entries:
       url: /fortran-how-to-contribute.html
       output: web, pdf
 
+    - title: Chat
+      url: /fortran-chat.html
+      output: web, pdf
+
   - title: Release Notes
     output: web, pdf
     folderitems:

--- a/docs/_data/sidebars/mydoc_sidebar.yml
+++ b/docs/_data/sidebars/mydoc_sidebar.yml
@@ -120,6 +120,10 @@ entries:
       url: /how-to-contribute.html
       output: web, pdf
 
+    - title: Chat
+      url: /chat.html
+      output: web, pdf
+
   - title: Release Notes
     output: web, pdf
     folderitems:

--- a/docs/pages/fortran/fortran-chat.md
+++ b/docs/pages/fortran/fortran-chat.md
@@ -1,0 +1,15 @@
+---
+title: "Chat"
+keywords: spherical harmonics software package, spherical harmonic transform, legendre functions, multitaper spectral analysis, fortran, Python, gravity, magnetic field
+sidebar: fortran_sidebar
+permalink: fortran-chat.html
+summary: Join the discussion in one of our chat rooms.
+toc: true
+folder: fortran
+---
+
+If you have a question, comment, or suggestions, please feel free to join us in one of our chat rooms. All the rooms below are bridged (thanks to the [matrix protocol](https://matrix.org/)), so it doesn't matter which one you join!
+
+* [Element](https://matrix.to/#/%23pyshtools:matrix.org)
+* [Gitter.im](https://gitter.im/SHTOOLS/SHTOOLS)
+* [Software Underground (Slack) ](https://softwareunderground.org/)

--- a/docs/pages/fortran/fortran-release-notes-v4.md
+++ b/docs/pages/fortran/fortran-release-notes-v4.md
@@ -11,6 +11,8 @@ folder: fortran
 
 **Enhancements**
 
+* Change the preferred backend from 'shtools' to 'ducc' (when both are available).
+* Link routines in top level modules `pyshtools.expand` and `pyshtools.rotate` to the corresponding backend routines.
 * Add historical lunar topography dataset GLTM-2B.
 * Add historical martian magnetic field models FSU50 and FSU90.
 * Add new Mars gravity model MRO120F as well as several historical Mars gravity models.
@@ -19,7 +21,6 @@ folder: fortran
 * Update urls for databases hosted at GSFC.
 * Reorder optional arguments in docs for `makegravgradgriddh` and `makemaggravgradgrid` for consistency with code.
 * Allow shtools and dov file formats to contain floats for degree and order.
-* Change the preferred backend from 'shtools' to 'ducc'.
 * Minor changes and enhancements to the documentation.
 
 **Bug fixes**
@@ -33,6 +34,10 @@ folder: fortran
 * Fix bug with `SHWindow.multitaper_cross_spectrum()` when using arbitrary localization regions.
 * Fix bug with the c-wrapper for `cMakeGradientDH` regarding the optional `radius` parameters.
 * Minor changes to remove deprecation warnings.
+
+**Future deprecation**
+
+The module `pyshtools.shtools` will be deprecated in the v4.11 release. This module represents 1 of 2 possible backends for pyshtools, and has been located at `pyshtools.backends.shtools` since version 4.9. Unless explicitly required, the user should avoid using the `backends` modules directly, and should instead call the routines that are located in the top level modules such as `pyshtools.expand` and `pyshtools.rotate`. Setting the backend by use of the routine `pyshtools.backends.selected_preferred_backend()` determines which backed to use when calling the routines in the top level modules.
 
 M. A. Wieczorek, M. Meschede, T. Brugere, A. Corbin, A. Hattori, K. Leinweber, I. Oshchepkov, M. Reinecke, E. Sales de Andrade, E. Schnetter, S. Schröder, A. Vasishta, A. Walker, B. Xu, J. Sierra (2022). SHTOOLS: Version 4.10, Zenodo, doi:[10.5281/zenodo.592762](https://doi.org/10.5281/zenodo.592762)
 

--- a/docs/pages/mydoc/chat.md
+++ b/docs/pages/mydoc/chat.md
@@ -1,0 +1,15 @@
+---
+title: "Chat"
+keywords: spherical harmonics software package, spherical harmonic transform, legendre functions, multitaper spectral analysis, fortran, Python, gravity, magnetic field
+sidebar: mydoc_sidebar
+permalink: chat.html
+summary: Join the discussion in one of our chat rooms.
+toc: true
+folder: mydoc
+---
+
+If you have a question, comment, or suggestions, please feel free to join us in one of our chat rooms. All the rooms below are bridged (thanks to the [matrix protocol](https://matrix.org/)), so it doesn't matter which one you join!
+
+* [Element](https://matrix.to/#/%23pyshtools:matrix.org)
+* [Gitter.im](https://gitter.im/SHTOOLS/SHTOOLS)
+* [Software Underground (Slack) ](https://softwareunderground.org/)

--- a/docs/pages/mydoc/release-notes-v4.md
+++ b/docs/pages/mydoc/release-notes-v4.md
@@ -11,6 +11,8 @@ folder: mydoc
 
 **Enhancements**
 
+* Change the preferred backend from 'shtools' to 'ducc' (when both are available).
+* Link routines in top level modules `pyshtools.expand` and `pyshtools.rotate` to the corresponding backend routines.
 * Add historical lunar topography dataset GLTM-2B.
 * Add historical martian magnetic field models FSU50 and FSU90.
 * Add new Mars gravity model MRO120F as well as several historical Mars gravity models.
@@ -19,7 +21,6 @@ folder: mydoc
 * Update urls for databases hosted at GSFC.
 * Reorder optional arguments in docs for `makegravgradgriddh` and `makemaggravgradgrid` for consistency with code.
 * Allow shtools and dov file formats to contain floats for degree and order.
-* Change the preferred backend from 'shtools' to 'ducc'.
 * Minor changes and enhancements to the documentation.
 
 **Bug fixes**
@@ -33,6 +34,10 @@ folder: mydoc
 * Fix bug with `SHWindow.multitaper_cross_spectrum()` when using arbitrary localization regions.
 * Fix bug with the c-wrapper for `cMakeGradientDH` regarding the optional `radius` parameters.
 * Minor changes to remove deprecation warnings.
+
+**Future deprecation**
+
+The module `pyshtools.shtools` will be deprecated in the v4.11 release. This module represents 1 of 2 possible backends for pyshtools, and has been located at `pyshtools.backends.shtools` since version 4.9. Unless explicitly required, the user should avoid using the `backends` modules directly, and should instead call the routines that are located in the top level modules such as `pyshtools.expand` and `pyshtools.rotate`. Setting the backend by use of the routine `pyshtools.backends.selected_preferred_backend()` determines which backed to use when calling the routines in the top level modules.
 
 M. A. Wieczorek, M. Meschede, T. Brugere, A. Corbin, A. Hattori, K. Leinweber, I. Oshchepkov, M. Reinecke, E. Sales de Andrade, E. Schnetter, S. Schröder, A. Vasishta, A. Walker, B. Xu, J. Sierra (2022). SHTOOLS: Version 4.10, Zenodo, doi:[10.5281/zenodo.592762](https://doi.org/10.5281/zenodo.592762)
 

--- a/examples/python/ClassInterface/ClassExample.py
+++ b/examples/python/ClassInterface/ClassExample.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python3
 """
 This script tests the python class interface
 """
 import numpy as np
+import pyshtools as pysh
 
-import pyshtools
-pyshtools.utils.figstyle()
+pysh.utils.figstyle()
 
 
 # ==== MAIN FUNCTION ====
@@ -22,7 +21,7 @@ def example1():
     scale = 10
     power = 1. / (1. + (degrees / scale)**2)**2
 
-    coeffs = pyshtools.SHCoeffs.from_random(power)
+    coeffs = pysh.SHCoeffs.from_random(power)
     coeffs.plot_spectrum(show=False, fname='power.png')
 
     # expand coefficients into a spatial grid and plot it

--- a/examples/python/ClassInterface/WindowExample.py
+++ b/examples/python/ClassInterface/WindowExample.py
@@ -1,10 +1,9 @@
-#!/usr/bin/env python3
 """
 This script tests the python class interface
 """
-import pyshtools
+import pyshtools as pysh
 
-pyshtools.utils.figstyle()
+pysh.utils.figstyle()
 
 
 # ==== MAIN FUNCTION ====
@@ -20,7 +19,7 @@ def example1():
     lmax = 20
     nwin = 20
     theta = 25.
-    cap = pyshtools.SHWindow.from_cap(theta, lmax, nwin=nwin)
+    cap = pysh.SHWindow.from_cap(theta, lmax, nwin=nwin)
     cap.info()
     cap.plot_windows(20, show=False, fname='cap_tapers.png')
     cap.plot_coupling_matrix(30, k=5, show=False, fname='cap_coupling.png')
@@ -32,12 +31,12 @@ def example2():
     lmax = 15
     nwins = 15
 
-    coeffs = pyshtools.SHCoeffs.from_file(
+    coeffs = pysh.SHCoeffs.from_file(
         '../../ExampleDataFiles/srtmp300.msl')
     topo = coeffs.expand(grid='DH2')
     dh_mask = topo.data > 0.
     print(dh_mask.shape)
-    region = pyshtools.SHWindow.from_mask(dh_mask, lmax, nwins)
+    region = pysh.SHWindow.from_mask(dh_mask, lmax, nwins)
     region.info()
     region.plot_windows(nwins, show=False, fname='continent_tapers.png')
     region.plot_coupling_matrix(30, k=5, show=False,

--- a/examples/python/ClassInterface/exact_power.py
+++ b/examples/python/ClassInterface/exact_power.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python3
 """Test the phaseonly keyword."""
 
 import matplotlib.pyplot as plt
-import pyshtools
+import pyshtools as pysh
 import numpy as np
 
 
@@ -13,8 +12,8 @@ def example():
     degrees[0] = np.inf
     power = degrees**(-1)
 
-    clm1 = pyshtools.SHCoeffs.from_random(power, exact_power=False)
-    clm2 = pyshtools.SHCoeffs.from_random(power, exact_power=True)
+    clm1 = pysh.SHCoeffs.from_random(power, exact_power=False)
+    clm2 = pysh.SHCoeffs.from_random(power, exact_power=True)
 
     fig, ax = plt.subplots()
     ax.plot(clm1.spectrum(unit='per_l'), label='Normal distributed power')

--- a/examples/python/GlobalSpectralAnalysis/GlobalSpectralAnalysis.py
+++ b/examples/python/GlobalSpectralAnalysis/GlobalSpectralAnalysis.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 This script tests the different Spherical Harmonics Transforms on the Mars
 topography data set
@@ -6,13 +5,9 @@ topography data set
 import os
 import numpy as np
 import matplotlib.pyplot as plt
+import pyshtools as pysh
 
-import pyshtools
-from pyshtools import spectralanalysis
-from pyshtools import shio
-from pyshtools import expand
-
-pyshtools.utils.figstyle()
+pysh.utils.figstyle()
 
 
 # ==== MAIN FUNCTION ====
@@ -29,17 +24,17 @@ def example():
     # --- input data filename ---
     infile = os.path.join(os.path.dirname(__file__),
                           '../../ExampleDataFiles/MarsTopo719.shape')
-    coeffs, lmax = shio.shread(infile)
+    coeffs, lmax = pysh.shio.shread(infile)
 
     # --- plot grid ---
-    grid = expand.MakeGridDH(coeffs, csphase=-1)
+    grid = pysh.expand.MakeGridDH(coeffs, csphase=-1)
     fig_map = plt.figure()
     plt.imshow(grid)
 
     # ---- compute spectrum ----
     ls = np.arange(lmax + 1)
-    pspectrum = spectralanalysis.spectrum(coeffs, unit='per_l')
-    pdensity = spectralanalysis.spectrum(coeffs, unit='per_lm')
+    pspectrum = pysh.spectralanalysis.spectrum(coeffs, unit='per_l')
+    pdensity = pysh.spectralanalysis.spectrum(coeffs, unit='per_lm')
 
     # ---- plot spectrum ----
     fig_spectrum, ax = plt.subplots(1, 1)

--- a/examples/python/GravMag/TestCT.py
+++ b/examples/python/GravMag/TestCT.py
@@ -1,17 +1,11 @@
-#!/usr/bin/env python3
 """
 This script creates a crustal thickness map of Mars.
 """
 import numpy as np
 import matplotlib.pyplot as plt
+import pyshtools as pysh
 
-import pyshtools
-from pyshtools import shio
-from pyshtools import expand
-from pyshtools import gravmag
-from pyshtools import constants
-
-pyshtools.utils.figstyle()
+pysh.utils.figstyle()
 
 
 # ==== MAIN FUNCTION ====
@@ -36,14 +30,14 @@ def TestCrustalThickness():
     half = 0
 
     gravfile = '../../ExampleDataFiles/gmm3_120_sha.tab'
-    pot, lmaxp, header = shio.shread(gravfile, lmax=degmax, header=True)
+    pot, lmaxp, header = pysh.shio.shread(gravfile, lmax=degmax, header=True)
     gm = float(header[1]) * 1.e9
-    mass = gm / constants.G.value
+    mass = gm / pysh.constants.G.value
     r_grav = float(header[0]) * 1.e3
     print(r_grav, gm, mass, lmaxp)
 
     topofile = '../../ExampleDataFiles/MarsTopo719.shape'
-    hlm, lmaxt = shio.shread(topofile)
+    hlm, lmaxt = pysh.shio.shread(topofile)
     r0 = hlm[0, 0, 0]
     d = r0 - 45.217409924028445e3
     print(r0, lmaxt)
@@ -51,12 +45,12 @@ def TestCrustalThickness():
     for l in range(2, lmaxp + 1):
         pot[:, l, :l + 1] = pot[:, l, :l + 1] * (r_grav / r0)**l
 
-    topo_grid = expand.MakeGridDH(hlm, lmax=lmax, sampling=2,
-                                  lmax_calc=degmax)
+    topo_grid = pysh.expand.MakeGridDH(hlm, lmax=lmax, sampling=2,
+                                       lmax_calc=degmax)
     print("Maximum radius (km) = ", topo_grid.max() / 1.e3)
     print("Minimum radius (km) = ", topo_grid.min() / 1.e3)
 
-    bc, r0 = gravmag.CilmPlusDH(topo_grid, nmax, mass, rho_c, lmax=degmax)
+    bc, r0 = pysh.gravmag.CilmPlusDH(topo_grid, nmax, mass, rho_c, lmax=degmax)
 
     ba = pot - bc
 
@@ -66,33 +60,30 @@ def TestCrustalThickness():
     for l in range(1, degmax + 1):
         if filter_type == 0:
             moho_c[:, l, :l + 1] = ba[:, l, :l + 1] * mass * (2 * l + 1) * \
-                                   ((r0 / d)**l) \
-                                   / (4.0 * np.pi * (rho_m - rho_c) * d**2)
+                ((r0 / d)**l) / (4.0 * np.pi * (rho_m - rho_c) * d**2)
         elif filter_type == 1:
-            moho_c[:, l, :l + 1] = gravmag.DownContFilterMA(l, half, r0, d) * \
-                                   ba[:, l, :l + 1] * mass * (2 * l + 1) * \
-                                   ((r0 / d)**l) / \
-                                   (4.0 * np.pi * (rho_m - rho_c) * d**2)
+            moho_c[:, l, :l + 1] = pysh.gravmag.DownContFilterMA(
+                l, half, r0, d) * ba[:, l, :l + 1] * mass * (2 * l + 1) * \
+                ((r0 / d)**l) / (4.0 * np.pi * (rho_m - rho_c) * d**2)
         else:
-            moho_c[:, l, :l + 1] = gravmag.DownContFilterMC(l, half, r0, d) * \
-                                   ba[:, l, :l + 1] * mass * (2 * l + 1) *\
-                                   ((r0 / d)**l) / \
-                                   (4.0 * np.pi * (rho_m - rho_c) * d**2)
+            moho_c[:, l, :l + 1] = pysh.gravmag.DownContFilterMC(
+                l, half, r0, d) * ba[:, l, :l + 1] * mass * (2 * l + 1) *\
+                ((r0 / d)**l) / (4.0 * np.pi * (rho_m - rho_c) * d**2)
 
-    moho_grid3 = expand.MakeGridDH(moho_c, lmax=lmax, sampling=2,
-                                   lmax_calc=degmax)
+    moho_grid3 = pysh.expand.MakeGridDH(moho_c, lmax=lmax, sampling=2,
+                                        lmax_calc=degmax)
     print('Maximum Crustal thickness (km) = ',
           (topo_grid - moho_grid3).max() / 1.e3)
     print('Minimum Crustal thickness (km) = ',
           (topo_grid - moho_grid3).min() / 1.e3)
 
-    moho_c = gravmag.BAtoHilmDH(ba, moho_grid3, nmax, mass, r0,
-                                (rho_m - rho_c), lmax=lmax,
-                                filter_type=filter_type, filter_deg=half,
-                                lmax_calc=degmax)
+    moho_c = pysh.gravmag.BAtoHilmDH(ba, moho_grid3, nmax, mass, r0,
+                                     (rho_m - rho_c), lmax=lmax,
+                                     filter_type=filter_type, filter_deg=half,
+                                     lmax_calc=degmax)
 
-    moho_grid2 = expand.MakeGridDH(moho_c, lmax=lmax, sampling=2,
-                                   lmax_calc=degmax)
+    moho_grid2 = pysh.expand.MakeGridDH(moho_c, lmax=lmax, sampling=2,
+                                        lmax_calc=degmax)
     print('Delta (km) = ', abs(moho_grid3 - moho_grid2).max() / 1.e3)
 
     temp_grid = topo_grid - moho_grid2
@@ -119,13 +110,14 @@ def TestCrustalThickness():
         iter += 1
         print('Iteration ', iter)
 
-        moho_c = gravmag.BAtoHilmDH(ba, moho_grid2, nmax, mass, r0,
-                                    rho_m - rho_c, lmax=lmax,
-                                    filter_type=filter_type, filter_deg=half,
-                                    lmax_calc=degmax)
+        moho_c = pysh.gravmag.BAtoHilmDH(ba, moho_grid2, nmax, mass, r0,
+                                         rho_m - rho_c, lmax=lmax,
+                                         filter_type=filter_type,
+                                         filter_deg=half,
+                                         lmax_calc=degmax)
 
-        moho_grid = expand.MakeGridDH(moho_c, lmax=lmax, sampling=2,
-                                      lmax_calc=degmax)
+        moho_grid = pysh.expand.MakeGridDH(moho_c, lmax=lmax, sampling=2,
+                                           lmax_calc=degmax)
         delta = abs(moho_grid - moho_grid2).max()
         print('Delta (km) = ', delta / 1.e3)
 

--- a/examples/python/GravMag/TestGrav.py
+++ b/examples/python/GravMag/TestGrav.py
@@ -1,16 +1,11 @@
-#!/usr/bin/env python3
 """
 This script tests the gravity and magnetics routines.
 """
 import numpy as np
 import matplotlib.pyplot as plt
+import pyshtools as pysh
 
-import pyshtools
-from pyshtools import gravmag
-from pyshtools import shio
-from pyshtools import constants
-
-pyshtools.utils.figstyle()
+pysh.utils.figstyle()
 
 
 # ==== MAIN FUNCTION ====
@@ -27,25 +22,26 @@ def main():
 
 def TestMakeGravGrid():
     infile = '../../ExampleDataFiles/gmm3_120_sha.tab'
-    clm, lmax, header = shio.shread(infile, header=True)
+    clm, lmax, header = pysh.shio.shread(infile, header=True)
     r0 = float(header[0]) * 1.e3
     gm = float(header[1]) * 1.e9
     clm[0, 0, 0] = 1.0
     print(gm, r0)
 
-    geoid = gravmag.MakeGeoidGridDH(clm, r0, gm, constants.Mars.u0.value,
-                                    a=constants.Mars.a.value,
-                                    f=constants.Mars.f.value,
-                                    omega=constants.Mars.omega.value)
+    geoid = pysh.gravmag.MakeGeoidGridDH(clm, r0, gm,
+                                         pysh.constants.Mars.u0.value,
+                                         a=pysh.constants.Mars.a.value,
+                                         f=pysh.constants.Mars.f.value,
+                                         omega=pysh.constants.Mars.omega.value)
     geoid = geoid / 1.e3  # convert to meters
     fig_map = plt.figure()
     plt.imshow(geoid)
     fig_map.savefig('MarsGeoid.png')
 
-    rad, theta, phi, total, pot = gravmag.MakeGravGridDH(
-        clm, gm, r0, lmax=719, a=constants.Mars.a.value,
-        f=constants.Mars.f.value, lmax_calc=85,
-        omega=constants.Mars.omega.value, normal_gravity=1)
+    rad, theta, phi, total, pot = pysh.gravmag.MakeGravGridDH(
+        clm, gm, r0, lmax=719, a=pysh.constants.Mars.a.value,
+        f=pysh.constants.Mars.f.value, lmax_calc=85,
+        omega=pysh.constants.Mars.omega.value, normal_gravity=1)
     fig, axes = plt.subplots(2, 2)
 
     for num, vv, s in ((0, rad, "$g_{r}$"), (1, theta, "$g_{\\theta}$"),
@@ -64,12 +60,13 @@ def TestMakeGravGrid():
 
 
 def TestNormalGravity():
-    gm = constants.Mars.gm.value
-    omega = constants.Mars.omega.value
-    a = constants.Mars.a.value
-    b = constants.Mars.b.value
+    gm = pysh.constants.Mars.gm.value
+    omega = pysh.constants.Mars.omega.value
+    a = pysh.constants.Mars.a.value
+    b = pysh.constants.Mars.b.value
     lat = np.arange(-90., 90., 1.)
-    ng = np.array([gravmag.NormalGravity(x, gm, omega, a, b) for x in lat])
+    ng = np.array(
+        [pysh.gravmag.NormalGravity(x, gm, omega, a, b) for x in lat])
     fig = plt.figure()
     plt.plot(lat, ng, '-')
     plt.xlim(-90, 90)
@@ -88,8 +85,8 @@ def TestGravGrad():
     a = 1.0
     f = 0.0
 
-    vxx, vyy, vzz, vxy, vxz, vyz = gravmag.MakeGravGradGridDH(clm, gm, r0,
-                                                              a=a, f=f)
+    vxx, vyy, vzz, vxy, vxz, vyz = pysh.gravmag.MakeGravGradGridDH(clm, gm, r0,
+                                                                   a=a, f=f)
 
     print("Maximum Trace(Vxx+Vyy+Vzz) = ", np.max(vxx + vyy + vzz))
     print("Minimum Trace(Vxx+Vyy+Vzz) = ", np.min(vxx + vyy + vzz))
@@ -110,15 +107,15 @@ def TestGravGrad():
 
 def TestFilter():
     half = 80
-    r = constants.Moon.mean_radius.value
+    r = pysh.constants.Moon.mean_radius.value
     d = r - 40.e3
     deglist = np.arange(1, 200, 1)
     wl = np.zeros(len(deglist) + 1)
     wlcurv = np.zeros(len(deglist) + 1)
 
     for l in deglist:
-        wl[l] = gravmag.DownContFilterMA(l, half, r, d)
-        wlcurv[l] = gravmag.DownContFilterMC(l, half, r, d)
+        wl[l] = pysh.gravmag.DownContFilterMA(l, half, r, d)
+        wlcurv[l] = pysh.gravmag.DownContFilterMC(l, half, r, d)
 
     fig = plt.figure()
     plt.plot(deglist, wl[1:], 'b-', label='Minimum amplitude')
@@ -132,13 +129,13 @@ def TestFilter():
 
 def TestMakeMagGrid():
     infile = '../../ExampleDataFiles/FSU_mars90.sh'
-    clm, lmax, header = shio.shread(infile, header=True, skip=1)
+    clm, lmax, header = pysh.shio.shread(infile, header=True, skip=1)
     r0 = float(header[0]) * 1.e3
-    a = constants.Mars.mean_radius.value + 145.0e3
+    a = pysh.constants.Mars.mean_radius.value + 145.0e3
     # radius to evaluate the field
 
-    rad, theta, phi, total, pot = gravmag.MakeMagGridDH(
-        clm, r0, lmax=719, a=a, f=constants.Mars.f.value, lmax_calc=90)
+    rad, theta, phi, total, pot = pysh.gravmag.MakeMagGridDH(
+        clm, r0, lmax=719, a=a, f=pysh.constants.Mars.f.value, lmax_calc=90)
     fig, axes = plt.subplots(2, 2)
 
     for num, vv, s in ((0, rad, "$B_{r}$"), (1, theta, "$B_{\\theta}$"),
@@ -154,7 +151,7 @@ def TestMakeMagGrid():
     fig.savefig('Mars_Mag.png')
 
     ls = np.arange(lmax + 1)
-    pspectrum = gravmag.mag_spectrum(clm, r0, r0)
+    pspectrum = pysh.gravmag.mag_spectrum(clm, r0, r0)
 
     fig_spectrum, ax = plt.subplots(1, 1)
     ax.set_xscale('linear')

--- a/examples/python/IOStorageConversions/SHConversions.py
+++ b/examples/python/IOStorageConversions/SHConversions.py
@@ -1,16 +1,12 @@
-#!/usr/bin/env python3
 """
 This script tests the conversions between real and complex spherical harmonics
 coefficients
 """
 import numpy as np
 import matplotlib.pyplot as plt
+import pyshtools as pysh
 
-import pyshtools
-from pyshtools import shio
-from pyshtools import expand
-
-pyshtools.utils.figstyle()
+pysh.utils.figstyle()
 
 
 def main():
@@ -26,8 +22,8 @@ def test_SHConversions():
     for l in np.arange(lmax + 1):
         mask[:, l, :l + 1] = True
     mask[1, :, 0] = False
-    coeffs2 = shio.SHrtoc(coeffs1)
-    coeffs3 = shio.SHctor(coeffs2)
+    coeffs2 = pysh.shio.SHrtoc(coeffs1)
+    coeffs3 = pysh.shio.SHctor(coeffs2)
     error = np.sqrt(np.sum((coeffs3[mask] - coeffs1[mask])**2))
     print('error after real to complex to real conversion: ', error)
 
@@ -36,20 +32,20 @@ def example():
     print('---- SHrtoc example ----')
     # --- input data filename ---
     infile = '../../ExampleDataFiles/MarsTopo719.shape'
-    coeffs1, lmax = shio.shread(infile)
+    coeffs1, lmax = pysh.shio.shread(infile)
     coeffs1 = coeffs1[:, :lmax + 1, :lmax + 1]
 
     # --- convert to complex coefficients, fill negative order coefficients ---
     coeffs2 = np.empty((2, lmax + 1, lmax + 1), dtype=np.complex128)
-    coeffs2_buf = shio.SHrtoc(coeffs1, convention=1, switchcs=0)
+    coeffs2_buf = pysh.shio.SHrtoc(coeffs1, convention=1, switchcs=0)
     coeffs2[0, :, :].real = coeffs2_buf[0, :, :]
     coeffs2[0, :, :].imag = coeffs2_buf[1, :, :]
     coeffs2[1] = (coeffs2[0].conjugate() *
                   ((-1)**np.arange(lmax + 1))[np.newaxis, :])
 
     # --- compute and plot grid ---
-    grid1 = expand.MakeGridDH(coeffs1, lmax, csphase=-1)
-    grid2 = expand.MakeGridDHC(coeffs2, lmax, csphase=-1)
+    grid1 = pysh.expand.MakeGridDH(coeffs1, lmax, csphase=-1)
+    grid2 = pysh.expand.MakeGridDHC(coeffs2, lmax, csphase=-1)
 
     gridmin = min(grid1.min(), grid2.real.min())
     gridmax = max(grid1.max(), grid2.real.max())

--- a/examples/python/IOStorageConversions/SHStorage.py
+++ b/examples/python/IOStorageConversions/SHStorage.py
@@ -1,14 +1,11 @@
-#!/usr/bin/env python3
 """
 This script tests the conversions between real and complex spherical harmonics
 coefficients
 """
 import numpy as np
+import pyshtools as pysh
 
-import pyshtools
-from pyshtools import shio
-
-pyshtools.utils.figstyle()
+pysh.utils.figstyle()
 
 
 def main():
@@ -27,8 +24,8 @@ def test_SHStorage():
     coeffs[np.invert(mask)] = 0.
 
     print('\n---- testing SHCilmToCindex and SHCindexToCilm ----')
-    coeffs_indexed = shio.SHCilmToCindex(coeffs)
-    coeffs_recomp = shio.SHCindexToCilm(coeffs_indexed)
+    coeffs_indexed = pysh.shio.SHCilmToCindex(coeffs)
+    coeffs_recomp = pysh.shio.SHCindexToCilm(coeffs_indexed)
     print('input coeffs (l={:d}):'.format(lmax))
     print(coeffs)
     print('indexed coeffs:')
@@ -37,8 +34,8 @@ def test_SHStorage():
     print(coeffs_recomp)
 
     print('\n---- testing SHCilmToVector and SHVectorToCilm ----')
-    coeffs_indexed = shio.SHCilmToVector(coeffs)
-    coeffs_recomp = shio.SHVectorToCilm(coeffs_indexed)
+    coeffs_indexed = pysh.shio.SHCilmToVector(coeffs)
+    coeffs_recomp = pysh.shio.SHVectorToCilm(coeffs_indexed)
     print('\ninput coeffs (l={:d}):'.format(lmax))
     print(coeffs)
     print('\nindexed coeffs:')

--- a/examples/python/LocalizedSpectralAnalysis/SHMTCouplingMatrix.py
+++ b/examples/python/LocalizedSpectralAnalysis/SHMTCouplingMatrix.py
@@ -1,13 +1,10 @@
-#!/usr/bin/env python3
 """
 This script tests the SHMTCouplingMatrix routine
 """
 import numpy as np
+import pyshtools as pysh
 
-import pyshtools
-from pyshtools import shtools
-
-pyshtools.utils.figstyle()
+pysh.utils.figstyle()
 
 
 def main():
@@ -22,7 +19,7 @@ def test_CouplingMatrix():
 
     sqrt_taper_power = np.zeros((lwin+1, nwins))
     sqrt_taper_power[:, 0] = np.hanning(lwin+1)
-    Mmt = shtools.SHMTCouplingMatrix(lmax, sqrt_taper_power)
+    Mmt = pysh.spectralanalysis.SHMTCouplingMatrix(lmax, sqrt_taper_power)
     print(Mmt)
 
 

--- a/examples/python/LocalizedSpectralAnalysis/SHMultitaperSE.py
+++ b/examples/python/LocalizedSpectralAnalysis/SHMultitaperSE.py
@@ -1,13 +1,10 @@
-#!/usr/bin/env python3
 """
 This script tests the localized spectral analysis routines
 """
 import numpy as np
+import pyshtools as pysh
 
-import pyshtools
-from pyshtools import shtools
-
-pyshtools.utils.figstyle()
+pysh.utils.figstyle()
 
 
 def main():
@@ -24,7 +21,7 @@ def test_MultitaperSE():
     print('size {:1.0f} deg, bandwidth {:d}, order {:d}'
           .format(theta0_deg, lmax, orderM))
     tapers, concentrations = \
-        shtools.SHReturnTapersM(theta0, lmax, orderM)
+        pysh.spectralanalysis.SHReturnTapersM(theta0, lmax, orderM)
     print('first 3 taper concentrations:')
     print(concentrations[:3])
 
@@ -35,7 +32,7 @@ def test_MultitaperSE():
     print('creating spherical cap tapers of', end=' ')
     print('size {:1.0f} deg with bandwidth {:d}'.format(theta0_deg, lmax))
     tapers, concentrations, taperorder = \
-        shtools.SHReturnTapers(theta0, lmax)
+        pysh.spectralanalysis.SHReturnTapers(theta0, lmax)
     print('first 10 taper concentrations:')
     print(concentrations[:10])
 
@@ -46,7 +43,7 @@ def test_MultitaperSE():
     torders = taperorder[:ntapers]
     coeffs = np.random.normal(size=(2, lmax + 1, lmax + 1))
     localpower, localpower_sd = \
-        shtools.SHMultiTaperSE(coeffs, tapersk, torders)
+        pysh.spectralanalysis.SHMultiTaperSE(coeffs, tapersk, torders)
     print('total power:', np.sum(localpower))
 
     print('\n---- testing SHMultiTaperCSE ----')
@@ -58,7 +55,8 @@ def test_MultitaperSE():
     coeffs2 = 0.5 * (coeffs1 + np.random.normal(size=(2, lmax + 1, lmax + 1)))
     print(coeffs1.shape, coeffs2.shape, tapersk.shape)
     localpower, localpower_sd = \
-        shtools.SHMultiTaperCSE(coeffs1, coeffs2, tapersk, torders)
+        pysh.spectralanalysis.SHMultiTaperCSE(coeffs1, coeffs2, tapersk,
+                                              torders)
     print('total power:', np.sum(localpower))
 
     print('\n---- testing SHLocalizedAdmitCorr ----')
@@ -66,8 +64,8 @@ def test_MultitaperSE():
     lon = 0.
     k = 3
     admit, corr, dadmit, dcorr = \
-        shtools.SHLocalizedAdmitCorr(coeffs1, coeffs2, tapers, taperorder,
-                                     lat, lon, k=k)
+        pysh.spectralanalysis.SHLocalizedAdmitCorr(coeffs1, coeffs2, tapers,
+                                                   taperorder, lat, lon, k=k)
     print(admit)
 
     print('\n---- testing ComputeDm ----')
@@ -75,7 +73,7 @@ def test_MultitaperSE():
     theta0 = np.radians(theta0_deg)
     lmax = 10
     m = 2
-    Dm = shtools.ComputeDm(lmax, m, theta0)
+    Dm = pysh.spectralanalysis.ComputeDm(lmax, m, theta0)
     print(Dm[:3, :3])
 
     print('\n---- testing ComputeDG82 ----')
@@ -83,7 +81,7 @@ def test_MultitaperSE():
     theta0 = np.radians(theta0_deg)
     lmax = 10
     m = 2
-    DG82 = shtools.ComputeDG82(lmax, m, theta0)
+    DG82 = pysh.spectralanalysis.ComputeDG82(lmax, m, theta0)
     print(DG82[:3, :3])
 
     print('\n---- testing SHFindLWin ----')
@@ -92,20 +90,20 @@ def test_MultitaperSE():
     m = 2
     ntapers = 3
     minconcentration = 0.8
-    lmax = shtools.SHFindLWin(theta0, m, minconcentration,
-                              taper_number=ntapers)
+    lmax = pysh.spectralanalysis.SHFindLWin(theta0, m, minconcentration,
+                                            taper_number=ntapers)
     print(lmax)
 
     print('\n---- testing SHBiasK ----')
     lmax = 80
     power_unbiased = 1. / (1. + np.arange(lmax + 1))**2
-    power_biased = shtools.SHBiasK(tapers, power_unbiased)
+    power_biased = pysh.spectralanalysis.SHBiasK(tapers, power_unbiased)
     print((power_biased[:lmax + 1] / power_unbiased)[:5])
 
     print('\n---- testing SHBias ----')
     lmax = 80
     power_unbiased = 1. / (1. + np.arange(lmax + 1))**2
-    power_biased = shtools.SHBias(tapers[:, 2], power_unbiased)
+    power_biased = pysh.spectralanalysis.SHBias(tapers[:, 2], power_unbiased)
     print(tapers.shape)
     print((power_biased[:lmax + 1] / power_unbiased)[:5])
 
@@ -114,7 +112,8 @@ def test_MultitaperSE():
     Stt = 1. / (1. + np.arange(lmax + 1))**2
     Sgg = 1. / (1. + np.arange(lmax + 1))**2
     Sgt = 0.5 / (1. + np.arange(lmax + 1))**2
-    admit, corr = shtools.SHBiasAdmitCorr(Sgt, Sgg, Stt, tapers[:, 2])
+    admit, corr = pysh.spectralanalysis.SHBiasAdmitCorr(Sgt, Sgg, Stt,
+                                                        tapers[:, 2])
     print(corr)
 
 

--- a/examples/python/LocalizedSpectralAnalysis/SHWindowsBiasOther.py
+++ b/examples/python/LocalizedSpectralAnalysis/SHWindowsBiasOther.py
@@ -1,14 +1,11 @@
-#!/usr/bin/env python3
 """
 This script tests other routines related to localized spectral analyses
 """
 import numpy as np
 import matplotlib.pyplot as plt
+import pyshtools as pysh
 
-import pyshtools
-from pyshtools import shtools
-
-pyshtools.utils.figstyle()
+pysh.utils.figstyle()
 
 
 def main():
@@ -23,14 +20,14 @@ def test_LocalizationWindows():
     lmax = 15
     theta = 50.
     print('generating {:2.1f} degrees cap:'.format(theta))
-    coeffsm0 = shtools.SphericalCapCoef(np.radians(theta), lmax)
+    coeffsm0 = pysh.spectralanalysis.SphericalCapCoef(np.radians(theta), lmax)
     print(coeffsm0)
 
     print('\n---- testing SHBias ----')
     winpower = coeffsm0**2
     ldata = 20
     globalpower = np.random.rand(ldata)
-    localpower = shtools.SHBias(winpower, globalpower)
+    localpower = pysh.spectralanalysis.SHBias(winpower, globalpower)
     print(localpower[:min(ldata, 20)])
 
     print('\n---- testing Curve2Mask ----')
@@ -44,7 +41,7 @@ def test_LocalizationWindows():
     points[2] = [80., 50.]
     points[3] = [80., 20.]
     hasnorthpole = False
-    dhmask = shtools.Curve2Mask(nlat, points, hasnorthpole)
+    dhmask = pysh.spectralanalysis.Curve2Mask(nlat, points, hasnorthpole)
     # compute covered area as a check
     thetas = np.linspace(0 + dlat / 2., 180. - dlat / 2., nlat)
     weights = 2 * np.sin(np.radians(thetas))
@@ -65,11 +62,12 @@ def test_LocalizationWindows():
     latgrid, longrid = np.meshgrid(lats, lons, indexing='ij')
     dh_mask = np.logical_and(5. < latgrid, latgrid < 20.)
     print('dij matrix[0,:lmax={:d}]:'.format(lmax))
-    dij_matrix = shtools.ComputeDMap(dh_mask, lmax)
+    dij_matrix = pysh.spectralanalysis.ComputeDMap(dh_mask, lmax)
     print(dij_matrix[0, :lmax])
 
     print('\n---- testing SHReturnTapersMap ----')
-    tapers, evalues = shtools.SHReturnTapersMap(dh_mask, lmax, ntapers=1)
+    tapers, evalues = pysh.spectralanalysis.SHReturnTapersMap(dh_mask, lmax,
+                                                              ntapers=1)
     print('best taper concentration: {:2.2f}'.format(evalues[0]))
 
 

--- a/examples/python/Other/TestOther.py
+++ b/examples/python/Other/TestOther.py
@@ -1,14 +1,11 @@
-#!/usr/bin/env python3
 """
 This script tests the gravity and magnetics routines.
 """
 import numpy as np
 import matplotlib.pyplot as plt
+import pyshtools as pysh
 
-import pyshtools
-from pyshtools import utils
-
-pyshtools.utils.figstyle()
+pysh.utils.figstyle()
 
 
 # ==== MAIN FUNCTION ====
@@ -22,27 +19,27 @@ def main():
 # ==== TEST FUNCTIONS ====
 
 def TestCircle():
-    coord = utils.MakeCircleCoord(30, 10, 30)
+    coord = pysh.utils.MakeCircleCoord(30, 10, 30)
     lat = coord[:, 0]
     lon = coord[:, 1]
     fig = plt.figure()
     plt.axis([-180, 180, -90, 90])
     plt.plot(lon, lat, 'r-', 10, 30, 'r.')
-    coord = utils.MakeCircleCoord(-75, -45, 10)
+    coord = pysh.utils.MakeCircleCoord(-75, -45, 10)
     plt.plot(coord[:, 1], coord[:, 0], 'b-', -45, -75, 'b.')
-    coord = utils.MakeEllipseCoord(0, 45, 20, 30, 10)
+    coord = pysh.utils.MakeEllipseCoord(0, 45, 20, 30, 10)
     plt.plot(coord[:, 1], coord[:, 0], 'g-', 45, 0, 'g.')
 
     fig.savefig('Circles.png')
 
 
 def TestWigner():
-    w3j, jmin, jmax = utils.Wigner3j(4, 2, 0, 0, 0)
+    w3j, jmin, jmax = pysh.utils.Wigner3j(4, 2, 0, 0, 0)
     print("< J, 4, 2 / 0, 0, 0 >")
     print("jmin = ", jmin)
     print("jmax = ", jmax)
     print(w3j)
-    w3j, jmin, jmax = utils.Wigner3j(10, 14, -1, -4, 5)
+    w3j, jmin, jmax = pysh.utils.Wigner3j(10, 14, -1, -4, 5)
     print("< J, 10, 14 / -1, -4, 5 >")
     print("jmin = ", jmin)
     print("jmax = ", jmax)
@@ -51,7 +48,7 @@ def TestWigner():
 
 def TestSHExpandWLSQ():
     file = "../../ExampleDataFiles/MarsTopo719.shape"
-    clm = pyshtools.SHCoeffs.from_file(file, lmax=9)
+    clm = pysh.SHCoeffs.from_file(file, lmax=9)
     nmax = 100
     np.random.seed(seed=123456)
     x = 2*np.random.random_sample(nmax)-1
@@ -67,10 +64,10 @@ def TestSHExpandWLSQ():
     print('Least squares inversion misit: chi2, chi2' +
           '(weighted, uniform weights),')
     for l in range(10):
-        hilm, chi2 = pyshtools.expand.SHExpandLSQ(d, lat, lon, l)
+        hilm, chi2 = pysh.expand.SHExpandLSQ(d, lat, lon, l)
         # hlm = pyshtools.SHCoeffs.from_array(hilm)
 
-        hilmw, chi2w = pyshtools.expand.SHExpandWLSQ(d, w, lat, lon, l)
+        hilmw, chi2w = pysh.expand.SHExpandWLSQ(d, w, lat, lon, l)
         # hlmw = pyshtools.SHCoeffs.from_array(hilmw)
 
         print('L = {:d}, chi2 = {:e}, chi2w = {:e}'

--- a/examples/python/SHRotations/SHRotations.py
+++ b/examples/python/SHRotations/SHRotations.py
@@ -1,13 +1,10 @@
-#!/usr/bin/env python3
 """
 This script tests the rotation of spherical harmonic coefficients
 """
 import numpy as np
+import pyshtools as pysh
 
-import pyshtools
-from pyshtools import rotate
-
-pyshtools.utils.figstyle()
+pysh.utils.figstyle()
 
 
 def main():
@@ -31,14 +28,14 @@ def test_SHRotations():
     print('computing rotation matrix for Euler angles: ' +
           '({:2.2f},{:2.2f},{:2.2f})'
           .format(alpha, beta, gamma))
-    dj_matrix = rotate.djpi2(lmax)
+    dj_matrix = pysh.rotate.djpi2(lmax)
 
     print('\n---- testing SHRotateRealCoef ----')
     print('generating normal distributed complex coefficients with ' +
           'variance 1...')
     rcoeffs = np.random.normal(size=(2, lmax + 1, lmax + 1))
     rcoeffs[np.invert(mask)] = 0.
-    rcoeffs_rot = rotate.SHRotateRealCoef(rcoeffs, angles, dj_matrix)
+    rcoeffs_rot = pysh.rotate.SHRotateRealCoef(rcoeffs, angles, dj_matrix)
     print(rcoeffs_rot)
 
     print('\n---- testing SHRotateCoef ----')
@@ -46,7 +43,7 @@ def test_SHRotations():
           'variance 1...')
     ccoeffs = np.random.normal(loc=0., scale=1.,
                                size=(2, (lmax + 1) * (lmax + 2) // 2))
-    ccoeffs_rot = rotate.SHRotateCoef(angles, ccoeffs, dj_matrix)
+    ccoeffs_rot = pysh.rotate.SHRotateCoef(angles, ccoeffs, dj_matrix)
     print(ccoeffs_rot)
 
 

--- a/examples/python/TestLegendre/TestLegendre.py
+++ b/examples/python/TestLegendre/TestLegendre.py
@@ -1,15 +1,12 @@
-#!/usr/bin/env python3
 """
 This script tests and plots all Geodesy normalized Legendre functions.
 Parameters can be changed in the main function.
 """
 import numpy as np
 import matplotlib.pyplot as plt
+import pyshtools as pysh
 
-import pyshtools
-from pyshtools import legendre
-
-pyshtools.utils.figstyle()
+pysh.utils.figstyle()
 
 
 # ==== MAIN FUNCTION ====
@@ -33,11 +30,11 @@ def test_legendre(lmax, normalization):
     print('testing Pl{0} and Pl{0}_d1...'.format(normalization))
     # --- import function from shtools ---
     if normalization == '':
-        Pl = legendre.PLegendre
-        Pl_d1 = legendre.PLegendre_d1
+        Pl = pysh.legendre.PLegendre
+        Pl_d1 = pysh.legendre.PLegendre_d1
     else:
-        Pl = getattr(legendre, 'Pl' + normalization)
-        Pl_d1 = getattr(legendre, 'Pl' + normalization + '_d1')
+        Pl = getattr(pysh.legendre, 'Pl' + normalization)
+        Pl_d1 = getattr(pysh.legendre, 'Pl' + normalization + '_d1')
 
     # --- derived parameters ---
     npoints = 5 * lmax
@@ -81,11 +78,11 @@ def test_associatedlegendre(lmax, mplot, normalization):
     print('testing Plm{0} and Plm{0}_d1...'.format(normalization))
     # --- import function from shtools ---
     if normalization == '':
-        Plm = legendre.PLegendreA
-        Plm_d1 = legendre.PLegendreA_d1
+        Plm = pysh.legendre.PLegendreA
+        Plm_d1 = pysh.legendre.PLegendreA_d1
     else:
-        Plm = getattr(legendre, 'Plm' + normalization)
-        Plm_d1 = getattr(legendre, 'Plm' + normalization + '_d1')
+        Plm = getattr(pysh.legendre, 'Plm' + normalization)
+        Plm_d1 = getattr(pysh.legendre, 'Plm' + normalization + '_d1')
 
     # --- derived parameters ---
     npoints = 5 * lmax
@@ -104,7 +101,7 @@ def test_associatedlegendre(lmax, mplot, normalization):
         Plm2_buf, dPlm2_buf = Plm_d1(lmax, z)
         for l in ls:
             for m in np.arange(l):
-                ind = legendre.PlmIndex(l, m) - 1  # Fortran indexing
+                ind = pysh.legendre.PlmIndex(l, m) - 1  # Fortran indexing
                 Plm1[iz, l, m] = Plm1_buf[ind]
                 Plm2[iz, l, m] = Plm2_buf[ind]
                 dPlm2[iz, l, m] = dPlm2_buf[ind]

--- a/examples/python/TimingAccuracy/TimingAccuracyDH.py
+++ b/examples/python/TimingAccuracy/TimingAccuracyDH.py
@@ -1,13 +1,10 @@
-#!/usr/bin/env python3
 """
 This script is a python version of TimingAccuracy. We use some numpy functions
 to simplify the creation of random coefficients.
 """
 import time
 import numpy as np
-
-from pyshtools import expand
-from pyshtools import spectralanalysis
+import pyshtools as pysh
 
 
 # ==== MAIN FUNCTION ====
@@ -35,7 +32,7 @@ def TimingAccuracyDH(sampling=1):
                                                      (maxdeg + 1)))
     np.random.seed(0)
     cilm = np.random.normal(loc=0., scale=1., size=(2, maxdeg + 1, maxdeg + 1))
-    old_power = spectralanalysis.spectrum(cilm)
+    old_power = pysh.spectralanalysis.spectrum(cilm)
     new_power = 1. / (1. + ls)**beta  # initialize degrees > 0 to power-law
     cilm[:, :, :] *= np.sqrt(new_power / old_power)[None, :, None]
     cilm[~mask] = 0.
@@ -51,13 +48,13 @@ def TimingAccuracyDH(sampling=1):
 
         # synthesis / inverse
         tstart = time.time()
-        grid = expand.MakeGridDH(cilm_trim, sampling=sampling)
+        grid = pysh.expand.MakeGridDH(cilm_trim, sampling=sampling)
         tend = time.time()
         tinverse = tend - tstart
 
         # analysis / forward
         tstart = time.time()
-        cilm2_trim = expand.SHExpandDH(grid, sampling=sampling)
+        cilm2_trim = pysh.expand.SHExpandDH(grid, sampling=sampling)
         tend = time.time()
         tforward = tend - tstart
 

--- a/examples/python/TimingAccuracy/TimingAccuracyDHC.py
+++ b/examples/python/TimingAccuracy/TimingAccuracyDHC.py
@@ -1,13 +1,10 @@
-#!/usr/bin/env python3
 """
 This script is a python version of TimingAccuracyDHC. We use numpy functions to
 simplify the creation of random coefficients.
 """
 import time
 import numpy as np
-
-from pyshtools import expand
-from pyshtools import spectralanalysis
+import pyshtools as pysh
 
 
 # ==== MAIN FUNCTION ====
@@ -41,7 +38,7 @@ def TimingAccuracyDHC(sampling=1):
                                  size=(2, maxdeg + 1, maxdeg + 1))
     cilm.real = np.random.normal(loc=0., scale=1.,
                                  size=(2, maxdeg + 1, maxdeg + 1))
-    old_power = spectralanalysis.spectrum(cilm)
+    old_power = pysh.spectralanalysis.spectrum(cilm)
     new_power = 1. / (1. + ls)**beta  # initialize degrees > 0 to power-law
     cilm[:, :, :] *= np.sqrt(new_power / old_power)[None, :, None]
     cilm[~mask] = 0.
@@ -57,13 +54,13 @@ def TimingAccuracyDHC(sampling=1):
 
         # synthesis / inverse
         tstart = time.time()
-        grid = expand.MakeGridDHC(cilm_trim, sampling=sampling)
+        grid = pysh.expand.MakeGridDHC(cilm_trim, sampling=sampling)
         tend = time.time()
         tinverse = tend - tstart
 
         # analysis / forward
         tstart = time.time()
-        cilm2_trim = expand.SHExpandDHC(grid, sampling=sampling)
+        cilm2_trim = pysh.expand.SHExpandDHC(grid, sampling=sampling)
         tend = time.time()
         tforward = tend - tstart
 

--- a/examples/python/TimingAccuracy/TimingAccuracyGLQ.py
+++ b/examples/python/TimingAccuracy/TimingAccuracyGLQ.py
@@ -1,13 +1,10 @@
-#!/usr/bin/env python3
 """
 This script is a python version of TimingAccuracyGLQ. We use numpy functions to
 simplify the creation of random coefficients.
 """
 import time
 import numpy as np
-
-from pyshtools import expand
-from pyshtools import spectralanalysis
+import pyshtools as pysh
 
 
 # ==== MAIN FUNCTION ====
@@ -37,7 +34,7 @@ def TimingAccuracyGLQ():
     cilm = np.random.normal(loc=0., scale=1., size=(2, maxdeg + 1, maxdeg + 1))
     cilm[:, 1:, :] *= np.sqrt((ls[1:]**beta) /
                               (2. * ls[1:] + 1.))[None, :, None]
-    old_power = spectralanalysis.spectrum(cilm)
+    old_power = pysh.spectralanalysis.spectrum(cilm)
     new_power = 1. / (1. + ls)**beta  # initialize degrees > 0 to power-law
     cilm[:, :, :] *= np.sqrt(new_power / old_power)[None, :, None]
     cilm[~mask] = 0.
@@ -53,19 +50,19 @@ def TimingAccuracyGLQ():
 
         # precompute grid nodes and associated Legendre functions
         tstart = time.time()
-        zeros, weights = expand.SHGLQ(lmax)
+        zeros, weights = pysh.expand.SHGLQ(lmax)
         tend = time.time()
         tprecompute = tend - tstart
 
         # synthesis / inverse
         tstart = time.time()
-        grid = expand.MakeGridGLQ(cilm_trim, zeros)
+        grid = pysh.expand.MakeGridGLQ(cilm_trim, zeros)
         tend = time.time()
         tinverse = tend - tstart
 
         # analysis / forward
         tstart = time.time()
-        cilm2_trim = expand.SHExpandGLQ(grid, weights, zeros)
+        cilm2_trim = pysh.expand.SHExpandGLQ(grid, weights, zeros)
         tend = time.time()
         tforward = tend - tstart
 

--- a/examples/python/TimingAccuracy/TimingAccuracyGLQC.py
+++ b/examples/python/TimingAccuracy/TimingAccuracyGLQC.py
@@ -1,13 +1,10 @@
-#!/usr/bin/env python3
 """
 This script is a python version of TimingAccuracyGLQC. We use numpy
 functions to simplify the creation of random coefficients.
 """
 import time
 import numpy as np
-
-from pyshtools import expand
-from pyshtools import spectralanalysis
+import pyshtools as pysh
 
 
 # ==== MAIN FUNCTION ====
@@ -41,7 +38,7 @@ def TimingAccuracyGLQC():
     cilm.real = np.random.normal(loc=0., scale=1.,
                                  size=(2, maxdeg + 1, maxdeg + 1))
 
-    old_power = spectralanalysis.spectrum(cilm)
+    old_power = pysh.spectralanalysis.spectrum(cilm)
     new_power = 1. / (1. + ls)**beta  # initialize degrees > 0 to power-law
     cilm[:, :, :] *= np.sqrt(new_power / old_power)[None, :, None]
     cilm[~mask] = 0.
@@ -57,19 +54,19 @@ def TimingAccuracyGLQC():
 
         # precompute grid nodes and associated Legendre functions
         tstart = time.time()
-        zeros, weights = expand.SHGLQ(lmax)
+        zeros, weights = pysh.expand.SHGLQ(lmax)
         tend = time.time()
         tprecompute = tend - tstart
 
         # synthesis / inverse
         tstart = time.time()
-        grid = expand.MakeGridGLQC(cilm_trim, zeros)
+        grid = pysh.expand.MakeGridGLQC(cilm_trim, zeros)
         tend = time.time()
         tinverse = tend - tstart
 
         # analysis / forward
         tstart = time.time()
-        cilm2_trim = expand.SHExpandGLQC(grid, weights, zeros)
+        cilm2_trim = pysh.expand.SHExpandGLQC(grid, weights, zeros)
         tend = time.time()
         tforward = tend - tstart
 

--- a/examples/python/ducctest.py
+++ b/examples/python/ducctest.py
@@ -2,7 +2,6 @@ import numpy as np
 import pyshtools as pysh
 from time import time
 
-
 nthreads = 1
 
 


### PR DESCRIPTION
* Update web documentation.
* Update python examples so that they don't call routines directly in the shtools backend.

Note: The module `pyshtools.shtools` will be deprecated in the v4.11 release. This module represents 1 of 2 possible backends for pyshtools, and will henceforth be located at `pyshtools.backends.shtools`. Unless explicitly required, the user should avoid using the `backends` modules directly, and should instead call the routines that are located in the top level modules such as `pyshtools.expand`. Setting the backend by use of the routine `pyshtools.backends.selected_preferred_backend()` determines which backed to use when calling the routines in the top level modules.