### PR TITLE
Version 4.11.4

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -52,12 +52,10 @@ jobs:
         python -m build -s
 
     - name: Upload release to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
       environment: release
       permissions:
         id-token: write
-      steps:
-        - name: Publish package distributions to PyPI
-          uses: pypa/gh-action-pypi-publish@release/v1
 
     - name: Trigger a build on the SHTOOLS/build-shtools repo
       run: |

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -44,20 +44,20 @@ jobs:
                                  twine
         mamba list -n pypi
 
-    - name: Build and publish
+    - name: Build
       env:
-        # PYPI repository
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        # PYPITEST repository
-        # TWINE_USERNAME: ${{ secrets.PYPITEST_USERNAME }}
-        # TWINE_PASSWORD: ${{ secrets.PYPITEST_PASSWORD }}
-        # TWINE_REPOSITORY_URL: 'https://test.pypi.org/legacy/'
       shell: bash -l {0}
       run: |
         mamba env list
         python -m build -s
-        twine upload dist/*
+
+    - name: Upload release to PyPI
+      environment: release
+      permissions:
+        id-token: write
+      steps:
+        - name: Publish package distributions to PyPI
+          uses: pypa/gh-action-pypi-publish@release/v1
 
     - name: Trigger a build on the SHTOOLS/build-shtools repo
       run: |


### PR DESCRIPTION
## Version 4.11.4

**Support for Python 3.12 using the Meson build system**

This version no longer relies on `distutils` (which was deprecated in python 3.12) and instead makes use of [Meson](https://mesonbuild.com/) and [Meson-Python](https://meson-python.readthedocs.io) to build and test the pyshtools package. The package can be built from source using pip as before, however, if you need to create an editable install, it will be necessary to use the slightly modified command
```bash
pip install --no-build-isolation -e .
```
Please see the online documentation for instructions on how to run the test suites and benchmarks.

**Other changes**

* We no longer use `versioneer` to determine the package version, but instead set the version in the main `meson.build` file using `setuptools_scm`. At the present time, it is not possible to determine the version when using a source tarball, and for this case, the build will fail. Please ensure that when building from source that you are doing so from a git versioned repository.
* Fixed a problem with `SHCoeffs.volume()` when the coefficient normalization was `ortho`.
* Fixed a potential LAPACK underscore problem when compiling with `LAPACK_UNDERSCORE` specified.
* Minor changes were made to the python source files to ensure numpy v2 compatibility.

M. A. Wieczorek, M. Meschede, A. Broquet, T. Brugere, A. Corbin, EricAtORS, A. Hattori, A. Kalinin, J. Kohler, D. Kutra, K. Leinweber, P. Lobo, I. Oshchepkov, P.-L. Phan, O. Poplawski, M. Reinecke, E. Sales de Andrade, E. Schnetter, S. Schröder, J. Sierra, A. Vasishta, A. Walker, xoviat, B. Xu (2024). SHTOOLS: Version 4.11.4, Zenodo, doi:[10.5281/zenodo.592762](https://doi.org/10.5281/zenodo.592762)
