### PR TITLE
develop

### DIFF
--- a/docs/pages/mydoc/python-installing.md
+++ b/docs/pages/mydoc/python-installing.md
@@ -96,7 +96,7 @@ When installing pyshtools using `conda`, the following will also be installed au
 * [fftw](https://www.fftw.org/): required for the fortran library.
 * [blas-devel](https://anaconda.org/conda-forge/blas-devel): required for the fortran components.
 * [cartopy](https://scitools.org.uk/cartopy/docs/latest/): required for Cartopy map projections. Cartopy requires (see below) *proj*, *geos*, *cython*, *pyshp*, *six*, and *shapely*.
-* [pygmt](https://www.pygmt.org) (>=0.3): required for pygmt map projections. pygmt requires (see below) *gmt (>=6.1.1)*.
+* [pygmt](https://www.pygmt.org) (>=0.7): required for pygmt map projections. pygmt requires (see below) *gmt (>=6.3.0)*.
 * [ducc0](https://gitlab.mpcdf.mpg.de/mtr/ducc) (>=0.15): required for using the 'ducc' backend for spherical harmonic transforms.
 * [palettable](https://jiffyclub.github.io/palettable/): scientific color maps required by one of the tutorials.
 
@@ -135,7 +135,7 @@ See [these instructions](https://scitools.org.uk/cartopy/docs/latest/installing.
 
 ### How to install pygmt
 
-In order to use the *pygmt* plotting routines, it will be necessary to install both *pygmt (>=0.3)* and the *gmt (>=6.1.1)* library. This is most easily achieved using conda with
+In order to use the *pygmt* plotting routines, it will be necessary to install both *pygmt (>=0.7)* and the *gmt (>=6.3.0)* library. This is most easily achieved using conda with
 ```bash
 conda install -c conda-forge pygmt gmt
 ```

--- a/environment.yml
+++ b/environment.yml
@@ -15,8 +15,8 @@ dependencies:
     - pooch>=1.1
     - tqdm
     - cartopy>=0.18.0
-    - gmt>=6.1.1
-    - pygmt>=0.3.0
+    - gmt>=6.3.0
+    - pygmt>=0.7.0
     - ducc0>=0.15
     - palettable>=3.3
     - jupyter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ download = 'https://github.com/SHTOOLS/SHTOOLS/zipball/master'
 
 [project.optional-dependencies]
 cartopy = ['cython', 'pyshp', 'six', 'shapely', 'cartopy>=0.18.0']
-pygmt = ['pygmt>=0.3']
+pygmt = ['pygmt>=0.7']
 palettable = ['palettable>=3.3']
 ducc = ['ducc0>=0.15']
 

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -451,7 +451,11 @@ class SHGrid(object):
         except:
             pass
 
-        return self.from_array(data_array.values, grid=grid, units=units)
+        array = data_array.values
+        if data_array.coords[data_array.dims[0]].values[0] == -90.:
+            array = _np.flipud(array)
+
+        return self.from_array(array, grid=grid, units=units)
 
     @classmethod
     def from_netcdf(self, netcdf, grid='DH', units=None):

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -1586,7 +1586,7 @@ class SHGrid(object):
             Van-der-Grinten (van)
 
         Rectangular projections using the coordinates of the lower-left and
-        upper-right corners (region='lon1/lat1/lon2/lat2+r') with
+        upper-right corners (region=[lon1, lat1, lon2, lat2]) with
         corresponding abbreviation used by `projection`:
 
         * Azimuthal projections
@@ -1597,7 +1597,7 @@ class SHGrid(object):
             Transverse Mercator (tra)
             Cassini cylindrical (cas)
 
-        Rectangular projections using the West, East, South and North bounding
+        Rectangular projections using the west, east, south and north bounding
         coordinates (region=[west, east, south, north]) with corresponding
         abbreviation used by `projection`:
 

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -1387,10 +1387,10 @@ class SHGrid(object):
                        cb_triangles=cb_triangles, cb_label=cb_label,
                        grid=grid, axes_labelsize=axes_labelsize,
                        tick_labelsize=tick_labelsize, title=title,
+                       titlesize=titlesize, title_offset=title_offset,
                        xlabel=xlabel, ylabel=ylabel,
                        tick_interval=tick_interval, ticks=ticks,
                        minor_tick_interval=minor_tick_interval,
-                       titlesize=titlesize, title_offset=title_offset,
                        cmap=cmap, cb_offset=cb_offset,
                        cb_tick_interval=cb_tick_interval,
                        cb_minor_tick_interval=cb_minor_tick_interval,
@@ -1414,8 +1414,9 @@ class SHGrid(object):
                 minor_tick_interval=[None, None], ticks='WSen', title=None,
                 title_offset=0, cmap='viridis', cmap_limits=None,
                 cmap_limits_complex=None, cmap_reverse=False,
-                cmap_continuous=False, colorbar=None, cb_triangles='both',
-                cb_label=None, cb_ylabel=None, cb_tick_interval=None,
+                cmap_continuous=False, cmap_background_foreground=True,
+                colorbar=None, cb_triangles='both', cb_label=None,
+                cb_ylabel=None, cb_tick_interval=None,
                 cb_minor_tick_interval=None, cb_offset=None, shading=None,
                 shading_azimuth=-45., shading_amplitude=1.0, titlesize=None,
                 axes_labelsize=None, tick_labelsize=None, horizon=60,
@@ -1430,7 +1431,8 @@ class SHGrid(object):
                          central_latitude, central_longitude, grid,
                          tick_interval, minor_tick_interval, ticks, title,
                          title_offset cmap, cmap_limits, cmap_limits_complex,
-                         cmap_reverse, cmap_continuous, colorbar, cb_triangles,
+                         cmap_reverse, cmap_continuous,
+                         cmap_background_foreground, colorbar, cb_triangles,
                          cb_label, cb_ylabel, cb_tick_interval,
                          cb_minor_tick_interval, cb_offset, shading,
                          shading_azimuth, shading_amplitude, titlesize,
@@ -1501,6 +1503,13 @@ class SHGrid(object):
         cmap_continuous : bool, optional, default = False
             If True, create a continuous colormap. Default behavior is to
             use contant colors for each interval.
+        cmap_background_foreground : bool, optional, default = True
+            If True, background and foreground colors will be used for values
+            that exceed cmap_limits. These colors are taken either from the
+            input colormap (if present) or the GMT defaults COLOR_BACKGROUND
+            and COLOR_FOREGROUND (which are black and white, respectively). If
+            False, values that exceed cmap_limits will be set to the minimum
+            and maximum values of cmap_limits.
         colorbar : str, optional, default = None
             Plot a colorbar along the 'top', 'right', 'bottom', or 'left' axis.
         cb_triangles : str, optional, default = 'both'
@@ -1645,11 +1654,12 @@ class SHGrid(object):
             minor_tick_interval=minor_tick_interval, ticks=ticks, title=title,
             title_offset=title_offset, cmap=cmap, cmap_limits=cmap_limits,
             cmap_limits_complex=cmap_limits_complex, cmap_reverse=cmap_reverse,
-            cmap_continuous=cmap_continuous, colorbar=colorbar,
-            cb_triangles=cb_triangles, cb_label=cb_label, cb_ylabel=cb_ylabel,
-            cb_tick_interval=cb_tick_interval, cb_offset=cb_offset,
-            cb_minor_tick_interval=cb_minor_tick_interval, shading=shading,
-            shading_azimuth=shading_azimuth,
+            cmap_continuous=cmap_continuous,
+            cmap_background_foreground=cmap_background_foreground,
+            colorbar=colorbar, cb_triangles=cb_triangles, cb_label=cb_label,
+            cb_ylabel=cb_ylabel, cb_tick_interval=cb_tick_interval,
+            cb_offset=cb_offset, cb_minor_tick_interval=cb_minor_tick_interval,
+            shading=shading, shading_azimuth=shading_azimuth,
             shading_amplitude=shading_amplitude, titlesize=titlesize,
             axes_labelsize=axes_labelsize, tick_labelsize=tick_labelsize,
             horizon=horizon, offset=offset)
@@ -2196,8 +2206,9 @@ class DHRealGrid(SHGrid):
                     tick_interval=None, minor_tick_interval=None, ticks=None,
                     title=None, title_offset=None, cmap=None, cmap_limits=None,
                     cmap_limits_complex=None, cmap_reverse=None,
-                    cmap_continuous=None, colorbar=None, cb_triangles=None,
-                    cb_label=None, cb_ylabel=None, cb_tick_interval=None,
+                    cmap_continuous=None, cmap_background_foreground=None,
+                    colorbar=None, cb_triangles=None, cb_label=None,
+                    cb_ylabel=None, cb_tick_interval=None,
                     cb_minor_tick_interval=None, shading=None,
                     shading_azimuth=None, shading_amplitude=None,
                     titlesize=None, axes_labelsize=None, tick_labelsize=None,
@@ -2260,6 +2271,8 @@ class DHRealGrid(SHGrid):
 
         if title_offset is not None:
             title_offset = str(title_offset) + unit
+
+        background = not cmap_background_foreground
 
         framex = 'x'
         framey = 'y'
@@ -2372,7 +2385,7 @@ class DHRealGrid(SHGrid):
                            FONT_ANNOT=tick_labelsize,
                            MAP_TITLE_OFFSET=title_offset):
             _pygmt.makecpt(series=cmap_limits, cmap=cmap, reverse=cmap_reverse,
-                           continuous=cmap_continuous)
+                           continuous=cmap_continuous, background=background)
             figure.shift_origin(xshift=xshift, yshift=yshift)
             figure.grdimage(self.to_xarray(), region=region,
                             projection=proj_str, frame=frame,
@@ -2491,7 +2504,7 @@ class DHComplexGrid(SHGrid):
     def _plot(self, projection=None, xlabel=None, ylabel=None, colorbar=None,
               cb_triangles=None, cb_label=None, grid=False, ticks=None,
               axes_labelsize=None, tick_labelsize=None, title=None,
-              titlesize=None, cmap=None, ax=None, ax2=None,
+              titlesize=None, title_offset=None, cmap=None, ax=None, ax2=None,
               tick_interval=None, minor_tick_interval=None, cb_ylabel=None,
               cb_tick_interval=None, cb_minor_tick_interval=None,
               cmap_limits=None, cmap_reverse=None, cmap_limits_complex=None,
@@ -2524,7 +2537,8 @@ class DHComplexGrid(SHGrid):
                             grid=grid, axes_labelsize=axes_labelsize,
                             tick_labelsize=tick_labelsize, cb_offset=cb_offset,
                             title=title[0], titlesize=titlesize,
-                            xlabel=xlabel, ylabel=ylabel, cb_ylabel=cb_ylabel,
+                            title_offset=title_offset, xlabel=xlabel,
+                            ylabel=ylabel, cb_ylabel=cb_ylabel,
                             cb_width=cb_width, cmap=cmap,
                             cmap_limits=cmap_limits, cmap_reverse=cmap_reverse,
                             ax=axreal)
@@ -2538,7 +2552,8 @@ class DHComplexGrid(SHGrid):
                             grid=grid, axes_labelsize=axes_labelsize,
                             tick_labelsize=tick_labelsize, cb_ylabel=cb_ylabel,
                             title=title[1], titlesize=titlesize,
-                            cmap=cmap, cmap_limits=cmap_limits_complex,
+                            title_offset=title_offset, cmap=cmap,
+                            cmap_limits=cmap_limits_complex,
                             cmap_reverse=cmap_reverse, cb_offset=cb_offset,
                             cb_width=cb_width, xlabel=xlabel, ylabel=ylabel,
                             ax=axcomplex)
@@ -2546,16 +2561,19 @@ class DHComplexGrid(SHGrid):
         if ax is None:
             return fig, axes
 
-    def _plot_pygmt(self, fig=None, projection=None, region=None, width=None,
-                    unit=None, central_latitude=None, central_longitude=None,
-                    grid=None, tick_interval=None, minor_tick_interval=None,
-                    ticks=None, title=None, cmap=None, cmap_limits=None,
+    def _plot_pygmt(self, fig=None, projection=None, region=None,
+                    rectangle=None, width=None, unit=None,
+                    central_latitude=None, central_longitude=None, grid=None,
+                    tick_interval=None, minor_tick_interval=None, ticks=None,
+                    title=None, cmap=None, cmap_limits=None,
                     cmap_limits_complex=None, cmap_reverse=None,
-                    cmap_continuous=None, colorbar=None, cb_triangles=None,
-                    cb_label=None, cb_ylabel=None, cb_tick_interval=None,
+                    cmap_continuous=None, cmap_background_foreground=None,
+                    colorbar=None, cb_triangles=None, cb_label=None,
+                    cb_ylabel=None, cb_tick_interval=None,
                     cb_minor_tick_interval=None, titlesize=None,
-                    axes_labelsize=None, tick_labelsize=None, horizon=None,
-                    offset=None, cb_offset=None):
+                    title_offset=None, axes_labelsize=None,
+                    tick_labelsize=None, horizon=None, offset=None,
+                    cb_offset=None):
         """
         Plot projected data using pygmt.
         """
@@ -2565,8 +2583,8 @@ class DHComplexGrid(SHGrid):
             figure = fig
 
         self.to_imag().plotgmt(fig=figure, projection=projection,
-                               region=region, width=width, unit=unit,
-                               central_latitude=central_latitude,
+                               region=region, rectangle=rectangle, width=width,
+                               unit=unit, central_latitude=central_latitude,
                                central_longitude=central_longitude,
                                grid=grid, tick_interval=tick_interval,
                                minor_tick_interval=minor_tick_interval,
@@ -2574,11 +2592,13 @@ class DHComplexGrid(SHGrid):
                                cmap_limits=cmap_limits_complex,
                                cmap_reverse=cmap_reverse, cb_offset=cb_offset,
                                cmap_continuous=cmap_continuous,
+                               cmap_background_foreground=  # noqa E251
+                               cmap_background_foreground,
                                colorbar=colorbar, cb_triangles=cb_triangles,
                                cb_label=cb_label, cb_ylabel=cb_ylabel,
                                cb_tick_interval=cb_tick_interval,
                                cb_minor_tick_interval=cb_minor_tick_interval,
-                               titlesize=titlesize,
+                               titlesize=titlesize, title_offset=title_offset,
                                axes_labelsize=axes_labelsize,
                                tick_labelsize=tick_labelsize, horizon=horizon,
                                offset=offset)
@@ -2590,8 +2610,8 @@ class DHComplexGrid(SHGrid):
             offset_real[1] += width / 2. + 50. / 72.
 
         self.to_real().plotgmt(fig=figure, projection=projection,
-                               region=region, width=width, unit=unit,
-                               central_latitude=central_latitude,
+                               region=region, rectangle=rectangle, width=width,
+                               unit=unit, central_latitude=central_latitude,
                                central_longitude=central_longitude,
                                grid=grid, tick_interval=tick_interval,
                                minor_tick_interval=minor_tick_interval,
@@ -2599,11 +2619,13 @@ class DHComplexGrid(SHGrid):
                                cmap_limits=cmap_limits, cb_offset=cb_offset,
                                cmap_reverse=cmap_reverse,
                                cmap_continuous=cmap_continuous,
+                               cmap_background_foreground=  # noqa E251
+                               cmap_background_foreground,
                                colorbar=colorbar, cb_triangles=cb_triangles,
                                cb_label=cb_label, cb_ylabel=cb_ylabel,
                                cb_tick_interval=cb_tick_interval,
                                cb_minor_tick_interval=cb_minor_tick_interval,
-                               titlesize=titlesize,
+                               titlesize=titlesize, title_offset=title_offset,
                                axes_labelsize=axes_labelsize,
                                tick_labelsize=tick_labelsize,
                                horizon=horizon, offset=offset_real)
@@ -2730,8 +2752,9 @@ class GLQRealGrid(SHGrid):
     def _plot(self, projection=None, xlabel=None, ylabel=None, ax=None,
               ax2=None, colorbar=None, cb_triangles=None, cb_label=None,
               grid=False, axes_labelsize=None, tick_labelsize=None,
-              title=None, titlesize=None, cmap=None, tick_interval=None,
-              minor_tick_interval=None, cb_tick_interval=None, ticks=None,
+              title=None, titlesize=None, title_offset=None, cmap=None,
+              tick_interval=None, minor_tick_interval=None,
+              cb_tick_interval=None, ticks=None,
               cb_minor_tick_interval=None, cmap_limits=None, cmap_reverse=None,
               cmap_limits_complex=None, cb_ylabel=None, cb_offset=None,
               cb_width=None):
@@ -2862,7 +2885,7 @@ class GLQRealGrid(SHGrid):
                          which='both')
         axes.grid(grid, which='major')
         if title is not None:
-            axes.set_title(title, fontsize=titlesize)
+            axes.set_title(title, fontsize=titlesize, pad=title_offset)
 
         # plot colorbar
         if colorbar is not None:
@@ -3043,8 +3066,8 @@ class GLQComplexGrid(SHGrid):
               xlabel=None, ylabel=None, ax=None, ax2=None, colorbar=None,
               cb_triangles=None, cb_label=None, grid=False, ticks=None,
               axes_labelsize=None, tick_labelsize=None, title=None,
-              titlesize=None, cmap=None, tick_interval=None, cb_ylabel=None,
-              minor_tick_interval=None, cb_tick_interval=None,
+              titlesize=None, title_offset=None, cmap=None, tick_interval=None,
+              cb_ylabel=None, minor_tick_interval=None, cb_tick_interval=None,
               cb_minor_tick_interval=None, cmap_limits=None, cmap_reverse=None,
               cmap_limits_complex=None, cb_offset=None, cb_width=None):
         """Plot the raw data using a simply cylindrical projection."""
@@ -3074,7 +3097,8 @@ class GLQComplexGrid(SHGrid):
                             grid=grid, axes_labelsize=axes_labelsize,
                             tick_labelsize=tick_labelsize, cb_offset=cb_offset,
                             title=title[0], titlesize=titlesize,
-                            xlabel=xlabel, ylabel=ylabel, cb_ylabel=cb_ylabel,
+                            title_offset=title_offset, xlabel=xlabel,
+                            ylabel=ylabel, cb_ylabel=cb_ylabel,
                             cb_width=cb_width, cmap=cmap,
                             cmap_limits=cmap_limits, cmap_reverse=cmap_reverse,
                             ax=axreal)
@@ -3088,7 +3112,8 @@ class GLQComplexGrid(SHGrid):
                             grid=grid, axes_labelsize=axes_labelsize,
                             tick_labelsize=tick_labelsize, cb_offset=cb_offset,
                             title=title[1], titlesize=titlesize,
-                            cmap=cmap, cmap_limits=cmap_limits_complex,
+                            title_offset=title_offset, cmap=cmap,
+                            cmap_limits=cmap_limits_complex,
                             cmap_reverse=cmap_reverse, cb_ylabel=cb_ylabel,
                             cb_width=cb_width, xlabel=xlabel, ylabel=ylabel,
                             ax=axcomplex)

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -1023,15 +1023,16 @@ class SHGrid(object):
 
     # ---- Plotting routines ----
     def plot3d(self, elevation=20, azimuth=30, cmap='viridis',
-               cmap_limits=None, cmap_reverse=False, title=False,
-               titlesize=None, scale=4., ax=None, show=True, fname=None):
+               cmap_limits=None, cmap_rlimits=None, cmap_reverse=False,
+               title=False, titlesize=None, scale=4., ax=None, show=True,
+               fname=None):
         """
         Plot a 3-dimensional representation of the data.
 
         Usage
         -----
-        x.plot3d([elevation, azimuth, cmap, cmap_limits, cmap_reverse, title,
-                  titlesize, scale, ax, show, fname])
+        x.plot3d([elevation, azimuth, cmap, cmap_limits, cmap_rlimits,
+                  cmap_reverse, title, titlesize, scale, ax, show, fname])
 
         Parameters
         ----------
@@ -1049,6 +1050,9 @@ class SHGrid(object):
             and optionally an interval for each color band. If the
             interval is specified, the number of discrete colors will be
             (cmap_limits[1]-cmap_limits[0])/cmap_limits[2].
+        cmap_rlimits : list, optional, default = None
+           Same as cmap_limits, except the provided upper and lower values are
+           relative with respect to the maximum value of the data.
         titlesize : int, optional, default = None
             The font size of the title.
         scale : float, optional, default = 4.
@@ -1084,8 +1088,14 @@ class SHGrid(object):
             titlesize = _mpl.rcParams['axes.titlesize']
 
         # make colormap
-        if cmap_limits is None:
+        if cmap_limits is None and cmap_rlimits is None:
             cmap_limits = [self.min(), self.max()]
+        elif cmap_rlimits is not None:
+            cmap_limits = [self.max() * cmap_rlimits[0],
+                           self.max() * cmap_rlimits[1]]
+            if len(cmap_rlimits) == 3:
+                cmap_limits.append(cmap_rlimits[2])
+
         if len(cmap_limits) == 3:
             num = int((cmap_limits[1] - cmap_limits[0]) / cmap_limits[2])
             if isinstance(cmap, _mpl.colors.Colormap):
@@ -1206,12 +1216,12 @@ class SHGrid(object):
              minor_tick_interval=[None, None], title=None, titlesize=None,
              title_offset=None, colorbar=None, cmap='viridis',
              cmap_limits=None, cmap_limits_complex=None, cmap_rlimits=None,
-             cmap_rlimits_complex=None, cmap_reverse=False,
-             cb_triangles='neither', cb_label=None, cb_ylabel=None,
-             cb_tick_interval=None, cb_minor_tick_interval=None,
-             cb_offset=None, cb_width=None, grid=False, axes_labelsize=None,
-             tick_labelsize=None, xlabel=True, ylabel=True, ax=None, ax2=None,
-             show=True, fname=None):
+             cmap_rlimits_complex=None, cmap_scale='lin',
+             cmap_reverse=False, cb_triangles='neither', cb_label=None,
+             cb_ylabel=None, cb_tick_interval=None,
+             cb_minor_tick_interval=None, cb_offset=None, cb_width=None,
+             grid=False, axes_labelsize=None, tick_labelsize=None, xlabel=True,
+             ylabel=True, ax=None, ax2=None, show=True, fname=None):
         """
         Plot the data using a Cartopy projection or a matplotlib cylindrical
         projection.
