### PR TITLE
Add pathlib support to input and output

### DIFF
--- a/pyshtools/shclasses/shcoeffs.py
+++ b/pyshtools/shclasses/shcoeffs.py
@@ -1046,7 +1046,7 @@ class SHCoeffs(object):
 
         if isinstance(filename, Path):
             filename = str(filename)
-        
+
         if filename[-3:] == '.gz':
             filebase = filename[:-3]
         else:

--- a/pyshtools/shclasses/shcoeffs.py
+++ b/pyshtools/shclasses/shcoeffs.py
@@ -12,6 +12,7 @@ import shutil as _shutil
 import warnings as _warnings
 from scipy.special import factorial as _factorial
 import xarray as _xr
+from pathlib import Path
 
 from ..spectralanalysis import spectrum as _spectrum
 from ..spectralanalysis import cross_spectrum as _cross_spectrum
@@ -1043,6 +1044,9 @@ class SHCoeffs(object):
         if errors is True and self.errors is None:
             errors = False
 
+        if isinstance(filename, Path):
+            filename = str(filename)
+        
         if filename[-3:] == '.gz':
             filebase = filename[:-3]
         else:

--- a/pyshtools/shclasses/shcoeffs.py
+++ b/pyshtools/shclasses/shcoeffs.py
@@ -363,7 +363,7 @@ class SHCoeffs(object):
 
         Parameters
         ----------
-        filename : str
+        filename : str or pathlib.Path
             File name or URL containing the spherical harmonic coefficients.
             filename will be treated as a URL if it starts with 'http://',
             'https://', or 'ftp://'. For 'shtools' and 'bshc' formatted files,
@@ -712,7 +712,7 @@ class SHCoeffs(object):
 
         Parameters
         ----------
-        filename : str
+        filename : str or pathlib.Path
             Name of the file, including path.
         lmax : int, optional, default = None
             The maximum spherical harmonic degree to read.
@@ -984,7 +984,7 @@ class SHCoeffs(object):
 
         Parameters
         ----------
-        filename : str
+        filename : str or pathlib.Path
             Name of the output file. If the filename ends with '.gz', the file
             will be compressed using gzip.
         format : str, optional, default = 'shtools'
@@ -1098,7 +1098,7 @@ class SHCoeffs(object):
 
         Parameters
         ----------
-        filename : str
+        filename : str or pathlib.Path
             Name of the output file.
         title : str, optional, default = ''
             Title of the dataset

--- a/pyshtools/shclasses/shgeoid.py
+++ b/pyshtools/shclasses/shgeoid.py
@@ -238,7 +238,7 @@ class SHGeoid(object):
 
         Parameters
         ----------
-        filename : str, optional, default = None
+        filename : str or pathlib.Path, optional, default = None
             Name of output file.
         title : str, optional, default = ''
             Title of the dataset.

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -415,7 +415,7 @@ class SHGravCoeffs(object):
 
         Parameters
         ----------
-        filename : str
+        filename : str or pathlib.Path
             File name or URL containing the spherical harmonic coefficients.
             filename will be treated as a URL if it starts with 'http://',
             'https://', or 'ftp://'. For 'shtools', 'icgem' and 'bshc'
@@ -895,7 +895,7 @@ class SHGravCoeffs(object):
 
         Parameters
         ----------
-        filename : str
+        filename : str or pathlib.Path
             Name of the file, including path.
         lmax : int, optional, default = None
             The maximum spherical harmonic degree to read.
@@ -1307,7 +1307,7 @@ class SHGravCoeffs(object):
 
         Parameters
         ----------
-        filename : str
+        filename : str or pathlib.Path
             Name of the output file. If the filename ends with '.gz', the file
             will be compressed using gzip.
         format : str, optional, default = 'shtools'
@@ -1460,7 +1460,7 @@ class SHGravCoeffs(object):
 
         Parameters
         ----------
-        filename : str
+        filename : str or pathlib.Path
             Name of the output file.
         title : str, optional, default = ''
             Title of the dataset

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -11,6 +11,7 @@ import xarray as _xr
 from scipy.special import factorial as _factorial
 import gzip as _gzip
 import shutil as _shutil
+from pathlib import Path
 
 from .shcoeffs import SHCoeffs as _SHCoeffs
 from .shcoeffs import SHRealCoeffs as _SHRealCoeffs
@@ -1378,6 +1379,9 @@ class SHGravCoeffs(object):
         if errors is True and self.errors is None:
             errors = False
 
