### PR TITLE
Fix wrapping of Fortran subroutines

### DIFF
--- a/pyshtools/backends/shtools.py
+++ b/pyshtools/backends/shtools.py
@@ -1,6 +1,7 @@
 """
 pyshtools subpackage that includes all Python wrapped Fortran routines.
 """
+import functools as _functools
 import os as _os
 import numpy as _np
 
@@ -204,6 +205,7 @@ def _shtools_status_message(status):
 
 
 def _raise_errors(func):
+    @_functools.wraps(func)
     def wrapped_func(*args, **kwargs):
         returned_values = func(*args, **kwargs)
         if returned_values[0] != 0:
@@ -212,7 +214,10 @@ def _raise_errors(func):
             return returned_values[1]
         else:
             return returned_values[1:]
-    wrapped_func.__doc__ = func.__doc__
+    # f2py's fortranobject.c adds this extra type prefix, but that's not needed
+    # for this wrapper, which Python knows is a function already.
+    if wrapped_func.__name__.startswith('function '):
+        wrapped_func.__name__ = wrapped_func.__name__[len('function '):]
     return wrapped_func
 
 


### PR DESCRIPTION
Currently, docs for wrapped subroutines start with:
```
Help on function wrapped_func in module pyshtools.backends.shtools:

wrapped_func(*args, **kwargs)
```

This is because only `__doc__` is copied, but not the `__name__` and other special properties. Using `functools.wraps` copies all important properties, and changes the docs to:
```
Help on function BAtoHilmDH in module pyshtools.backends.shtools:

BAtoHilmDH(...)
```

But note there needs to be a small tweak to `__name__` because f2py adds an extra 'function ' prefix to the name.

**Reminders**

- [x] Base all changes on the `develop` branch: the `master` branch is used only when releasing new versions.
- [x] Run `make check` to ensure that the python code follows standard formatting conventions.
- [n/a] If adding new features, update the docstring to provide all information that is required to use the feature.
