### PR TITLE
Fix shcoeffs.volume for ortho, fix LAPACK underscore issue + numpy2

### DIFF
--- a/pyshtools/shclasses/shcoeffs.py
+++ b/pyshtools/shclasses/shcoeffs.py
@@ -2904,7 +2904,7 @@ class SHCoeffs(object):
         if cmap_limits is None and cmap_rlimits is None:
             if cmap_scale.lower() == 'log':
                 _temp = spectrum
-                _temp[_temp == 0] = _np.NaN
+                _temp[_temp == 0] = _np.nan
                 vmin = _np.nanmin(_temp)
             else:
                 vmin = _np.nanmin(spectrum)
@@ -3403,7 +3403,7 @@ class SHCoeffs(object):
         if cmap_limits is None and cmap_rlimits is None:
             if cmap_scale.lower() == 'log':
                 _temp = spectrum
-                _temp[_temp == 0] = _np.NaN
+                _temp[_temp == 0] = _np.nan
                 vmin = _np.nanmin(_temp)
             else:
                 vmin = _np.nanmin(spectrum)
@@ -4163,7 +4163,7 @@ class SHRealCoeffs(SHCoeffs):
                              'Input types are {:s} and {:s}.'
                              .format(repr(type(lat)), repr(type(lon))))
 
-        if type(lat) is int or type(lat) is float or type(lat) is _np.float_:
+        if type(lat) is int or type(lat) is float or type(lat) is _np.float64:
             return _shtools.MakeGridPoint(self.coeffs, lat=latin, lon=lonin,
                                           lmax=lmax_calc, norm=norm,
                                           csphase=self.csphase)
@@ -4449,7 +4449,7 @@ class SHComplexCoeffs(SHCoeffs):
                              'Input types are {:s} and {:s}.'
                              .format(repr(type(lat)), repr(type(lon))))
 
-        if type(lat) is int or type(lat) is float or type(lat) is _np.float_:
+        if type(lat) is int or type(lat) is float or type(lat) is _np.float64:
             return _shtools.MakeGridPointC(self.coeffs, lat=latin, lon=lonin,
                                            lmax=lmax_calc, norm=norm,
                                            csphase=self.csphase)

--- a/pyshtools/shclasses/shcoeffs.py
+++ b/pyshtools/shclasses/shcoeffs.py
@@ -1833,6 +1833,8 @@ class SHCoeffs(object):
             lmax = min(3*lmax, 2800)
 
         r0 = self.coeffs[0, 0, 0]
+        if self.normalization == 'ortho':
+            r0 = r0 / _np.sqrt(4 * _np.pi)
         grid = self.expand(lmax=lmax, backend=backend,
                            nthreads=nthreads) - r0
         h200 = (grid**2).expand(lmax_calc=0, backend=backend,

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -3144,7 +3144,7 @@ class SHGravCoeffs(object):
         if cmap_limits is None and cmap_rlimits is None:
             if cmap_scale.lower() == 'log':
                 _temp = spectrum
-                _temp[_temp == 0] = _np.NaN
+                _temp[_temp == 0] = _np.nan
                 vmin = _np.nanmin(_temp)
             else:
                 vmin = _np.nanmin(spectrum)
@@ -3853,7 +3853,7 @@ class SHGravRealCoeffs(SHGravCoeffs):
                              'Input types are {:s} and {:s}.'
                              .format(repr(type(lat)), repr(type(lon))))
 
-        if type(lat) is int or type(lat) is float or type(lat) is _np.float_:
+        if type(lat) is int or type(lat) is float or type(lat) is _np.float64:
             if f == 0.:
                 r = a
             else:

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -2530,7 +2530,7 @@ class SHMagCoeffs(object):
         if cmap_limits is None and cmap_rlimits is None:
             if cmap_scale.lower() == 'log':
                 _temp = spectrum
-                _temp[_temp == 0] = _np.NaN
+                _temp[_temp == 0] = _np.nan
                 vmin = _np.nanmin(_temp)
             else:
                 vmin = _np.nanmin(spectrum)
@@ -2989,7 +2989,7 @@ class SHMagRealCoeffs(SHMagCoeffs):
                              'Input types are {:s} and {:s}.'
                              .format(repr(type(lat)), repr(type(lon))))
 
-        if type(lat) is int or type(lat) is float or type(lat) is _np.float_:
+        if type(lat) is int or type(lat) is float or type(lat) is _np.float64:
             if f == 0.:
                 r = a
             else:

--- a/src/SHExpandLSQ.F95
+++ b/src/SHExpandLSQ.F95
@@ -33,7 +33,7 @@ subroutine SHExpandLSQ(cilm, d, lat, lon, nmax, lmax, norm, chi2, &
 !           nmax    Number of data points.
 !           lmax    Maximum degree of spherical harmonic expansion.
 !
-!       OUT 
+!       OUT
 !           cilm    The spherical harmonic coefficients.
 !
 !       OPTIONAL (IN)
@@ -84,6 +84,7 @@ subroutine SHExpandLSQ(cilm, d, lat, lon, nmax, lmax, norm, chi2, &
                              din(:)
 #ifdef LAPACK_UNDERSCORE
 #define dgels dgels_
+#define dggglm dggglm_
 #endif
     external :: dgels, dggglm
 


### PR DESCRIPTION
* Fix a problem with `SHCoeffs.volume()` when the normalization is `ortho`.
* Fix a potential LAPACK underscore problem when compiling with `LAPACK_UNDERSCORE` specified.
* Minor changes for Numpy 2 compatibility.


**Reminders**

- [ ] Base all changes on the `develop` branch: the `master` branch is used only when releasing new versions.
- [ ] Run `make check` to ensure that the python code follows standard formatting conventions.
- [ ] If adding new features, update the docstring to provide all information that is required to use the feature.