@@ -1221,8 +1231,8 @@ class SHGrid(object):
         fig, ax = x.plot([projection, tick_interval, minor_tick_interval,
                           ticks, xlabel, ylabel, title, title_offset, colorbar,
                           cmap, cmap_limits, cmap_limits_complex, cmap_rlimits,
-                          cmap_rlimits_complex, cmap_reverse, cb_triangles,
-                          cb_label, cb_ylabel, cb_tick_interval,
+                          cmap_rlimits_complex, cmap_scale, cmap_reverse,
+                          cb_triangles, cb_label, cb_ylabel, cb_tick_interval,
                           cb_minor_tick_interval, cb_offset, cb_width, grid,
                           titlesize, axes_labelsize, tick_labelsize, ax, ax2,
                           show, fname])
@@ -1276,6 +1286,8 @@ class SHGrid(object):
         cmap_reverse : bool, optional, default = False
             Set to True to reverse the sense of the color progression in the
             color table.
+        cmap_scale : str, optional, default = 'lin'
+            Scale of the color axis: 'lin' for linear or 'log' for logarithmic.
         cb_triangles : str, optional, default = 'neither'
             Add triangles to the edges of the colorbar for minimum and maximum
             values. Can be 'neither', 'both', 'min', or 'max'.
@@ -1383,8 +1395,8 @@ class SHGrid(object):
                 cmap_limits=cmap_limits, cmap_rlimits=cmap_rlimits,
                 cmap_limits_complex=cmap_limits_complex,
                 cmap_rlimits_complex=cmap_rlimits_complex,
