### PR TITLE
fix_np_types

### DIFF
--- a/pyshtools/shclasses/shcoeffs.py
+++ b/pyshtools/shclasses/shcoeffs.py
@@ -959,7 +959,7 @@ class SHCoeffs(object):
         ls = _np.array(ls)
         ms = _np.array(ms)
 
-        mneg_mask = (ms < 0).astype(_np.int)
+        mneg_mask = (ms < 0).astype(_np.int_)
         self.coeffs[mneg_mask, ls, _np.abs(ms)] = values
 
     # ---- IO Routines

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -1281,7 +1281,7 @@ class SHGravCoeffs(object):
         ls = _np.array(ls)
         ms = _np.array(ms)
 
-        mneg_mask = (ms < 0).astype(_np.int)
+        mneg_mask = (ms < 0).astype(_np.int_)
         self.coeffs[mneg_mask, ls, _np.abs(ms)] = values
 
     # ---- IO routines ----

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -960,7 +960,7 @@ class SHMagCoeffs(object):
         ls = _np.array(ls)
         ms = _np.array(ms)
 
-        mneg_mask = (ms < 0).astype(_np.int)
+        mneg_mask = (ms < 0).astype(_np.int_)
         self.coeffs[mneg_mask, ls, _np.abs(ms)] = values
 
     # ---- IO routines ----


### PR DESCRIPTION
Dear colleague,

This is a minor change (3 characters), to fix this error I had:
```
>>> import pyshtools as pysh
>>> hlm = pysh.datasets.Venus.VenusTopo719()
>>> hlm.set_coeffs(ls=2, ms=0, values=0.)

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "[...]/lib/python3.8/site-packages/pyshtools/shclasses/shcoeffs.py", line 962, in set_coeffs
    mneg_mask = (ms < 0).astype(_np.int)
  File "[...]/lib/python3.8/site-packages/numpy/__init__.py", line 284, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'int'
```
This error appears for the latest numpy release, I traced it back to [this numpy deprecation](https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated) (2021-01-30).

As recommended in the release notes, I replaced the 3 occurrences of `_np.int` by `_np.int_`.
The pull request fixes the error, and also does not break with the earlier versions of numpy that were already working well.

Regards

</br></br>
**Reminders**

- [x] Base all changes on the `develop` branch: the `master` branch is used only when releasing new versions.
- [x] Run `make check` to ensure that the python code follows standard formatting conventions.
- [n/a] If adding new features, update the docstring to provide all information that is required to use the feature.
