### PR TITLE
Update url for Earth2012/2014 datasets

### DIFF
--- a/pyshtools/datasets/Earth/Earth2012/__init__.py
+++ b/pyshtools/datasets/Earth/Earth2012/__init__.py
@@ -42,7 +42,7 @@ def shape_air(lmax=2160):
         doi:10.1029/2011JB008878.
     '''
     fname = _retrieve(
-        url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.shape_air.SHCto2160.zip",  # noqa: E501
+        url="http://ddfe.curtin.edu.au/models/Earth2012/topo_shape_to2160/Earth2012.shape_air.SHCto2160.zip",  # noqa: E501
         known_hash="sha256:07b948727c96022f40375d82cb3e505732fb3e1bf72f41b1cc072445dafab059",  # noqa: E501
         downloader=_HTTPDownloader(progressbar=True),
         path=_os_cache('pyshtools'),
@@ -69,7 +69,7 @@ def shape_bathy(lmax=2160):
         doi:10.1029/2011JB008878.
     '''
     fname = _retrieve(
-        url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.shape_bathy.SHCto2160.zip",  # noqa: E501
+        url="http://ddfe.curtin.edu.au/models/Earth2012/topo_shape_to2160/Earth2012.shape_bathy.SHCto2160.zip",  # noqa: E501
         known_hash="sha256:ee03c7addf13f60efd3c928f166f83f5a9f17991c9dd74a88c6c8d9ede8bb15e",  # noqa: E501
         downloader=_HTTPDownloader(progressbar=True),
         path=_os_cache('pyshtools'),
@@ -98,7 +98,7 @@ def shape_bathy_bed(lmax=2160):
         doi:10.1029/2011JB008878.
     '''
     fname = _retrieve(
-        url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.shape_bathy_bed.SHCto2160.zip",  # noqa: E501
+        url="http://ddfe.curtin.edu.au/models/Earth2012/topo_shape_to2160/Earth2012.shape_bathy_bed.SHCto2160.zip",  # noqa: E501
         known_hash="sha256:66ffd58246566b4f62cc1f71145388057a4c2a1a8142f55e089e26a0b2a22d57",  # noqa: E501
         downloader=_HTTPDownloader(progressbar=True),
         path=_os_cache('pyshtools'),
@@ -126,7 +126,7 @@ def shape_ret(lmax=2160):
         doi:10.1029/2011JB008878.
     '''
     fname = _retrieve(
-        url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.shape_RET2012.SHCto2160.zip",  # noqa: E501
+        url="http://ddfe.curtin.edu.au/models/Earth2012/topo_shape_to2160/Earth2012.shape_RET2012.SHCto2160.zip",  # noqa: E501
         known_hash="sha256:16c769df9d2c790fb62d1a1e73fd6070c5b5b663c2bd7f68fd21ad4aa8c96a2b",  # noqa: E501
         downloader=_HTTPDownloader(progressbar=True),
         path=_os_cache('pyshtools'),
@@ -154,7 +154,7 @@ def topo_air(lmax=2160):
         doi:10.1029/2011JB008878.
     '''
     fname = _retrieve(
-        url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.topo_air.SHCto2160.zip",  # noqa: E501
+        url="http://ddfe.curtin.edu.au/models/Earth2012/topo_shape_to2160/Earth2012.topo_air.SHCto2160.zip",  # noqa: E501
         known_hash="sha256:7b68053ba74246f1a755fcce05266a58ab96529b1e48309b98a0e9ba49b4ba3f",  # noqa: E501
         downloader=_HTTPDownloader(progressbar=True),
         path=_os_cache('pyshtools'),
@@ -183,7 +183,7 @@ def topo_bathy(lmax=2160):
         doi:10.1029/2011JB008878.
     '''
     fname = _retrieve(
-        url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.topo_bathy.SHCto2160.zip",  # noqa: E501
+        url="http://ddfe.curtin.edu.au/models/Earth2012/topo_shape_to2160/Earth2012.topo_bathy.SHCto2160.zip",  # noqa: E501
         known_hash="sha256:997a16f85dafbfd1a0ee2339f503470acea6c8cb8eecdf5f2e057904a97f9718",  # noqa: E501
         downloader=_HTTPDownloader(progressbar=True),
         path=_os_cache('pyshtools'),
@@ -213,7 +213,7 @@ def topo_bathy_bed(lmax=2160):
         doi:10.1029/2011JB008878.
     '''
     fname = _retrieve(
-        url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.topo_bathy_bed.SHCto2160.zip",  # noqa: E501
+        url="http://ddfe.curtin.edu.au/models/Earth2012/topo_shape_to2160/Earth2012.topo_bathy_bed.SHCto2160.zip",  # noqa: E501
         known_hash="sha256:f8b0535a76de11de767d0ebb6c032f5983ac48ad29d1750b0d22e15a627f88e1",  # noqa: E501
         downloader=_HTTPDownloader(progressbar=True),
         path=_os_cache('pyshtools'),
@@ -241,7 +241,7 @@ def ret(lmax=2160):
         doi:10.1029/2011JB008878.
     '''
     fname = _retrieve(
-        url="http://ddfe.curtin.edu.au/gravitymodels/Earth2012/topo_shape_to2160/Earth2012.RET2012.SHCto2160.zip",  # noqa: E501
+        url="http://ddfe.curtin.edu.au/models/Earth2012/topo_shape_to2160/Earth2012.RET2012.SHCto2160.zip",  # noqa: E501
         known_hash="sha256:36b3204d86fa01fa9e8f693e2df8e91905b67619a0192cc0c269be21a7ba5799",  # noqa: E501
         downloader=_HTTPDownloader(progressbar=True),
         path=_os_cache('pyshtools'),

--- a/pyshtools/datasets/Earth/Earth2014/__init__.py
+++ b/pyshtools/datasets/Earth/Earth2014/__init__.py
@@ -45,10 +45,10 @@ def surface(lmax=2160):
         and Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
     '''
     if lmax <= 2160:
-        file_url = "http://ddfe.curtin.edu.au/gravitymodels/Earth2014/data_5min/shcs_to2160/Earth2014.SUR2014.degree2160.bshc"  # noqa: E501
+        file_url = "http://ddfe.curtin.edu.au/models/Earth2014/data_5min/shcs_to2160/Earth2014.SUR2014.degree2160.bshc"  # noqa: E501
         file_hash = "sha256:5694260d135c17427270ed18d48af23f4788e5fbc1dfb9dcb19f1cf9b401c9ce"  # noqa: E501
     else:
-        file_url = "http://ddfe.curtin.edu.au/gravitymodels/Earth2014/data_1min/shcs_to10800/Earth2014.SUR2014.degree10800.bshc"  # noqa: E501
+        file_url = "http://ddfe.curtin.edu.au/models/Earth2014/data_1min/shcs_to10800/Earth2014.SUR2014.degree10800.bshc"  # noqa: E501
         file_hash = "sha256:f9cc0209cffeb1faef58ec9d03886941448bfffd9e36f5ee56c51063c3f778f9"  # noqa: E501
 
     fname = _retrieve(
@@ -79,10 +79,10 @@ def bedrock(lmax=2160):
         and Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
     '''
     if lmax <= 2160:
-        file_url = "http://ddfe.curtin.edu.au/gravitymodels/Earth2014/data_5min/shcs_to2160/Earth2014.BED2014.degree2160.bshc"  # noqa: E501
+        file_url = "http://ddfe.curtin.edu.au/models/Earth2014/data_5min/shcs_to2160/Earth2014.BED2014.degree2160.bshc"  # noqa: E501
         file_hash = "sha256:146dcc80f17d201352d391aa90f487f5ed16006a6a3966add2d023b998727af7"  # noqa: E501
     else:
-        file_url = "http://ddfe.curtin.edu.au/gravitymodels/Earth2014/data_1min/shcs_to10800/Earth2014.BED2014.degree10800.bshc"  # noqa: E501
+        file_url = "http://ddfe.curtin.edu.au/models/Earth2014/data_1min/shcs_to10800/Earth2014.BED2014.degree10800.bshc"  # noqa: E501
         file_hash = "sha256:6a2976484d1b62b89e4bb55b484adcd037c9bf2f03a5272a1dffb3c644e0e6ec"  # noqa: E501
 
     fname = _retrieve(
@@ -113,10 +113,10 @@ def tbi(lmax=2160):
         and Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
     '''
     if lmax <= 2160:
-        file_url = "http://ddfe.curtin.edu.au/gravitymodels/Earth2014/data_5min/shcs_to2160/Earth2014.TBI2014.degree2160.bshc"  # noqa: E501
+        file_url = "http://ddfe.curtin.edu.au/models/Earth2014/data_5min/shcs_to2160/Earth2014.TBI2014.degree2160.bshc"  # noqa: E501
         file_hash = "sha256:84a72ef25fe26fd746d2c6988c01840a12e9e414ee266e9357acb81faaaa6d5f"  # noqa: E501
     else:
-        file_url = "http://ddfe.curtin.edu.au/gravitymodels/Earth2014/data_1min/shcs_to10800/Earth2014.TBI2014.degree10800.bshc"  # noqa: E501
+        file_url = "http://ddfe.curtin.edu.au/models/Earth2014/data_1min/shcs_to10800/Earth2014.TBI2014.degree10800.bshc"  # noqa: E501
         file_hash = "sha256:72ffb432d268ae6972d3251ef395b980b38e3313627c6c981a0197882efb4f4c"  # noqa: E501
 
     fname = _retrieve(
@@ -148,10 +148,10 @@ def ret(lmax=2160):
         and Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
     '''
     if lmax <= 2160:
-        file_url = "http://ddfe.curtin.edu.au/gravitymodels/Earth2014/data_5min/shcs_to2160/Earth2014.RET2014.degree2160.bshc"  # noqa: E501
+        file_url = "http://ddfe.curtin.edu.au/models/Earth2014/data_5min/shcs_to2160/Earth2014.RET2014.degree2160.bshc"  # noqa: E501
         file_hash = "sha256:1fa87749532811614c00e9723dae1aa312e5511570d101bccb74bc40cb7dd5d1"  # noqa: E501
     else:
-        file_url = "http://ddfe.curtin.edu.au/gravitymodels/Earth2014/data_1min/shcs_to10800/Earth2014.RET2014.degree10800.bshc"  # noqa: E501
+        file_url = "http://ddfe.curtin.edu.au/models/Earth2014/data_1min/shcs_to10800/Earth2014.RET2014.degree10800.bshc"  # noqa: E501
         file_hash = "sha256:717245367018f68aee9ebdb4bb76a2d9c8e64c9c8fc74d0b673186a35dfadac2"  # noqa: E501
 
     fname = _retrieve(
@@ -182,10 +182,10 @@ def ice(lmax=2160):
         and Geoinformation, 39, 103-112, doi:10.10.1016/j.jag.2015.03.001.
     '''
     if lmax <= 2160:
-        file_url = "http://ddfe.curtin.edu.au/gravitymodels/Earth2014/data_5min/shcs_to2160/Earth2014.ICE2014.degree2160.bshc"  # noqa: E501
+        file_url = "http://ddfe.curtin.edu.au/models/Earth2014/data_5min/shcs_to2160/Earth2014.ICE2014.degree2160.bshc"  # noqa: E501
         file_hash = "sha256:04cd185cc668eba6f9bd1db527c4985703cce8d1a9fb993509e625e2bbecc78e"  # noqa: E501
     else:
-        file_url = "http://ddfe.curtin.edu.au/gravitymodels/Earth2014/data_1min/shcs_to10800/Earth2014.ICE2014.degree10800.bshc"  # noqa: E501
+        file_url = "http://ddfe.curtin.edu.au/models/Earth2014/data_1min/shcs_to10800/Earth2014.ICE2014.degree10800.bshc"  # noqa: E501
         file_hash = "sha256:7c08342326c9a3843b80ca759e9b78e3c2f30bc227039c7e4ffd5c0fee70a74f"  # noqa: E501
 
     fname = _retrieve(


### PR DESCRIPTION
Update the URLs for the Earth2012/2014 datasets. Curtin appears to have changed the folder name where these are located from "gravitymodels" to just "models".