-                cb_offset=cb_offset, cb_width=cb_width,
-                cmap_reverse=cmap_reverse)
+                cmap_reverse=cmap_reverse, cmap_scale=cmap_scale,
+                cb_offset=cb_offset, cb_width=cb_width)
         else:
             if self.kind == 'complex':
                 if (ax is None and ax2 is not None) or (ax2 is None and
@@ -1406,8 +1418,8 @@ class SHGrid(object):
                        cmap_limits=cmap_limits, cmap_rlimits=cmap_rlimits,
                        cmap_limits_complex=cmap_limits_complex,
                        cmap_rlimits_complex=cmap_limits_complex,
-                       cb_width=cb_width, cb_ylabel=cb_ylabel,
-                       cmap_reverse=cmap_reverse)
+                       cmap_reverse=cmap_reverse, cmap_scale=cmap_scale,
+                       cb_width=cb_width, cb_ylabel=cb_ylabel)
 
         if ax is None:
             fig.tight_layout(pad=0.5)
@@ -1426,12 +1438,12 @@ class SHGrid(object):
                 cmap_rlimits=None, cmap_limits_complex=None,
                 cmap_rlimits_complex=None, cmap_reverse=False,
                 cmap_continuous=False, cmap_background_foreground=True,
-                colorbar=None, cb_triangles='both', cb_label=None,
-                cb_ylabel=None, cb_tick_interval=None,
-                cb_minor_tick_interval=None, cb_offset=None, shading=None,
-                shading_azimuth=-45., shading_amplitude=1.0, titlesize=None,
-                axes_labelsize=None, tick_labelsize=None, horizon=60,
-                offset=[None, None], fname=None):
+                cmap_scale='lin', colorbar=None, cb_triangles='both',
+                cb_label=None, cb_ylabel=None, cb_tick_interval=None,
+                cb_minor_tick_interval=None, cb_offset=None, cb_power=True,
+                shading=None, shading_azimuth=-45., shading_amplitude=1.0,
+                titlesize=None, axes_labelsize=None, tick_labelsize=None,
+                horizon=60, offset=[None, None], fname=None):
         """
         Plot projected data using the Generic Mapping Tools (pygmt). Use
         fig.show() to display the figure.
@@ -1444,12 +1456,12 @@ class SHGrid(object):
                          title_offset cmap, cmap_limits, cmap_rlimits,
                          cmap_limits_complex, cmap_rlimits_complex,
                          cmap_reverse, cmap_continuous,
-                         cmap_background_foreground, colorbar, cb_triangles,
-                         cb_label, cb_ylabel, cb_tick_interval,
-                         cb_minor_tick_interval, cb_offset, shading,
-                         shading_azimuth, shading_amplitude, titlesize,
-                         axes_labelsize, tick_labelsize, horizon, offset,
-                         fname])
+                         cmap_background_foreground, cmap_scale,
+                         colorbar, cb_triangles, cb_label, cb_ylabel,
+                         cb_tick_interval, cb_minor_tick_interval, cb_offset,
+                         cb_power, shading, shading_azimuth, shading_amplitude,
+                         titlesize, axes_labelsize, tick_labelsize, horizon,
+                         offset, fname])
 
         Returns
         -------
@@ -1528,6 +1540,8 @@ class SHGrid(object):
             and COLOR_FOREGROUND (which are black and white, respectively). If
             False, values that exceed cmap_limits will be set to the minimum
             and maximum values of cmap_limits.
+        cmap_scale : str, optional, default = 'lin'
+            Scale of the color axis: 'lin' for linear or 'log' for logarithmic.
         colorbar : str, optional, default = None
             Plot a colorbar along the 'top', 'right', 'bottom', or 'left' axis.
         cb_triangles : str, optional, default = 'both'
@@ -1538,12 +1552,18 @@ class SHGrid(object):
         cb_ylabel : str, optional, default = None
             Text label for the y axis of the colorbar
         cb_tick_interval : float, optional, default = None
-            Annotation interval on the colorbar.
+            Annotation interval on the colorbar. If cmap_scale is 'log' and
+            cb_power is True, then use 1 to annotate each power of 10, use 2
+            to annotate 3 intervals per decade, and use 3 to annotate 10
+            intervals per decade.
         cb_minor_tick_interval : float, optional, default = None
-            Colorbar minor tick interval.
+            Colorbar minor tick interval as described in cb_tick_interval.
         cb_offset : float or int, optional, default = None
             Offset of the colorbar from the map edge in points. If None,
             the offset will be calculated automatically.
+        cb_power : bool, optional, default = True
+            If True, and cmap_scale is 'log', plot annotations on the colorbar
+            as 10^p, where p is an integer.
         shading : bool, str, or SHGrid instance, optional, default = None
             Apply intensity shading to the image. The shading (with values
             from -1 to 1) can be derived from the data by setting to True,
@@ -1675,9 +1695,10 @@ class SHGrid(object):
             cmap_rlimits_complex=cmap_rlimits_complex,
             cmap_reverse=cmap_reverse, cmap_continuous=cmap_continuous,
             cmap_background_foreground=cmap_background_foreground,
-            colorbar=colorbar, cb_triangles=cb_triangles, cb_label=cb_label,
-            cb_ylabel=cb_ylabel, cb_tick_interval=cb_tick_interval,
-            cb_offset=cb_offset, cb_minor_tick_interval=cb_minor_tick_interval,
+            cmap_scale=cmap_scale, colorbar=colorbar,
+            cb_triangles=cb_triangles, cb_label=cb_label, cb_ylabel=cb_ylabel,
+            cb_tick_interval=cb_tick_interval, cb_offset=cb_offset,
+            cb_minor_tick_interval=cb_minor_tick_interval, cb_power=cb_power,
             shading=shading, shading_azimuth=shading_azimuth,
             shading_amplitude=shading_amplitude, titlesize=titlesize,
             axes_labelsize=axes_labelsize, tick_labelsize=tick_labelsize,
@@ -1955,8 +1976,8 @@ class DHRealGrid(SHGrid):
               ticks=None, minor_tick_interval=None, cb_tick_interval=None,
               cb_ylabel=None, cb_minor_tick_interval=None, cmap_limits=None,
               cmap_rlimits=None, cmap_rlimits_complex=None,
-              cmap_limits_complex=None, cb_offset=None, cmap_reverse=None,
-              cb_width=None):
+              cmap_limits_complex=None, cmap_scale=None, cb_offset=None,
+              cmap_reverse=None, cb_width=None):
         """Plot the data as a matplotlib cylindrical projection,
            or with Cartopy when projection is specified."""
         if ax is None:
@@ -2013,6 +2034,7 @@ class DHRealGrid(SHGrid):
                            self.max() * cmap_rlimits[1]]
             if len(cmap_rlimits) == 3:
                 cmap_limits.append(cmap_rlimits[2])
+
         if len(cmap_limits) == 3:
             num = int((cmap_limits[1] - cmap_limits[0]) / cmap_limits[2])
             if isinstance(cmap, _mpl.colors.Colormap):
@@ -2021,8 +2043,20 @@ class DHRealGrid(SHGrid):
                 cmap_scaled = _mpl.cm.get_cmap(cmap, num)
         else:
             cmap_scaled = _mpl.cm.get_cmap(cmap)
+
         if cmap_reverse:
             cmap_scaled = cmap_scaled.reversed()
+
+        if cmap_scale.lower() == 'log':
+            norm = _mpl.colors.LogNorm(cmap_limits[0], cmap_limits[1],
+                                       clip=True)
+            # Clipping is required to avoid an invalid value error
+        elif cmap_scale.lower() == 'lin':
+            norm = _plt.Normalize(cmap_limits[0], cmap_limits[1])
+        else:
+            raise ValueError(
+                "cmap_scale must be 'lin' or 'log'. "
+                "Input value is {:s}.".format(repr(cmap_scale)))
 
         # compute colorbar ticks
         cb_ticks = None
@@ -2101,8 +2135,7 @@ class DHRealGrid(SHGrid):
             axes.set_global()
             cim = axes.imshow(
                 self.data, transform=_ccrs.PlateCarree(central_longitude=0.0),
-                origin='upper', extent=extent, cmap=cmap_scaled,
-                vmin=cmap_limits[0], vmax=cmap_limits[1])
+                origin='upper', extent=extent, cmap=cmap_scaled, norm=norm)
             if isinstance(projection, _ccrs.PlateCarree):
                 axes.set_xticks(
                     xticks, crs=_ccrs.PlateCarree(central_longitude=0.0))
@@ -2121,8 +2154,7 @@ class DHRealGrid(SHGrid):
                                crs=_ccrs.PlateCarree(central_longitude=0.0))
         else:
             cim = axes.imshow(self.data, origin='upper', extent=extent,
-                              cmap=cmap_scaled, vmin=cmap_limits[0],
-                              vmax=cmap_limits[1])
+                              cmap=cmap_scaled, norm=norm)
             axes.set(xlim=(0, 360), ylim=(-90, 90))
             axes.set_xlabel(xlabel, fontsize=axes_labelsize)
             axes.set_ylabel(ylabel, fontsize=axes_labelsize)
@@ -2233,9 +2265,9 @@ class DHRealGrid(SHGrid):
                     cmap_rlimits=None, cmap_limits_complex=None,
                     cmap_rlimits_complex=None, cmap_reverse=None,
                     cmap_continuous=None, cmap_background_foreground=None,
-                    colorbar=None, cb_triangles=None, cb_label=None,
-                    cb_ylabel=None, cb_tick_interval=None,
-                    cb_minor_tick_interval=None, shading=None,
+                    cmap_scale=None, colorbar=None, cb_triangles=None,
+                    cb_label=None, cb_ylabel=None, cb_tick_interval=None,
+                    cb_minor_tick_interval=None, cb_power=None, shading=None,
                     shading_azimuth=None, shading_amplitude=None,
                     titlesize=None, axes_labelsize=None, tick_labelsize=None,
                     horizon=None, offset=[None, None], cb_offset=None):
@@ -2353,6 +2385,8 @@ class DHRealGrid(SHGrid):
                 x_str += 'a' + str(cb_tick_interval)
             if cb_minor_tick_interval is not None:
                 x_str += 'f' + str(cb_minor_tick_interval)
+            if cmap_scale.lower() == 'log' and cb_power:
+                x_str += 'p'
             cb_str.extend([x_str])
             if cb_label is not None:
                 cb_str.extend(['x+l"{:s}"'.format(cb_label)])
@@ -2380,6 +2414,13 @@ class DHRealGrid(SHGrid):
                            self.max() * cmap_rlimits[1]]
             if len(cmap_rlimits) == 3:
                 cmap_limits.append(cmap_rlimits[2])
+
+        if cmap_scale.lower() == 'log':
+            log = True
+            cmap_limits[0] = _np.log10(cmap_limits[0])
+            cmap_limits[1] = _np.log10(cmap_limits[1])
+        else:
+            log = False
 
         if shading is True:
             # generate shading from self
@@ -2413,7 +2454,8 @@ class DHRealGrid(SHGrid):
                            FONT_ANNOT=tick_labelsize,
                            MAP_TITLE_OFFSET=title_offset):
             _pygmt.makecpt(series=cmap_limits, cmap=cmap, reverse=cmap_reverse,
-                           continuous=cmap_continuous, background=background)
+                           continuous=cmap_continuous, background=background,
+                           log=log)
             figure.shift_origin(xshift=xshift, yshift=yshift)
             figure.grdimage(self.to_xarray(), region=region,
                             projection=proj_str, frame=frame,
@@ -2421,9 +2463,9 @@ class DHRealGrid(SHGrid):
             if colorbar is not None:
                 if shading is not None:
                     figure.colorbar(position=position, frame=cb_str,
-                                    shading=shading_amplitude)
+                                    shading=shading_amplitude, log=log)
                 else:
-                    figure.colorbar(position=position, frame=cb_str)
+                    figure.colorbar(position=position, frame=cb_str, log=log)
 
         return figure
 
@@ -2533,8 +2575,8 @@ class DHComplexGrid(SHGrid):
               tick_interval=None, minor_tick_interval=None, cb_ylabel=None,
               cb_tick_interval=None, cb_minor_tick_interval=None,
               cmap_limits=None, cmap_rlimits=None, cmap_rlimits_complex=None,
-              cmap_reverse=None, cmap_limits_complex=None, cb_offset=None,
-              cb_width=None):
+              cmap_reverse=None, cmap_limits_complex=None, cmap_scale=None,
+              cb_offset=None, cb_width=None):
         """Plot the raw data as a matplotlib simple cylindrical projection,
            or with Cartopy when projection is specified."""
         if ax is None:
@@ -2567,7 +2609,8 @@ class DHComplexGrid(SHGrid):
                             ylabel=ylabel, cb_ylabel=cb_ylabel,
                             cb_width=cb_width, cmap=cmap,
                             cmap_limits=cmap_limits, cmap_rlimits=cmap_rlimits,
-                            cmap_reverse=cmap_reverse, ax=axreal)
+                            cmap_reverse=cmap_reverse, cmap_scale=cmap_scale,
+                            ax=axreal)
 
         self.to_imag().plot(projection=projection, tick_interval=tick_interval,
                             minor_tick_interval=minor_tick_interval,
@@ -2581,9 +2624,9 @@ class DHComplexGrid(SHGrid):
                             title_offset=title_offset, cmap=cmap,
                             cmap_limits=cmap_limits_complex,
                             cmap_rlimits=cmap_rlimits_complex,
-                            cmap_reverse=cmap_reverse, cb_offset=cb_offset,
-                            cb_width=cb_width, xlabel=xlabel, ylabel=ylabel,
-                            ax=axcomplex)
+                            cmap_scale=cmap_scale, cmap_reverse=cmap_reverse,
+                            cb_offset=cb_offset, cb_width=cb_width,
+                            xlabel=xlabel, ylabel=ylabel, ax=axcomplex)
 
         if ax is None:
             return fig, axes
@@ -2595,10 +2638,11 @@ class DHComplexGrid(SHGrid):
                     title=None, cmap=None, cmap_limits=None, cmap_rlimits=None,
                     cmap_limits_complex=None, cmap_rlimits_complex=None,
                     cmap_reverse=None, cmap_continuous=None,
-                    cmap_background_foreground=None, colorbar=None,
-                    cb_triangles=None, cb_label=None, cb_ylabel=None,
-                    cb_tick_interval=None, cb_minor_tick_interval=None,
-                    titlesize=None, title_offset=None, axes_labelsize=None,
+                    cmap_background_foreground=None, cmap_scale=None,
+                    colorbar=None, cb_triangles=None, cb_label=None,
+                    cb_ylabel=None, cb_tick_interval=None, cb_power=None,
+                    cb_minor_tick_interval=None, titlesize=None,
+                    title_offset=None, axes_labelsize=None,
                     tick_labelsize=None, horizon=None, offset=None,
                     cb_offset=None):
         """
