### PR TITLE
Remove Cartopy build-time dependencies

### DIFF
--- a/docs/pages/mydoc/python-installing.md
+++ b/docs/pages/mydoc/python-installing.md
@@ -95,7 +95,7 @@ When installing pyshtools using `conda`, the following will also be installed au
 
 * [fftw](https://www.fftw.org/): required for the fortran library.
 * [blas-devel](https://anaconda.org/conda-forge/blas-devel): required for the fortran components.
-* [cartopy](https://scitools.org.uk/cartopy/docs/latest/): required for Cartopy map projections. Cartopy requires (see below) *proj*, *geos*, *cython*, *pyshp*, *six*, and *shapely*.
+* [cartopy](https://scitools.org.uk/cartopy/docs/latest/): required for Cartopy map projections.
 * [pygmt](https://www.pygmt.org) (>=0.3): required for pygmt map projections. pygmt requires (see below) *gmt (>=6.1.1)*.
 * [ducc0](https://gitlab.mpcdf.mpg.de/mtr/ducc) (>=0.15): required for using the 'ducc' backend for spherical harmonic transforms.
 * [palettable](https://jiffyclub.github.io/palettable/): scientific color maps required by one of the tutorials.
@@ -115,23 +115,6 @@ sudo dnf install blas-devel lapack-devel fftw-devel  # Fedora, Centos, RHEL and 
 brew install fftw  # macOS
 ```
 Note that pyshtools supports the use of any FFTW3-compatible library, such as Intel's [MKL](https://software.intel.com/en-us/mkl).
-
-### How to install Cartopy
-
-The easiest way to install Cartopy is with `conda`:
-```bash
-conda install -c conda-forge cartopy
-```
-Cartopy can also be installed using `pip`, but there are several dependencies that need to be installed first. On macOS, this can be accomplished using
-```bash
-brew install proj geos
-pip install --upgrade cython numpy pyshp six
-# shapely needs to be built from source to link to geos. If it is already
-# installed, uninstall it by: pip3 uninstall shapely
-pip install shapely --no-binary shapely
-pip install cartopy
-```
-See [these instructions](https://scitools.org.uk/cartopy/docs/latest/installing.html#installing) for further details.
 
 ### How to install pygmt
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ homepage = 'https://shtools.github.io/SHTOOLS/'
 download = 'https://github.com/SHTOOLS/SHTOOLS/zipball/master'
 
 [project.optional-dependencies]
-cartopy = ['cython', 'pyshp', 'six', 'shapely', 'cartopy>=0.18.0']
+cartopy = ['cartopy>=0.18.0']
 pygmt = ['pygmt>=0.3']
 palettable = ['palettable>=3.3']
 ducc = ['ducc0>=0.15']


### PR DESCRIPTION
Latest Cartopy produces wheels, so there's no need to install its build-time dependencies ourselves.

**Reminders**

- [x] Base all changes on the `develop` branch: the `master` branch is used only when releasing new versions.
- [x] Run `make check` to ensure that the python code follows standard formatting conventions.
- [n/a] If adding new features, update the docstring to provide all information that is required to use the feature.