+        if isinstance(filename, Path):
+            filename = str(filename)
+            
         if filename[-3:] == '.gz':
             filebase = filename[:-3]
         else:

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -1381,7 +1381,7 @@ class SHGravCoeffs(object):
 
         if isinstance(filename, Path):
             filename = str(filename)
-            
+
         if filename[-3:] == '.gz':
             filebase = filename[:-3]
         else:

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -391,7 +391,7 @@ class SHGrid(object):
 
         Parameters
         ----------
-        fname : str
+        fname : str or pathlib.Path
             The filename containing the gridded data. For text files (default)
             the file is read using the numpy routine loadtxt(), whereas for
             binary files, the file is read using numpy.load(). For Driscoll and
@@ -468,7 +468,7 @@ class SHGrid(object):
 
         Parameters
         ----------
-        netcdf : str or netcdf object
+        netcdf : str or netcdf object or pathlib.Path
             The name of a netcdf file or object.
         grid : str, optional, default = 'DH'
             'DH' or 'GLQ' for Driscoll and Healy grids or Gauss-Legendre
@@ -506,7 +506,7 @@ class SHGrid(object):
 
         Parameters
         ----------
-        filename : str
+        filename : str or pathlib.Path
             Name of output file. For text files (default), the file will be
             compressed using gzip if filename ends in '.gz.'
         binary : bool, optional, default = False
@@ -597,7 +597,7 @@ class SHGrid(object):
 
         Parameters
         ----------
-        filename : str, optional, default = None
+        filename : str or pathlib.Path, optional, default = None
             Name of output file.
         title : str, optional, default = None
             Title of the dataset.

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -373,7 +373,7 @@ class SHMagCoeffs(object):
 
         Parameters
         ----------
-        filename : str
+        filename : str or pathlib.Path
             File name or URL containing the spherical harmonic coefficients.
             filename will be treated as a URL if it starts with 'http://',
             'https://', or 'ftp://'. For 'shtools' and 'bshc' formatted files,
@@ -819,7 +819,7 @@ class SHMagCoeffs(object):
 
         Parameters
         ----------
-        filename : str
+        filename : str or pathlib.Path
             Name of the file, including path.
         lmax : int, optional, default = None
             The maximum spherical harmonic degree to read.
@@ -985,7 +985,7 @@ class SHMagCoeffs(object):
 
         Parameters
         ----------
-        filename : str
+        filename : str or pathlib.Path
             Name of the output file. If the filename ends with '.gz', the file
             will be compressed using gzip.
         format : str, optional, default = 'shtools'
@@ -1105,7 +1105,7 @@ class SHMagCoeffs(object):
 
         Parameters
         ----------
-        filename : str
+        filename : str or pathlib.Path
             Name of the output file.
         title : str, optional, default = ''
             Title of the dataset

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -1049,7 +1049,7 @@ class SHMagCoeffs(object):
 
         if isinstance(filename, Path):
             filename = str(filename)
-        
+
         if filename[-3:] == '.gz':
             filebase = filename[:-3]
         else:

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -11,6 +11,7 @@ import xarray as _xr
 from scipy.special import factorial as _factorial
 import gzip as _gzip
 import shutil as _shutil
+from pathlib import Path
 
 from .shcoeffs import SHCoeffs as _SHCoeffs
 from .shmaggrid import SHMagGrid as _SHMagGrid
@@ -1046,6 +1047,9 @@ class SHMagCoeffs(object):
         if errors is True and self.errors is None:
             errors = False
 
+        if isinstance(filename, Path):
+            filename = str(filename)
+        
         if filename[-3:] == '.gz':
             filebase = filename[:-3]
         else:

--- a/pyshtools/shio/bshc.py
+++ b/pyshtools/shio/bshc.py
@@ -9,6 +9,7 @@ import zipfile as _zipfile
 import numpy as _np
 import requests as _requests
 import shutil as _shutil
+from pathlib import Path
 
 
 def read_bshc(filename, lmax=None):
@@ -28,7 +29,7 @@ def read_bshc(filename, lmax=None):
 
     Parameters
     ----------
-    filename : str
+    filename : str or pathlib.Path
         File name or URL that contains the spherical harmonic coefficients.
         filename will be treated as a URL if it starts with 'http://',
         'https://', or 'ftp://'. If filename ends with '.gz' or '.zip', the