@@ -2622,8 +2666,9 @@ class DHComplexGrid(SHGrid):
                                cmap_continuous=cmap_continuous,
                                cmap_background_foreground=  # noqa E251
                                cmap_background_foreground,
-                               colorbar=colorbar, cb_triangles=cb_triangles,
-                               cb_label=cb_label, cb_ylabel=cb_ylabel,
+                               cmap_scale=cmap_scale, colorbar=colorbar,
+                               cb_triangles=cb_triangles, cb_label=cb_label,
+                               cb_ylabel=cb_ylabel, cb_power=cb_power,
                                cb_tick_interval=cb_tick_interval,
                                cb_minor_tick_interval=cb_minor_tick_interval,
                                titlesize=titlesize, title_offset=title_offset,
@@ -2650,8 +2695,9 @@ class DHComplexGrid(SHGrid):
                                cmap_continuous=cmap_continuous,
                                cmap_background_foreground=  # noqa E251
                                cmap_background_foreground,
-                               colorbar=colorbar, cb_triangles=cb_triangles,
-                               cb_label=cb_label, cb_ylabel=cb_ylabel,
+                               cmap_scale=cmap_scale, colorbar=colorbar,
+                               cb_triangles=cb_triangles, cb_label=cb_label,
+                               cb_ylabel=cb_ylabel, cb_power=cb_power,
                                cb_tick_interval=cb_tick_interval,
                                cb_minor_tick_interval=cb_minor_tick_interval,
                                titlesize=titlesize, title_offset=title_offset,
@@ -2785,8 +2831,8 @@ class GLQRealGrid(SHGrid):
               tick_interval=None, minor_tick_interval=None,
               cb_tick_interval=None, ticks=None, cb_minor_tick_interval=None,
               cmap_limits=None, cmap_rlimits=None, cmap_limits_complex=None,
-              cmap_rlimits_complex=None, cb_ylabel=None, cb_offset=None,
-              cb_width=None, cmap_reverse=None):
+              cmap_rlimits_complex=None, cmap_scale=None, cb_ylabel=None,
+              cb_offset=None, cb_width=None, cmap_reverse=None):
         """Plot the data using a matplotlib cylindrical projection."""
         if ax is None:
             if colorbar is not None:
@@ -2827,6 +2873,7 @@ class GLQRealGrid(SHGrid):
                            self.max() * cmap_rlimits[1]]
             if len(cmap_rlimits) == 3:
                 cmap_limits.append(cmap_rlimits[2])
