### PR TITLE
Fix setup.py to work with setuptools newer and older than 62.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -150,10 +150,17 @@ class install(_install):
 
 def distutils_dir_name(dname):
     """Returns the name of a distutils build directory"""
-    f = "{dirname}.{platform}-{cache_tag}"
-    return f.format(dirname=dname,
-                    platform=sysconfig.get_platform(),
-                    cache_tag=sys.implementation.cache_tag)
+    parse_version = setuptools.version.pkg_resources.packaging.version.parse
+    if parse_version(setuptools.__version__) < parse_version('62.1.0'):
+        f = "{dirname}.{platform}-{version[0]}.{version[1]}"
+        return f.format(dirname=dname,
+                        platform=sysconfig.get_platform(),
+                        version=sys.version_info)
+    else:
+        f = "{dirname}.{platform}-{cache_tag}"
+        return f.format(dirname=dname,
+                        platform=sysconfig.get_platform(),
+                        cache_tag=sys.implementation.cache_tag)
 
 
 # configure python extension to be compiled with f2py


### PR DESCRIPTION
The PR fixes `setup.py` to work with all versions of setuptools. In a previous commit, we fixed this to work with setuptools=62.1.0, but this was not backwards compatible. This change checks for the version of setuptools and then formats the build directory accordingly.



**Reminders**

- [ ] Base all changes on the `develop` branch: the `master` branch is used only when releasing new versions.
- [ ] Run `make check` to ensure that the python code follows standard formatting conventions.
- [ ] If adding new features, update the docstring to provide all information that is required to use the feature.