@@ -58,6 +59,9 @@ def read_bshc(filename, lmax=None):
     uncompressed before parsing. For zip files, archives with only a single
     file are supported.
     """
+    if isinstance(filename, Path):
+        filename = str(filename)
+
     if _isurl(filename):
         _response = _requests.get(filename, stream=True)
         if filename[-4:] == '.zip':
@@ -119,7 +123,7 @@ def write_bshc(filename, coeffs, lmax=None):
 
     Parameters
     ----------
-    filename : str
+    filename : str or pathlib.Path
         File name of the binary 'bshc'-formatted spherical harmonic
         coefficients. If filename ends with '.gz' the file will be
         automatically compressed with gzip.
@@ -145,6 +149,9 @@ def write_bshc(filename, coeffs, lmax=None):
     If the filename ends with '.gz', the file will be automatically
     compressed using gzip.
     """
+    if isinstance(filename, Path):
+        filename = str(filename)
+
     if lmax is None:
         lmax = coeffs.shape[1] - 1
     else:

--- a/pyshtools/shio/dov.py
+++ b/pyshtools/shio/dov.py
@@ -9,6 +9,7 @@ import zipfile as _zipfile
 import numpy as _np
 import requests as _requests
 import shutil as _shutil
+from pathlib import Path
 
 
 def read_dov(filename, lmax=None, error=False, header=False, header2=False,
@@ -40,7 +41,7 @@ def read_dov(filename, lmax=None, error=False, header=False, header2=False,
 
     Parameters
     ----------
-    filename : str
+    filename : str or pathlib.Path
         File name or URL that contains the text-formatted spherical harmonic
         coefficients. filename will be treated as a URL if it starts with
         'http://', 'https://', or 'ftp://'. If filename ends with '.gz' or
@@ -102,6 +103,9 @@ def read_dov(filename, lmax=None, error=False, header=False, header2=False,
     file are supported. Note that reading '.gz' and '.zip' files will be
     extremely slow if lmax is not specified.
     """
+    if isinstance(filename, Path):
+        filename = str(filename)
+
     if _isurl(filename):
         _response = _requests.get(filename)
         if filename[-4:] == '.zip':
@@ -357,7 +361,7 @@ def write_dov(filename, coeffs, errors=None, header=None, header2=None,
 
     Parameters
     ----------
-    filename : str
+    filename : str or pathlib.Path
         File name of the 'dov'-formatted spherical harmonic coefficients. If
         filename ends with '.gz' the file will be automatically compressed with
         gzip.
@@ -402,6 +406,9 @@ def write_dov(filename, coeffs, errors=None, header=None, header2=None,
     If the filename ends with '.gz', the file will be automatically compressed
     using gzip.
     """
+    if isinstance(filename, Path):
+        filename = str(filename)
+
     if lmax is None:
         lmax = coeffs.shape[1] - 1
     else:

--- a/pyshtools/shio/icgem.py
+++ b/pyshtools/shio/icgem.py
@@ -9,6 +9,7 @@ import numpy as _np
 import shutil as _shutil
 import requests as _requests
 from pyshtools.utils.datetime import _yyyymmdd_to_year_fraction
+from pathlib import Path
 
 
 def read_icgem_gfc(filename, errors=None, lmax=None, epoch=None,
@@ -37,7 +38,7 @@ def read_icgem_gfc(filename, errors=None, lmax=None, epoch=None,
 
     Parameters
     ----------
-    filename : str
+    filename : str or pathlib.Path
         The filename containing the spherical harmonic ICGEM-formatted
         coefficients. filename will be treated as a URL if it starts with
         'http://', 'https://', or 'ftp://'. If filename ends with '.gz' or
@@ -89,6 +90,9 @@ def read_icgem_gfc(filename, errors=None, lmax=None, epoch=None,
 
     Data lines starting with an unknown key are ignored.
     """
+    if isinstance(filename, Path):
+        filename = str(filename)
+
     header = {}
     header_keys = ['modelname', 'product_type', 'earth_gravity_constant',
                    'gravity_constant', 'radius', 'max_degree', 'errors',
@@ -268,7 +272,7 @@ def write_icgem_gfc(filename, coeffs, errors=None, header=None, lmax=None,
 
     Parameters
     ----------
-    filename : str
+    filename : str or pathlib.Path
         The filename to save the spherical harmonic ICGEM-formatted
         coefficients. If filename ends with '.gz' the file will be compressed
         using gzip.
@@ -304,6 +308,9 @@ def write_icgem_gfc(filename, coeffs, errors=None, header=None, lmax=None,
     encoding : str, optional, default = None
         Encoding of the output file. The default is to use the system default.
     """
+    if isinstance(filename, Path):
+        filename = str(filename)
+
     valid_err = ('unknown', 'calibrated', 'formal', 'calibrated_and_formal')
     valid_tide = ('zero_tide', 'tide_free', 'unknown')
     valid_norm = ('4pi', 'unnorm')

--- a/pyshtools/shio/read_igrf.py
+++ b/pyshtools/shio/read_igrf.py
@@ -7,6 +7,7 @@ import gzip
 import zipfile
 import numpy as _np
 import requests as _requests
+from pathlib import Path
 
 
 def read_igrf(filename, year=2020., encoding=None):
@@ -25,7 +26,7 @@ def read_igrf(filename, year=2020., encoding=None):
 
     Parameters
     ----------
-    filename : str
+    filename : str or pathlib.Path
         The filename containing the IGRF formatted spherical harmonic
         coefficients. filename will be treated as a URL if it starts with
         'http://', 'https://', or 'ftp://'. If filename ends with '.gz' or
@@ -47,6 +48,9 @@ def read_igrf(filename, year=2020., encoding=None):
     This routine can read the models IGRF-11, 12, and 13. Prior models have a
     different format.
     """
+    if isinstance(filename, Path):
+        filename = str(filename)
+
     lmax = 13
     coeffs = _np.zeros([2, lmax+1, lmax+1])
 

--- a/pyshtools/shio/shtools.py
+++ b/pyshtools/shio/shtools.py
@@ -40,7 +40,7 @@ def shread(filename, lmax=None, error=False, header=False, header2=False,
 
     Parameters
     ----------
-    filename : str
+    filename : str or pathlib.Path
         File name or URL that contains the text-formatted spherical harmonic
         coefficients. filename will be treated as a URL if it starts with
         'http://', 'https://', or 'ftp://'. If filename ends with '.gz' or

--- a/pyshtools/shio/shtools.py
+++ b/pyshtools/shio/shtools.py
@@ -338,7 +338,7 @@ def shwrite(filename, coeffs, errors=None, header=None, header2=None,
 
     Parameters
     ----------
-    filename : str
+    filename : str or pathlib.Path
         File name of the shtools-formatted spherical harmonic coefficients. If
         filename ends with '.gz' the file will be automatically compressed with
         gzip.
@@ -380,6 +380,9 @@ def shwrite(filename, coeffs, errors=None, header=None, header2=None,
     If the filename ends with '.gz', the file will be automatically compressed
     using gzip.
     """
+    if isinstance(filename, Path):
+        filename = str(filename)
+
     if lmax is None:
         lmax = coeffs.shape[1] - 1
     else:

--- a/pyshtools/shio/shtools.py
+++ b/pyshtools/shio/shtools.py
@@ -6,6 +6,7 @@ import os as _os
 import io as _io
 import gzip as _gzip
 import zipfile as _zipfile
+from pathlib import Path
 import numpy as _np
 import requests as _requests
 import shutil as _shutil
@@ -100,6 +101,10 @@ def shread(filename, lmax=None, error=False, header=False, header2=False,
     file are supported. Note that reading '.gz' and '.zip' files will be
     extremely slow if lmax is not specified.
     """
+        
+    if isinstance(filename, Path):
+        filename = str(filename)
+
     if _isurl(filename):
         _response = _requests.get(filename)
         if filename[-4:] == '.zip':

--- a/pyshtools/shio/shtools.py
+++ b/pyshtools/shio/shtools.py
@@ -101,7 +101,7 @@ def shread(filename, lmax=None, error=False, header=False, header2=False,
     file are supported. Note that reading '.gz' and '.zip' files will be
     extremely slow if lmax is not specified.
     """
-        
+
     if isinstance(filename, Path):
         filename = str(filename)
 


### PR DESCRIPTION
With this change you can pass `pathlib.Path` to `shread` and other input/output functions, including `SHCoeffs.to/from_file`, `SHGravCoeffs.to/from_file` and `SHMagCoeffs.to/from_file`.

- [x] Base all changes on the `develop` branch: the `master` branch is used only when releasing new versions.
- [x] Run `make check` to ensure that the python code follows standard formatting conventions.
- [x] If adding new features, update the docstring to provide all information that is required to use the feature.