+
         if len(cmap_limits) == 3:
             num = int((cmap_limits[1] - cmap_limits[0]) / cmap_limits[2])
             if isinstance(cmap, _mpl.colors.Colormap):
@@ -2835,8 +2882,20 @@ class GLQRealGrid(SHGrid):
                 cmap_scaled = _mpl.cm.get_cmap(cmap, num)
         else:
             cmap_scaled = _mpl.cm.get_cmap(cmap)
+
         if cmap_reverse:
             cmap_scaled = cmap_scaled.reversed()
+
+        if cmap_scale.lower() == 'log':
+            norm = _mpl.colors.LogNorm(cmap_limits[0], cmap_limits[1],
+                                       clip=True)
+            # Clipping is required to avoid an invalid value error
+        elif cmap_scale.lower() == 'lin':
+            norm = _plt.Normalize(cmap_limits[0], cmap_limits[1])
+        else:
+            raise ValueError(
+                "cmap_scale must be 'lin' or 'log'. "
+                "Input value is {:s}.".format(repr(cmap_scale)))
 
         # compute colorbar ticks
         cb_ticks = None
@@ -2904,8 +2963,7 @@ class GLQRealGrid(SHGrid):
         # plot image, ticks, and annotations
         extent = (-0.5, self.nlon-0.5, -0.5, self.nlat-0.5)
         cim = axes.imshow(self.data, extent=extent, origin='upper',
-                          cmap=cmap_scaled, vmin=cmap_limits[0],
-                          vmax=cmap_limits[1])
+                          cmap=cmap_scaled, norm=norm)
         axes.set(xticks=xticks, yticks=yticks)
         axes.set_xlabel(xlabel, fontsize=axes_labelsize)
         axes.set_ylabel(ylabel, fontsize=axes_labelsize)
@@ -3104,7 +3162,7 @@ class GLQComplexGrid(SHGrid):
               cb_ylabel=None, minor_tick_interval=None, cb_tick_interval=None,
               cb_minor_tick_interval=None, cmap_limits=None, cmap_rlimits=None,
               cmap_limits_complex=None, cmap_rlimits_complex=None,
-              cmap_reverse=None, cb_offset=None, cb_width=None):
+              cmap_reverse=None, cmap_scale=None, cb_offset=None, cb_width=None):
         """Plot the raw data using a simply cylindrical projection."""
         if ax is None:
             if colorbar is not None:
@@ -3136,7 +3194,8 @@ class GLQComplexGrid(SHGrid):
                             ylabel=ylabel, cb_ylabel=cb_ylabel,
                             cb_width=cb_width, cmap=cmap,
                             cmap_limits=cmap_limits, cmap_rlimits=cmap_rlimits,
