### PR TITLE
Allow passing test input data from command line

### DIFF
--- a/examples/cpp/test.cpp
+++ b/examples/cpp/test.cpp
@@ -26,7 +26,7 @@ int
 main(int argc, char** argv)
 {
 
-  std::string infile = "../ExampleDataFiles/MarsTopo719.shape";
+  std::string infile;
 
   int lmax = 15;
   int cilm_dim = lmax + 1;
@@ -37,6 +37,12 @@ main(int argc, char** argv)
   
   int exitstatus;
 
+  if( argc > 1 ){
+    infile = argv[1];
+  } else {
+    infile = "../ExampleDataFiles";
+  }
+  infile += "/MarsTopo719.shape";
   shtools::SHRead(infile.c_str(),
                    infile.size(),
                    &cilm[0],

--- a/examples/fortran/MarsCrustalThickness/MarsCrustalThickness.f95
+++ b/examples/fortran/MarsCrustalThickness/MarsCrustalThickness.f95
@@ -44,12 +44,67 @@ program MarsCrustalThickness
                       n_out, iter, j, r1, lmaxp, lmaxt, filter_type, half, &
                       degmax, sampling
     character(120) :: grav_file, moho_out, thick_grid_out, topo_file, &
-                      misfit_file
+                      misfit_file, infile
 
-    print*,  "rho_crust (kg/m3) > "
-    read(*,*) rho_crust
-    print*, "rho_mantle (kg/m3) > "
-    read(*,*) rho_mantle
+    ! Path to example data files may be passed as first argument, or use a default.
+    if (command_argument_count() > 0) then
+        call get_command_argument(1, infile)
+    else
+        infile = "../../ExampleDataFiles"
+    end if
+
+    grav_file = trim(infile) // "/gmm3_120_sha.tab"
+    topo_file = trim(infile) // "/MarsTopo719.shape"
+
+    ! A data input file may be passed as second argument, or else prompt for required settings.
+    if (command_argument_count() > 1) then
+        call get_command_argument(2, infile)
+        open(unit=20, file=infile, action="read")
+        read(20,*) rho_crust
+        read(20,*) rho_mantle
+        read(20,*) filter_type
+        if (filter_type /= 0 ) then
+            read(20,*) half
+        end if
+        read(20,*) r1
+        read(20,*) degmax
+        read(20,*) t0
+        read(20,*) moho_out
+        read(20,*) interval
+        read(20,*) thick_grid_out
+        read(20,*) misfit_file
+        close(20)
+    else
+        print*,  "rho_crust (kg/m3) > "
+        read(*,*) rho_crust
+        print*, "rho_mantle (kg/m3) > "
+        read(*,*) rho_mantle
+
+        print*, "Input filter type (1) Minimum amplitude, (2) minimum curvature, (0) no filter "
+        read(*,*) filter_type
+        if (filter_type /= 0 ) then
+            print*, "Degree at which the filter is 1/2 "
+            read(*,*) half
+        end if
+
+        print*, "Remove degree 1 topo coefficients from Bouguer Correction? (0:no, 1:yes) > "
+        read(*,*) r1
+
+        print*, "maximum degree to compute Moho relief to >"
+        read(*,*) degmax
+
+        print*, "Minimum assumed crustal thickness (km) > "
+        read(*,*) t0
+
+        print*, "Moho spherical harmonic coeficient output filename > "
+        read(*,*) moho_out
+        print*, "Grid spacing for output crustal thickness map (degrees) > "
+        read(*,*) interval
+        print*, "gridded crustal thickness output filename >"
+        read(*,*) thick_grid_out
+        print*, "Gravity misfit spherical harmonic filename >"
+        read(*,*) misfit_file
+    end if
 
     pi = acos(-1.0_dp)
     delta_max = 5.0_dp
@@ -66,38 +121,11 @@ program MarsCrustalThickness
 
     nmax = 7    ! nmax of Wieczorek and Phillips (1998)
 
-    print*, "Input filter type (1) Minimum amplitude, (2) minimum curvature, (0) no filter "
-    read(*,*) filter_type
-    if (filter_type /= 0 ) then
-        print*, "Degree at which the filter is 1/2 " 
-        read(*,*) half
-    end if
-
-    grav_file = "../../ExampleDataFiles/gmm3_120_sha.tab"
-    topo_file = "../../ExampleDataFiles/MarsTopo719.shape"
-
-    print*, "Remove degree 1 topo coefficients from Bouguer Correction? (0:no, 1:yes) > "
-    read(*,*) r1
-
-    print*, "maximum degree to compute Moho relief to >"
-    read(*,*) degmax
-
     lmax = 2 * degmax ! this partially takes into account aliasing problems. Technically, it should be nmax*degmax
 
     nlat = 2 * lmax + 2
     nlong = 2 * nlat
-    print*, "Minimum assumed crustal thickness (km) > "
-    read(*,*) t0
     t0 = t0 * 1.0e3_dp
-
-    print*, "Moho spherical harmonic coeficient output filename > "
-    read(*,*) moho_out
-    print*, "Grid spacing for output crustal thickness map (degrees) > "
-    read(*,*) interval
-    print*, "gridded crustal thickness output filename >"
-    read(*,*) thick_grid_out
-    print*, "Gravity misfit spherical harmonic filename >"
-    read(*,*) misfit_file
 
     call cpu_time(timein)
 

--- a/examples/fortran/SHCilmPlus/TestCilmPlus.f95
+++ b/examples/fortran/SHCilmPlus/TestCilmPlus.f95
@@ -76,7 +76,13 @@ program TestCilmPlus
 
     !print*, "Spherical Harmonic file > "
     !read(*,*) infile
-    infile = "../../ExampleDataFiles/MarsTopo719.shape"
+    ! Path to example data files may be passed as first argument, or use a default.
+    if (command_argument_count() > 0) then
+        call get_command_argument(1, infile)
+    else
+        infile = "../../ExampleDataFiles"
+    end if
+    infile = trim(infile) // "/MarsTopo719.shape"
 
     !print*, "Maximum degree to read > "
     !read(*,*) lmax

--- a/examples/fortran/SHExpandDH/TestExpandDH.f95
+++ b/examples/fortran/SHExpandDH/TestExpandDH.f95
@@ -14,13 +14,19 @@ Program TestExpandDH
 
     implicit none
     integer(int32), parameter :: maxdeg = 120, maxgrid = 800
-    character(80) :: infile
+    character(120) :: infile
     real(dp) :: cilm(2, maxdeg+1, maxdeg+1), grid(maxgrid, maxgrid), &
                 griddh(maxgrid, maxgrid), cilm2(2, maxdeg+1, maxdeg+1), &
                 interval, error, maxerror
     integer(int32) :: lmax, n, nlat, nlong, lmax2, l, m, i
 
-    infile = "../../ExampleDataFiles/MarsTopo719.shape"
+    ! Path to example data files may be passed as first argument, or use a default.
+    if (command_argument_count() > 0) then
+        call get_command_argument(1, infile)
+    else
+        infile = "../../ExampleDataFiles"
+    end if
+    infile = trim(infile) // "/MarsTopo719.shape"
 
     call SHRead(infile, cilm, lmax)
     print*, "Lmax of data file = ", lmax

--- a/examples/fortran/SHExpandLSQ/TestSHExpandLSQ.f95
+++ b/examples/fortran/SHExpandLSQ/TestSHExpandLSQ.f95
@@ -22,7 +22,7 @@ program TestSHExpandLSQ
                 x, y, z, pi, maxerror, cilm1(2,degmax+1, degmax+1), &
                 dd(dmax), misfit
     integer(int32) :: nmax, lmax, l, i, seed, lmaxfile
-    character(80) :: infile
+    character(120) :: infile
 
     d = 0.0_dp
     dd = 0.0_dp
@@ -30,13 +30,28 @@ program TestSHExpandLSQ
     lat = 0.0_dp
     pi = acos(-1.0_dp)
 
-    infile = "../../ExampleDataFiles/MarsTopo719.shape"
+    ! Path to example data files may be passed as first argument, or use a default.
+    if (command_argument_count() > 0) then
+        call get_command_argument(1, infile)
+    else
+        infile = "../../ExampleDataFiles"
+    end if
+    infile = trim(infile) // "/MarsTopo719.shape"
 
     call SHRead(infile, cilm, lmaxfile)
     print*, "Maximum degree of spherical harmonic file = ", lmaxfile
 
-    print*, "Number of random data points to use > "
-    read(*,*) nmax
+    ! A data input file may be passed as second argument, or else prompt for required settings.
+    if (command_argument_count() > 1) then
+        call get_command_argument(2, infile)
+        open(unit=20, file=infile, action="read")
+        read(20,*) nmax
+        close(20)
+    else
+        print*, "Number of random data points to use > "
+        read(*,*) nmax
+    end if
+
     lmax = floor(sqrt(dble(nmax)) - 1)
     print*, "Maximum spherical harmonic degree for overdetermined least-squares inversion = ", lmax
 

--- a/examples/fortran/SHMag/SHMag.f95
+++ b/examples/fortran/SHMag/SHMag.f95
@@ -25,7 +25,13 @@ program SHMag
                              total(:,:), pot(:,:)
     integer(int32) :: lmax, lmaxp, n, n_out, nlong, nlat, i, j, astat(6), sampling
 
-    infile = "../../ExampleDataFiles/FSU_mars90.sh"
+    ! Path to example data files may be passed as first argument, or use a default.
+    if (command_argument_count() > 0) then
+        call get_command_argument(1, infile)
+    else
+        infile = "../../ExampleDataFiles"
+    end if
+    infile = trim(infile) // "/FSU_mars90.sh"
 
     f = 1.0_dp / 169.864881_dp    ! Mars flattening = (R_eq - R_p)/R_eq
     mpr = 3389.508e3_dp           ! Mean radius of mars

--- a/examples/fortran/SHRotate/TestSHRotate.f95
+++ b/examples/fortran/SHRotate/TestSHRotate.f95
@@ -27,26 +27,55 @@ program TestSHRotate
         stop
     end if
 
-    infile = "../../ExampleDataFiles/MarsTopo719.shape"
+    ! Path to example data files may be passed as first argument, or use a default.
+    if (command_argument_count() > 0) then
+        call get_command_argument(1, infile)
+    else
+        infile = "../../ExampleDataFiles"
+    end if
+    infile = trim(infile) // "/MarsTopo719.shape"
     print*, "Input file = ", infile
     call SHRead(infile, cilm1, lmax)
     print*, "Lmax of input file = ", lmax
 
-    print*, "Maximum degree to be used with rotations > "
-    read(*,*) lmax
+    ! A data input file may be passed as second argument, or else prompt for required settings.
+    if (command_argument_count() > 1) then
+        call get_command_argument(2, infile)
+        open(unit=20, file=infile, action="read")
+        read(20,*) lmax
+        read(20,*) alpha
+        read(20,*) beta
+        read(20,*) gamma
+        read(20,*) bodycoord
+        read(20,*) outsh
+        read(20,*) interval
+        read(20,*) outgrid
+        close(20)
+    else
+        print*, "Maximum degree to be used with rotations > "
+        read(*,*) lmax
 
-    print*, "Input Euler Angles"
-    print*, "Alpha (deg) = "
-    read(*,*) alpha
-    print*, "Beta (deg) = "
-    read(*,*) beta
-    print*, "Gamma (deg) = "
-    read(*,*) gamma
+        print*, "Input Euler Angles"
+        print*, "Alpha (deg) = "
+        read(*,*) alpha
+        print*, "Beta (deg) = "
+        read(*,*) beta
+        print*, "Gamma (deg) = "
+        read(*,*) gamma
 
-    print*, "Do these correspond to "
-    print*, "(1) Rotation of the coordinate system without rotation of the physical body, or"
-    print*, "(2) Rotation of the physical body without rotation of the coordinate system."
-    read(*,*) bodycoord
+        print*, "Do these correspond to "
+        print*, "(1) Rotation of the coordinate system without rotation of the physical body, or"
+        print*, "(2) Rotation of the physical body without rotation of the coordinate system."
+        read(*,*) bodycoord
+
+        print*, "Output file name of rotated spherical harmonics > "
+        read(*,*) outsh
+
+        print*, "Grid spacing for output grid (deg) > "
+        read(*,*) interval
+        print*, "File name of gridded rotated field > "
+        read(*,*) outgrid
+    end if
 
     if (bodycoord ==1) then
         x(1) = alpha ; x(2) = beta ; x(3) = gamma
@@ -58,14 +87,6 @@ program TestSHRotate
     end if
 
     x = x * pi / 180.0_dp
-
-    print*, "Output file name of rotated spherical harmonics > "
-    read(*,*) outsh
-
-    print*, "Grid spacing for output grid (deg) > "
-    read(*,*) interval
-    print*, "File name of gridded rotated field > "
-    read(*,*) outgrid
 
     allocate(cilm2(2, lmax+1, lmax+1), stat = astat(2))
     allocate(dj(lmax+1, lmax+1, lmax+1), stat = astat(3))


### PR DESCRIPTION
When building with Meson, the build will _always_ be in an out-of-source build directory, so tests cannot rely on relative paths like these do to find their data.

This PR reads the data path from the command line, which allows testing from any build directory, no matter where it is, as the path to the source directory can be passed.

I also had to modify the an additional input file to some of the Fortran tests, in order to supply test options directly, instead of as data on standard input.

**Reminders**

- [x] Base all changes on the `develop` branch: the `master` branch is used only when releasing new versions.
- [x] Run `make check` to ensure that the python code follows standard formatting conventions.
- [n/a] If adding new features, update the docstring to provide all information that is required to use the feature.
