### PR TITLE
fix import of pkg_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ try:
     import pypandoc
     rst = pypandoc.convert_file('README.md', 'rst')
     long_description = rst.split('\n', 5)[5]
-except(IOError, ImportError):
+except (IOError, ImportError):
     print('*** pypandoc is not installed. PYPI long_description will not be '
           'formatted correctly. ***')
     long_description = open('README.md').read()

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ if sys.version_info < min_version:
     raise SystemError(error)
 
 import os  # noqa: E402
+import pkg_resources  # noqa: E402
 import sysconfig  # noqa: E402
 import setuptools  # noqa: E402
 import numpy  # noqa: E402
@@ -150,7 +151,7 @@ class install(_install):
 
 def distutils_dir_name(dname):
     """Returns the name of a distutils build directory"""
-    parse_version = setuptools.version.pkg_resources.packaging.version.parse
+    parse_version = pkg_resources.packaging.version.parse
     if parse_version(setuptools.__version__) < parse_version('62.1.0'):
         f = "{dirname}.{platform}-{version[0]}.{version[1]}"
         return f.format(dirname=dname,


### PR DESCRIPTION
While trying to [fix the conda recipe for arm64](https://github.com/conda-forge/pyshtools-feedstock/pull/37), I ran into an issue for all platforms with updated setuptools versions.

`setup.py` was previously relying on `pkg_resources` being imported from `setuptools`. That broke in
https://github.com/pypa/setuptools/commit/6050634818943befefe3a85a12503b6d8a1e8106






**Reminders**

- [x] Base all changes on the `develop` branch: the `master` branch is used only when releasing new versions.
- [x] Run `make check` to ensure that the python code follows standard formatting conventions.
- [ ] If adding new features, update the docstring to provide all information that is required to use the feature.