-                            cmap_reverse=cmap_reverse, ax=axreal)
+                            cmap_reverse=cmap_reverse, cmap_scale=cmap_scale,
+                            ax=axreal)
 
         self.to_imag().plot(projection=projection, tick_interval=tick_interval,
                             minor_tick_interval=minor_tick_interval,
@@ -3150,9 +3209,9 @@ class GLQComplexGrid(SHGrid):
                             title_offset=title_offset, cmap=cmap,
                             cmap_limits=cmap_limits_complex,
                             cmap_rlimits=cmap_rlimits_complex,
-                            cmap_reverse=cmap_reverse, cb_ylabel=cb_ylabel,
-                            cb_width=cb_width, xlabel=xlabel, ylabel=ylabel,
-                            ax=axcomplex)
+                            cmap_reverse=cmap_reverse, cmap_scale=cmap_scale,
+                            cb_ylabel=cb_ylabel, cb_width=cb_width,
+                            xlabel=xlabel, ylabel=ylabel, ax=axcomplex)
 
         if ax is None:
             return fig, axes

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -1205,8 +1205,8 @@ class SHGrid(object):
 
     def plot(self, projection=None, tick_interval=[30, 30], ticks='WSen',
              minor_tick_interval=[None, None], title=None, titlesize=None,
-             colorbar=None, cmap='viridis', cmap_limits=None,
-             cmap_limits_complex=None, cmap_reverse=False,
+             title_offset=None, colorbar=None, cmap='viridis',
+             cmap_limits=None, cmap_limits_complex=None, cmap_reverse=False,
              cb_triangles='neither', cb_label=None, cb_ylabel=None,
              cb_tick_interval=None, cb_minor_tick_interval=None,
              cb_offset=None, cb_width=None, grid=False, axes_labelsize=None,
@@ -1219,8 +1219,8 @@ class SHGrid(object):
         Usage
         -----
         fig, ax = x.plot([projection, tick_interval, minor_tick_interval,
-                          ticks, xlabel, ylabel, title, colorbar, cmap,
-                          cmap_limits, cmap_limits_complex, cmap_reverse,
+                          ticks, xlabel, ylabel, title, title_offset, colorbar,
+                          cmap, cmap_limits, cmap_limits_complex, cmap_reverse,
                           cb_triangles, cb_label, cb_ylabel, cb_tick_interval,
                           cb_minor_tick_interval, cb_offset, cb_width, grid,
                           titlesize, axes_labelsize, tick_labelsize, ax, ax2,
@@ -1250,6 +1250,8 @@ class SHGrid(object):
         title : str or list, optional, default = None
             The title of the plot. If the grid is complex, title should be a
             list of strings for the real and complex components.
+        title_offset : float, optional, default = None
+            The offset between the title and top of the plot in points.
         colorbar : str, optional, default = None
             Plot a colorbar along the 'top', 'right', 'bottom', or 'left' axis.
         cmap : str, optional, default = 'viridis'
@@ -1366,9 +1368,9 @@ class SHGrid(object):
                 projection=projection, colorbar=colorbar,
                 cb_triangles=cb_triangles, cb_label=cb_label, grid=grid,
                 axes_labelsize=axes_labelsize, tick_labelsize=tick_labelsize,
-                title=title, titlesize=titlesize, xlabel=xlabel, ylabel=ylabel,
-                tick_interval=tick_interval, ticks=ticks,
-                minor_tick_interval=minor_tick_interval,
+                title=title, titlesize=titlesize, title_offset=title_offset,
+                xlabel=xlabel, ylabel=ylabel, tick_interval=tick_interval,
+                ticks=ticks, minor_tick_interval=minor_tick_interval,
                 cb_tick_interval=cb_tick_interval, cb_ylabel=cb_ylabel,
                 cb_minor_tick_interval=cb_minor_tick_interval, cmap=cmap,
                 cmap_limits=cmap_limits, cb_offset=cb_offset,
@@ -1388,7 +1390,8 @@ class SHGrid(object):
                        xlabel=xlabel, ylabel=ylabel,
                        tick_interval=tick_interval, ticks=ticks,
                        minor_tick_interval=minor_tick_interval,
-                       titlesize=titlesize, cmap=cmap, cb_offset=cb_offset,
+                       titlesize=titlesize, title_offset=title_offset,
+                       cmap=cmap, cb_offset=cb_offset,
                        cb_tick_interval=cb_tick_interval,
                        cb_minor_tick_interval=cb_minor_tick_interval,
                        cmap_limits=cmap_limits, cb_ylabel=cb_ylabel,
@@ -1406,36 +1409,33 @@ class SHGrid(object):
             return fig, axes
 
     def plotgmt(self, fig=None, projection='mollweide', region='g',
-                width=None, unit='i', central_latitude=0, central_longitude=0,
-                grid=[30, 30], tick_interval=[30, 30],
+                rectangle=False, width=None, unit='i', central_latitude=0,
+                central_longitude=0, grid=[30, 30], tick_interval=[30, 30],
                 minor_tick_interval=[None, None], ticks='WSen', title=None,
-                cmap='viridis', cmap_limits=None, cmap_limits_complex=None,
-                cmap_reverse=False, cmap_continuous=False, colorbar=None,
-                cb_triangles='both', cb_label=None, cb_ylabel=None,
-                cb_tick_interval=None, cb_minor_tick_interval=None,
-                cb_offset=None, shading=None, shading_azimuth=-45.,
-                shading_amplitude=1.0, titlesize=None, axes_labelsize=None,
-                tick_labelsize=None, horizon=60, offset=[None, None],
-                fname=None):
+                title_offset=0, cmap='viridis', cmap_limits=None,
+                cmap_limits_complex=None, cmap_reverse=False,
+                cmap_continuous=False, colorbar=None, cb_triangles='both',
+                cb_label=None, cb_ylabel=None, cb_tick_interval=None,
+                cb_minor_tick_interval=None, cb_offset=None, shading=None,
+                shading_azimuth=-45., shading_amplitude=1.0, titlesize=None,
+                axes_labelsize=None, tick_labelsize=None, horizon=60,
+                offset=[None, None], fname=None):
         """
-        Plot projected data using the Generic Mapping Tools (pygmt).
-
-        To display the figure in a jupyter notebook, use
-            fig.show()
-        To display the figure in the terminal environment, use
-            fig.show(method='external')
+        Plot projected data using the Generic Mapping Tools (pygmt). Use
+        fig.show() to display the figure.
 
         Usage
         -----
-        fig = x.plotgmt([fig, projection, region, width, unit,
+        fig = x.plotgmt([fig, projection, region, rectangle, width, unit,
                          central_latitude, central_longitude, grid,
                          tick_interval, minor_tick_interval, ticks, title,
-                         cmap, cmap_limits, cmap_limits_complex, cmap_reverse,
-                         cmap_continuous, colorbar, cb_triangles, cb_label,
-                         cb_ylabel, cb_tick_interval, cb_minor_tick_interval,
-                         cb_offset, shading, shading_azimuth,
-                         shading_amplitude, titlesize, axes_labelsize,
-                         tick_labelsize, horizon, offset, fname])
+                         title_offset cmap, cmap_limits, cmap_limits_complex,
+                         cmap_reverse, cmap_continuous, colorbar, cb_triangles,
+                         cb_label, cb_ylabel, cb_tick_interval,
+                         cb_minor_tick_interval, cb_offset, shading,
+                         shading_azimuth, shading_amplitude, titlesize,
+                         axes_labelsize, tick_labelsize, horizon, offset,
+                         fname])
 
         Returns
         -------
@@ -1450,14 +1450,18 @@ class SHGrid(object):
             characters are necessary to identify the projection.
         region : str or list, optional, default = 'g'
             The map region, which can be the string 'g' for the entire sphere,
-            a bounded region specified by a list [West, East, South, North], or
-            a string that provides the lower-left and upper-right coordinates
-            of a rectangular projection of the form 'lon1/lat1/lon2/lat2+r'.
+            a bounded region specified by the list [west, east, south, north],
+            or, when the argument rectangle is True, a list containing the
+            lower-left and upper-right coordinates of the projection.
+        rectangle : bool, optional, default = False
+            If True, region corresponds to a list containing the lower-left and
+            upper-right coordinates of the projection of the form
+            [lon-lower-left, lat-lower-left, lon-upper-right, lat-upper-right].
         width : float, optional, default = mpl.rcParams['figure.figsize'][0]
             The width of the projected image.
         unit : str, optional, default = 'i'
-            The measurement unit of the figure width and offset: 'i' for
-            inches or 'c' for cm.
+            The measurement unit of the figure width, title_offset and offset:
+            'i' for inches or 'c' for cm.
         central_longitude : float, optional, default = 0
             The central meridian or center of the projection.
         central_latitude : float, optional, default = 0
@@ -1480,6 +1484,8 @@ class SHGrid(object):
             south, east and north boundaries of the plot.
         title : str, optional, default = None
             The title to be displayed above the plot.
+        title_offset : float, optional, default = 0
+            Vertical offset between the upper edge of the plot and the title in
         cmap : str, optional, default = 'viridis'
             The color map to use when plotting the data and colorbar.
         cmap_limits : list, optional, default = [self.min(), self.max()]
@@ -1632,12 +1638,12 @@ class SHGrid(object):
                                  .get_size_in_points()
 
         figure = self._plot_pygmt(
-            fig=fig, projection=projection, region=region, width=width,
-            unit=unit, central_latitude=central_latitude,
+            fig=fig, projection=projection, region=region, rectangle=rectangle,
+            width=width, unit=unit, central_latitude=central_latitude,
             central_longitude=central_longitude, grid=grid,
             tick_interval=tick_interval,
             minor_tick_interval=minor_tick_interval, ticks=ticks, title=title,
-            cmap=cmap, cmap_limits=cmap_limits,
+            title_offset=title_offset, cmap=cmap, cmap_limits=cmap_limits,
             cmap_limits_complex=cmap_limits_complex, cmap_reverse=cmap_reverse,
             cmap_continuous=cmap_continuous, colorbar=colorbar,
             cb_triangles=cb_triangles, cb_label=cb_label, cb_ylabel=cb_ylabel,
@@ -1916,10 +1922,11 @@ class DHRealGrid(SHGrid):
     def _plot(self, projection=None, xlabel=None, ylabel=None, ax=None,
               ax2=None, colorbar=None, cb_triangles=None, cb_label=None,
               grid=False, axes_labelsize=None, tick_labelsize=None, title=None,
-              titlesize=None, cmap=None, tick_interval=None, ticks=None,
-              minor_tick_interval=None, cb_tick_interval=None, cb_ylabel=None,
-              cb_minor_tick_interval=None, cmap_limits=None, cmap_reverse=None,
-              cmap_limits_complex=None, cb_offset=None, cb_width=None):
+              titlesize=None, title_offset=None, cmap=None, tick_interval=None,
+              ticks=None, minor_tick_interval=None, cb_tick_interval=None,
+              cb_ylabel=None, cb_minor_tick_interval=None, cmap_limits=None,
+              cmap_reverse=None, cmap_limits_complex=None, cb_offset=None,
+              cb_width=None):
         """Plot the data as a matplotlib cylindrical projection,
            or with Cartopy when projection is specified."""
         if ax is None:
@@ -2099,7 +2106,7 @@ class DHRealGrid(SHGrid):
                          which='both')
         axes.tick_params(which='major', labelsize=tick_labelsize)
         if title is not None:
-            axes.set_title(title, fontsize=titlesize)
+            axes.set_title(title, fontsize=titlesize, pad=title_offset)
 
         # plot colorbar
         if colorbar is not None:
@@ -2183,10 +2190,11 @@ class DHRealGrid(SHGrid):
         if ax is None:
             return fig, axes
 
-    def _plot_pygmt(self, fig=None, projection=None, region=None, width=None,
-                    unit=None, central_latitude=None, central_longitude=None,
-                    grid=None, tick_interval=None, minor_tick_interval=None,
-                    ticks=None, title=None, cmap=None, cmap_limits=None,
+    def _plot_pygmt(self, fig=None, projection=None, region=None,
+                    rectangle=None, width=None, unit=None,
+                    central_latitude=None, central_longitude=None, grid=None,
+                    tick_interval=None, minor_tick_interval=None, ticks=None,
+                    title=None, title_offset=None, cmap=None, cmap_limits=None,
                     cmap_limits_complex=None, cmap_reverse=None,
                     cmap_continuous=None, colorbar=None, cb_triangles=None,
                     cb_label=None, cb_ylabel=None, cb_tick_interval=None,
@@ -2245,6 +2253,13 @@ class DHRealGrid(SHGrid):
                              .format(repr(projection)))
 
         proj_str += '/' + str(width) + unit
+
+        if rectangle:
+            region = str(region[0]) + '/' + str(region[1]) + '/' + \
+                str(region[2]) + '/' + str(region[3]) + '+r'
+
+        if title_offset is not None:
+            title_offset = str(title_offset) + unit
 
         framex = 'x'
         framey = 'y'
@@ -2354,7 +2369,8 @@ class DHRealGrid(SHGrid):
             shading_str = False
 
         with _pygmt.config(FONT_TITLE=titlesize, FONT_LABEL=axes_labelsize,
-                           FONT_ANNOT=tick_labelsize):
+                           FONT_ANNOT=tick_labelsize,
+                           MAP_TITLE_OFFSET=title_offset):
             _pygmt.makecpt(series=cmap_limits, cmap=cmap, reverse=cmap_reverse,
                            continuous=cmap_continuous)
             figure.shift_origin(xshift=xshift, yshift=yshift)

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -1205,7 +1205,8 @@ class SHGrid(object):
     def plot(self, projection=None, tick_interval=[30, 30], ticks='WSen',
              minor_tick_interval=[None, None], title=None, titlesize=None,
              title_offset=None, colorbar=None, cmap='viridis',
-             cmap_limits=None, cmap_limits_complex=None, cmap_reverse=False,
+             cmap_limits=None, cmap_limits_complex=None, cmap_rlimits=None,
+             cmap_rlimits_complex=None, cmap_reverse=False,
              cb_triangles='neither', cb_label=None, cb_ylabel=None,
              cb_tick_interval=None, cb_minor_tick_interval=None,
              cb_offset=None, cb_width=None, grid=False, axes_labelsize=None,
@@ -1219,8 +1220,9 @@ class SHGrid(object):
         -----
         fig, ax = x.plot([projection, tick_interval, minor_tick_interval,
                           ticks, xlabel, ylabel, title, title_offset, colorbar,
-                          cmap, cmap_limits, cmap_limits_complex, cmap_reverse,
-                          cb_triangles, cb_label, cb_ylabel, cb_tick_interval,
+                          cmap, cmap_limits, cmap_limits_complex, cmap_rlimits,
+                          cmap_rlimits_complex, cmap_reverse, cb_triangles,
+                          cb_label, cb_ylabel, cb_tick_interval,
                           cb_minor_tick_interval, cb_offset, cb_width, grid,
                           titlesize, axes_labelsize, tick_labelsize, ax, ax2,
                           show, fname])
@@ -1265,6 +1267,12 @@ class SHGrid(object):
             Set the lower and upper limits of the imaginary component of the
             data used by the colormap, and optionally an interval for each
             color band.
+        cmap_rlimits : list, optional, default = None
+           Same as cmap_limits, except the provided upper and lower values are
+           relative with respect to the maximum value of the data.
+        cmap_rlimits_complex : list, optional, default = None
+            Same as cmap_limits_complex, except the provided upper and lower
+            values are relative with respect to the maximum value of the data.
         cmap_reverse : bool, optional, default = False
             Set to True to reverse the sense of the color progression in the
             color table.
@@ -1372,8 +1380,10 @@ class SHGrid(object):
                 ticks=ticks, minor_tick_interval=minor_tick_interval,
                 cb_tick_interval=cb_tick_interval, cb_ylabel=cb_ylabel,
                 cb_minor_tick_interval=cb_minor_tick_interval, cmap=cmap,
-                cmap_limits=cmap_limits, cb_offset=cb_offset,
-                cb_width=cb_width, cmap_limits_complex=cmap_limits_complex,
+                cmap_limits=cmap_limits, cmap_rlimits=cmap_rlimits,
+                cmap_limits_complex=cmap_limits_complex,
+                cmap_rlimits_complex=cmap_rlimits_complex,
+                cb_offset=cb_offset, cb_width=cb_width,
                 cmap_reverse=cmap_reverse)
         else:
             if self.kind == 'complex':
@@ -1393,9 +1403,10 @@ class SHGrid(object):
                        cmap=cmap, cb_offset=cb_offset,
                        cb_tick_interval=cb_tick_interval,
                        cb_minor_tick_interval=cb_minor_tick_interval,
-                       cmap_limits=cmap_limits, cb_ylabel=cb_ylabel,
-                       cb_width=cb_width,
+                       cmap_limits=cmap_limits, cmap_rlimits=cmap_rlimits,
                        cmap_limits_complex=cmap_limits_complex,
+                       cmap_rlimits_complex=cmap_limits_complex,
+                       cb_width=cb_width, cb_ylabel=cb_ylabel,
                        cmap_reverse=cmap_reverse)
 
         if ax is None:
@@ -1412,7 +1423,8 @@ class SHGrid(object):
                 central_longitude=0, grid=[30, 30], tick_interval=[30, 30],
                 minor_tick_interval=[None, None], ticks='WSen', title=None,
                 title_offset=0, cmap='viridis', cmap_limits=None,
-                cmap_limits_complex=None, cmap_reverse=False,
+                cmap_rlimits=None, cmap_limits_complex=None,
+                cmap_rlimits_complex=None, cmap_reverse=False,
                 cmap_continuous=False, cmap_background_foreground=True,
                 colorbar=None, cb_triangles='both', cb_label=None,
                 cb_ylabel=None, cb_tick_interval=None,
@@ -1429,7 +1441,8 @@ class SHGrid(object):
         fig = x.plotgmt([fig, projection, region, rectangle, width, unit,
                          central_latitude, central_longitude, grid,
                          tick_interval, minor_tick_interval, ticks, title,
-                         title_offset cmap, cmap_limits, cmap_limits_complex,
+                         title_offset cmap, cmap_limits, cmap_rlimits,
+                         cmap_limits_complex, cmap_rlimits_complex,
                          cmap_reverse, cmap_continuous,
                          cmap_background_foreground, colorbar, cb_triangles,
                          cb_label, cb_ylabel, cb_tick_interval,
@@ -1496,6 +1509,12 @@ class SHGrid(object):
             Set the lower and upper limits of the imaginary component of the
             data used by the colormap, and optionally an interval for each
             color band.
+        cmap_rlimits : list, optional, default = None
+           Same as cmap_limits, except the provided upper and lower values are
+           relative with respect to the maximum value of the data.
+        cmap_rlimits_complex : list, optional, default = None
+            Same as cmap_limits_complex, except the provided upper and lower
+            values are relative with respect to the maximum value of the data.
         cmap_reverse : bool, optional, default = False
             Set to True to reverse the sense of the color progression in the
             color table.
@@ -1652,8 +1671,9 @@ class SHGrid(object):
             tick_interval=tick_interval,
             minor_tick_interval=minor_tick_interval, ticks=ticks, title=title,
             title_offset=title_offset, cmap=cmap, cmap_limits=cmap_limits,
-            cmap_limits_complex=cmap_limits_complex, cmap_reverse=cmap_reverse,
-            cmap_continuous=cmap_continuous,
+            cmap_rlimits=cmap_rlimits, cmap_limits_complex=cmap_limits_complex,
+            cmap_rlimits_complex=cmap_rlimits_complex,
+            cmap_reverse=cmap_reverse, cmap_continuous=cmap_continuous,
             cmap_background_foreground=cmap_background_foreground,
             colorbar=colorbar, cb_triangles=cb_triangles, cb_label=cb_label,
             cb_ylabel=cb_ylabel, cb_tick_interval=cb_tick_interval,
@@ -1934,7 +1954,8 @@ class DHRealGrid(SHGrid):
               titlesize=None, title_offset=None, cmap=None, tick_interval=None,
               ticks=None, minor_tick_interval=None, cb_tick_interval=None,
               cb_ylabel=None, cb_minor_tick_interval=None, cmap_limits=None,
-              cmap_reverse=None, cmap_limits_complex=None, cb_offset=None,
+              cmap_rlimits=None, cmap_rlimits_complex=None,
+              cmap_limits_complex=None, cb_offset=None, cmap_reverse=None,
               cb_width=None):
         """Plot the data as a matplotlib cylindrical projection,
            or with Cartopy when projection is specified."""
@@ -1985,8 +2006,13 @@ class DHRealGrid(SHGrid):
                 -90, 90, num=180//minor_tick_interval[1]+1, endpoint=True)
 
         # make colormap
-        if cmap_limits is None:
+        if cmap_limits is None and cmap_rlimits is None:
             cmap_limits = [self.min(), self.max()]
+        elif cmap_rlimits is not None:
+            cmap_limits = [self.max() * cmap_rlimits[0],
+                           self.max() * cmap_rlimits[1]]
+            if len(cmap_rlimits) == 3:
+                cmap_limits.append(cmap_rlimits[2])
         if len(cmap_limits) == 3:
             num = int((cmap_limits[1] - cmap_limits[0]) / cmap_limits[2])
             if isinstance(cmap, _mpl.colors.Colormap):
@@ -2204,7 +2230,8 @@ class DHRealGrid(SHGrid):
                     central_latitude=None, central_longitude=None, grid=None,
                     tick_interval=None, minor_tick_interval=None, ticks=None,
                     title=None, title_offset=None, cmap=None, cmap_limits=None,
-                    cmap_limits_complex=None, cmap_reverse=None,
+                    cmap_rlimits=None, cmap_limits_complex=None,
+                    cmap_rlimits_complex=None, cmap_reverse=None,
                     cmap_continuous=None, cmap_background_foreground=None,
                     colorbar=None, cb_triangles=None, cb_label=None,
                     cb_ylabel=None, cb_tick_interval=None,
@@ -2346,8 +2373,13 @@ class DHRealGrid(SHGrid):
         else:
             figure = fig
 
-        if cmap_limits is None:
+        if cmap_limits is None and cmap_rlimits is None:
             cmap_limits = [self.min(), self.max()]
+        elif cmap_rlimits is not None:
+            cmap_limits = [self.max() * cmap_rlimits[0],
+                           self.max() * cmap_rlimits[1]]
+            if len(cmap_rlimits) == 3:
+                cmap_limits.append(cmap_rlimits[2])
 
         if shading is True:
             # generate shading from self
@@ -2500,8 +2532,9 @@ class DHComplexGrid(SHGrid):
               titlesize=None, title_offset=None, cmap=None, ax=None, ax2=None,
               tick_interval=None, minor_tick_interval=None, cb_ylabel=None,
               cb_tick_interval=None, cb_minor_tick_interval=None,
-              cmap_limits=None, cmap_reverse=None, cmap_limits_complex=None,
-              cb_offset=None, cb_width=None):
+              cmap_limits=None, cmap_rlimits=None, cmap_rlimits_complex=None,
+              cmap_reverse=None, cmap_limits_complex=None, cb_offset=None,
+              cb_width=None):
         """Plot the raw data as a matplotlib simple cylindrical projection,
            or with Cartopy when projection is specified."""
         if ax is None:
@@ -2533,8 +2566,8 @@ class DHComplexGrid(SHGrid):
                             title_offset=title_offset, xlabel=xlabel,
                             ylabel=ylabel, cb_ylabel=cb_ylabel,
                             cb_width=cb_width, cmap=cmap,
-                            cmap_limits=cmap_limits, cmap_reverse=cmap_reverse,
-                            ax=axreal)
+                            cmap_limits=cmap_limits, cmap_rlimits=cmap_rlimits,
+                            cmap_reverse=cmap_reverse, ax=axreal)
 
         self.to_imag().plot(projection=projection, tick_interval=tick_interval,
                             minor_tick_interval=minor_tick_interval,
@@ -2547,6 +2580,7 @@ class DHComplexGrid(SHGrid):
                             title=title[1], titlesize=titlesize,
                             title_offset=title_offset, cmap=cmap,
                             cmap_limits=cmap_limits_complex,
+                            cmap_rlimits=cmap_rlimits_complex,
                             cmap_reverse=cmap_reverse, cb_offset=cb_offset,
                             cb_width=cb_width, xlabel=xlabel, ylabel=ylabel,
                             ax=axcomplex)
@@ -2558,13 +2592,13 @@ class DHComplexGrid(SHGrid):
                     rectangle=None, width=None, unit=None,
                     central_latitude=None, central_longitude=None, grid=None,
                     tick_interval=None, minor_tick_interval=None, ticks=None,
-                    title=None, cmap=None, cmap_limits=None,
-                    cmap_limits_complex=None, cmap_reverse=None,
-                    cmap_continuous=None, cmap_background_foreground=None,
-                    colorbar=None, cb_triangles=None, cb_label=None,
-                    cb_ylabel=None, cb_tick_interval=None,
-                    cb_minor_tick_interval=None, titlesize=None,
-                    title_offset=None, axes_labelsize=None,
+                    title=None, cmap=None, cmap_limits=None, cmap_rlimits=None,
+                    cmap_limits_complex=None, cmap_rlimits_complex=None,
+                    cmap_reverse=None, cmap_continuous=None,
+                    cmap_background_foreground=None, colorbar=None,
+                    cb_triangles=None, cb_label=None, cb_ylabel=None,
+                    cb_tick_interval=None, cb_minor_tick_interval=None,
+                    titlesize=None, title_offset=None, axes_labelsize=None,
                     tick_labelsize=None, horizon=None, offset=None,
                     cb_offset=None):
         """
@@ -2583,6 +2617,7 @@ class DHComplexGrid(SHGrid):
                                minor_tick_interval=minor_tick_interval,
                                ticks=ticks, title=title[1], cmap=cmap,
                                cmap_limits=cmap_limits_complex,
+                               cmap_rlimits=cmap_rlimits_complex,
                                cmap_reverse=cmap_reverse, cb_offset=cb_offset,
                                cmap_continuous=cmap_continuous,
                                cmap_background_foreground=  # noqa E251
@@ -2609,7 +2644,8 @@ class DHComplexGrid(SHGrid):
                                grid=grid, tick_interval=tick_interval,
                                minor_tick_interval=minor_tick_interval,
                                ticks=ticks, title=title[0], cmap=cmap,
-                               cmap_limits=cmap_limits, cb_offset=cb_offset,
+                               cmap_limits=cmap_limits,
+                               cmap_rlimits=cmap_rlimits, cb_offset=cb_offset,
                                cmap_reverse=cmap_reverse,
                                cmap_continuous=cmap_continuous,
                                cmap_background_foreground=  # noqa E251
@@ -2747,10 +2783,10 @@ class GLQRealGrid(SHGrid):
               grid=False, axes_labelsize=None, tick_labelsize=None,
               title=None, titlesize=None, title_offset=None, cmap=None,
               tick_interval=None, minor_tick_interval=None,
-              cb_tick_interval=None, ticks=None,
-              cb_minor_tick_interval=None, cmap_limits=None, cmap_reverse=None,
-              cmap_limits_complex=None, cb_ylabel=None, cb_offset=None,
-              cb_width=None):
+              cb_tick_interval=None, ticks=None, cb_minor_tick_interval=None,
+              cmap_limits=None, cmap_rlimits=None, cmap_limits_complex=None,
+              cmap_rlimits_complex=None, cb_ylabel=None, cb_offset=None,
+              cb_width=None, cmap_reverse=None):
         """Plot the data using a matplotlib cylindrical projection."""
         if ax is None:
             if colorbar is not None:
@@ -2784,8 +2820,13 @@ class GLQRealGrid(SHGrid):
             minor_yticks = _np.arange(0, self.nlat, minor_tick_interval[1])
 
         # make colormap
-        if cmap_limits is None:
+        if cmap_limits is None and cmap_rlimits is None:
             cmap_limits = [self.min(), self.max()]
+        elif cmap_rlimits is not None:
+            cmap_limits = [self.max() * cmap_rlimits[0],
+                           self.max() * cmap_rlimits[1]]
+            if len(cmap_rlimits) == 3:
+                cmap_limits.append(cmap_rlimits[2])
         if len(cmap_limits) == 3:
             num = int((cmap_limits[1] - cmap_limits[0]) / cmap_limits[2])
             if isinstance(cmap, _mpl.colors.Colormap):
@@ -3061,8 +3102,9 @@ class GLQComplexGrid(SHGrid):
               axes_labelsize=None, tick_labelsize=None, title=None,
               titlesize=None, title_offset=None, cmap=None, tick_interval=None,
               cb_ylabel=None, minor_tick_interval=None, cb_tick_interval=None,
-              cb_minor_tick_interval=None, cmap_limits=None, cmap_reverse=None,
-              cmap_limits_complex=None, cb_offset=None, cb_width=None):
+              cb_minor_tick_interval=None, cmap_limits=None, cmap_rlimits=None,
+              cmap_limits_complex=None, cmap_rlimits_complex=None,
+              cmap_reverse=None, cb_offset=None, cb_width=None):
         """Plot the raw data using a simply cylindrical projection."""
         if ax is None:
             if colorbar is not None:
@@ -3093,8 +3135,8 @@ class GLQComplexGrid(SHGrid):
                             title_offset=title_offset, xlabel=xlabel,
                             ylabel=ylabel, cb_ylabel=cb_ylabel,
                             cb_width=cb_width, cmap=cmap,
-                            cmap_limits=cmap_limits, cmap_reverse=cmap_reverse,
-                            ax=axreal)
+                            cmap_limits=cmap_limits, cmap_rlimits=cmap_rlimits,
+                            cmap_reverse=cmap_reverse, ax=axreal)
 
         self.to_imag().plot(projection=projection, tick_interval=tick_interval,
                             minor_tick_interval=minor_tick_interval,
@@ -3107,6 +3149,7 @@ class GLQComplexGrid(SHGrid):
                             title=title[1], titlesize=titlesize,
                             title_offset=title_offset, cmap=cmap,
                             cmap_limits=cmap_limits_complex,
+                            cmap_rlimits=cmap_rlimits_complex,
                             cmap_reverse=cmap_reverse, cb_ylabel=cb_ylabel,
                             cb_width=cb_width, xlabel=xlabel, ylabel=ylabel,
                             ax=axcomplex)

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -1446,12 +1446,13 @@ class SHGrid(object):
         fig : pygmt.Figure() class instance, optional, default = None
             If provided, the plot will be placed in a pre-existing figure.
         projection : str, optional, default = 'mollweide'
-            The name of a global or hemispherical projection (see Notes). Only
-            the first three characters are necessary to identify the
-            projection.
+            The name of a projection (see Notes). Only the first three
+            characters are necessary to identify the projection.
         region : str or list, optional, default = 'g'
-            The map region, consisting of a list [West, East, South, North] in
-            degrees. The default 'g' specifies the entire sphere.
+            The map region, which can be the string 'g' for the entire sphere,
+            a bounded region specified by a list [West, East, South, North], or
+            a string that provides the lower-left and upper-right coordinates
+            of a rectangular projection of the form 'lon1/lat1/lon2/lat2+r'.
         width : float, optional, default = mpl.rcParams['figure.figsize'][0]
             The width of the projected image.
         unit : str, optional, default = 'i'
@@ -1460,8 +1461,8 @@ class SHGrid(object):
         central_longitude : float, optional, default = 0
             The central meridian or center of the projection.
         central_latitude : float, optional, default = 0
-            The center of the projection used with hemispheric projections, or
-            the standard parallel used with cylindrical projections.
+            The central latitude of the projection, or the standard parallel
+            used with cylindrical and Mercator projections.
         grid : list, optional, default = [30, 30]
             Grid line interval [longitude, latitude] in degrees. If None, grid
             lines will not be plotted for that axis. If true, gridlines will be
@@ -1548,20 +1549,20 @@ class SHGrid(object):
         Global and hemispherical projections (region='g') with corresponding
         abbreviation used by `projection`:
 
-        Azimuthal projections
+        * Azimuthal projections
             Lambert-azimuthal-equal-area (lam)
             Stereographic-equal-angle (ste)
             Orthographic (ort)
             Azimuthal-equidistant (azi)
             Gnomonic (gno)
 
-        Cylindrical projections (case sensitive)
+        * Cylindrical projections (case sensitive)
             cylindrical-equidistant (cyl)
             Cylindrical-equal-area (Cyl)
             CYLindrical-stereographic (CYL)
             Miller-cylindrical (mil)
 
-        Miscellaneous projections
+        * Miscellaneous projections
             Mollweide (mol)
             Hammer (ham)
             Winkel-Tripel (win)
@@ -1569,6 +1570,29 @@ class SHGrid(object):
             Eckert (eck)
             Sinusoidal (sin)
             Van-der-Grinten (van)
+
+        Rectangular projections using the coordinates of the lower-left and
+        upper-right corners (region='lon1/lat1/lon2/lat2+r') with
+        corresponding abbreviation used by `projection`:
+
+        * Azimuthal projections
+            Lambert-azimuthal-equal-area (lam)
+            Stereographic-equal-angle (ste)
+
+        * Cylindrical projections
+            Transverse Mercator (tra)
+            Cassini cylindrical (cas)
+
+        Rectangular projections using the West, East, South and North bounding
+        coordinates (region=[west, east, south, north]) with corresponding
+        abbreviation used by `projection`:
+
+        * Cylindrical projections (case sensitive)
+            Mercator (mer)
+            cylindrical-equidistant (cyl)
+            Cylindrical-equal-area (Cyl)
+            CYLindrical-stereographic (CYL)
+            Miller-cylindrical (mil)
         """
         if not _pygmt_module:
             raise ImportError('plotgmt() requires installation of the module '
@@ -2209,6 +2233,12 @@ class DHRealGrid(SHGrid):
         elif projection[0:3] == 'CYLindrical-stereographic'[0:3]:
             proj_str = 'Cyl_stere' + '/' + str(center[0]) + '/' \
                 + str(center[1])
+        elif projection[0:3].lower() == 'mercator'[0:3]:
+            proj_str = 'M' + str(center[0]) + '/' + str(center[1])
+        elif projection[0:3].lower() == 'transverse-mercator'[0:3]:
+            proj_str = 'T' + str(center[0]) + '/' + str(center[1])
+        elif projection[0:3].lower() == 'cassini-cylindrical'[0:3]:
+            proj_str = 'C' + str(center[0]) + '/' + str(center[1])
         else:
             raise ValueError('Input projection is not recognized or '
                              'supported. Input projection = {:s}'

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -2997,7 +2997,7 @@ class SHMagRealCoeffs(SHMagCoeffs):
                 if _np.isscalar(lat):
                     radius = _np.array(a)
                 else:
-                    radius = _np.empty(len(latin))
+                    radius = _np.empty(len(lat))
                     radius[:] = a
             else:
                 radius = _np.cos(_np.deg2rad(latin))**2 + \

--- a/pyshtools/shio/icgem.py
+++ b/pyshtools/shio/icgem.py
@@ -196,7 +196,8 @@ def read_icgem_gfc(filename, errors=None, lmax=None, epoch=None,
 
             value_cs = [float(line[3]), float(line[4]), 0, 0]
             if errors:
-                value_cs[2:] = float(line[err_cols[0]]), float(line[err_cols[1]])
+                value_cs[2:] = float(line[err_cols[0]]), \
+                    float(line[err_cols[1]])
 
             if key == 'gfc':
                 cilm[:, l, m] = value_cs

--- a/pyshtools/utils/figstyle.py
+++ b/pyshtools/utils/figstyle.py
@@ -75,7 +75,7 @@ def figstyle(rel_width=0.75, screen_dpi=114, aspect_ratio=4/3,
         'xtick.major.width': 0.6,
         'ytick.major.width': 0.6,
         'xtick.minor.width': 0.6,
-        'xtick.minor.width': 0.6,
+        'ytick.minor.width': 0.6,
         'xtick.top': True,
         'ytick.right': True,
         # grids

--- a/src/MakeMagGridPoint.f95
+++ b/src/MakeMagGridPoint.f95
@@ -13,7 +13,7 @@ function MakeMagGridPoint(cilm, lmax, a, r, lat, lon, dealloc)
 !           cilm        Spherical harmonic coefficients, with dimensions
 !                       (2, lmax+1, lmax+1).
 !           lmax        Maximum degree used in the expansion.
-!           a          Reference radius of the potential coefficients.
+!           a           Reference radius of the potential coefficients.
 !           r           Radius where the magnetic field is computed (meters).
 !           lat         Latitude where the gravity vector is computed, in
 !                       degrees.


### PR DESCRIPTION
* When importing an xarray grid with `SHGrid.from_xarray()`, check if the first row is 90 or -90 and flip accordingly.
* Add the optional parameter `rectangle` to the `SHGrid.plotgmt()` method that allows the use of rectangular projections that are specified by the lower-left and upper-right coordinates.
* Add the optional parameter `cmap_background_foreground` to  `SHGrid.plotgmt()` that controls how data are plotted when they exceed the limits of the colormap.
* Add the optional parameter `title_offset` to  `SHGrid.plotgmt()`  and  `SHGrid.plot()` that specifies how much space to add between the plot and title.
* Cleanup `SHGrid.plotgmt()` shading options based on changes made in pygmt 0.7, including the use of xarrays directly instead of creating temporary files.
* Add the optional argument `r` to `SHMagCoeffs.expand()` and `SHGravCoeffs.expand()` that allows one to compute the field at an arbitrary list of (r, lat, lon) points.
* Add the optional argument `cmap_rlimits` and `cmap_rlimits_complex` to `SHGrid.plot()`, `SHGrid.plotgmt()` and `SHGrid.plot3d()` to specify colorbar limits with respect to the maximum value of the data.
* Add the optional argument `cmap_scale` to `SHGrid.plot()` and `SHGrid.plotgmt()` to allow using either a linear or logarithmic color map.
* Add the optional argument `cb_power` to `SHGrid.plotgmt()` to allow plotting annotations as powers of 10.


**Reminders**

- [ ] Base all changes on the `develop` branch: the `master` branch is used only when releasing new versions.
- [ ] Run `make check` to ensure that the python code follows standard formatting conventions.
- [ ] If adding new features, update the docstring to provide all information that is required to use the feature.
