### PR TITLE
Fix type comparisons and bare except

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,3 +67,5 @@ dist = ['--no-tests']
 [tool.setuptools_scm]
 version_scheme =  'no-guess-dev'
 local_scheme =  'dirty-tag'
+parentdir_prefix_version = 'SHTOOLS-'
+fallback_version = '0.0.0'

--- a/pyshtools/backends/ducc0_wrapper.py
+++ b/pyshtools/backends/ducc0_wrapper.py
@@ -11,7 +11,7 @@ try:
     major, minor, patch = ducc0.__version__.split(".")
     if int(major) < 1 and int(minor) < 15:
         raise RuntimeError
-except:
+except Exception:
     ducc0 = None
 
 # setup a few required variables
@@ -20,7 +20,7 @@ if ducc0 is not None:
 
     try:
         nthreads = int(_os.environ["OMP_NUM_THREADS"])
-    except:
+    except Exception:
         nthreads = 0
 
 

--- a/pyshtools/shclasses/shcoeffs.py
+++ b/pyshtools/shclasses/shcoeffs.py
@@ -738,7 +738,7 @@ class SHCoeffs(object):
 
         try:
             normalization = ds.coeffs.normalization
-        except:
+        except Exception:
             pass
 
         if not isinstance(normalization, str):
@@ -754,7 +754,7 @@ class SHCoeffs(object):
 
         try:
             csphase = ds.coeffs.csphase
-        except:
+        except Exception:
             pass
 
         if csphase != 1 and csphase != -1:
@@ -765,7 +765,7 @@ class SHCoeffs(object):
 
         try:
             units = ds.coeffs.units
-        except:
+        except Exception:
             pass
 
         lmaxout = ds.dims['degree'] - 1
@@ -796,7 +796,7 @@ class SHCoeffs(object):
             serrors = serrors[:lmaxout+1, :lmaxout+1]
             errors = _np.array([cerrors, serrors])
             error_kind = ds.errors.error_kind
-        except:
+        except Exception:
             errors = None
             error_kind = None
 

--- a/pyshtools/shclasses/shcoeffs.py
+++ b/pyshtools/shclasses/shcoeffs.py
@@ -196,7 +196,7 @@ class SHCoeffs(object):
         else:
             kind = 'real'
 
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. ' +
                              'Input type is {:s}.'
                              .format(str(type(normalization))))
@@ -435,7 +435,7 @@ class SHCoeffs(object):
         header_list = None
         header2_list = None
 
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. '
                              'Input type is {:s}.'
                              .format(str(type(normalization))))
@@ -597,7 +597,7 @@ class SHCoeffs(object):
         exactly to the input spectrum by setting exact_power to True.
         """
         # check if all arguments are correct
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. ' +
                              'Input type is {:s}.'
                              .format(str(type(normalization))))
@@ -741,7 +741,7 @@ class SHCoeffs(object):
         except:
             pass
 
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. '
                              'Input type was {:s}'
                              .format(str(type(normalization))))
@@ -870,7 +870,7 @@ class SHCoeffs(object):
         specified latitude and longitude, specify the optional parameters clat
         and clon.
         """
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. ' +
                              'Input type is {:s}.'
                              .format(str(type(normalization))))
@@ -1957,7 +1957,7 @@ class SHCoeffs(object):
         True. This rotation is accomplished by performing the inverse rotation
         using the angles (-gamma, -beta, -alpha).
         """
-        if type(convention) is not str:
+        if not isinstance(convention, str):
             raise ValueError('convention must be a string. Input type is {:s}.'
                              .format(str(type(convention))))
 
@@ -2043,7 +2043,7 @@ class SHCoeffs(object):
             kind = self.kind
 
         # check argument consistency
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. ' +
                              'Input type is {:s}.'
                              .format(str(type(normalization))))
@@ -2206,7 +2206,7 @@ class SHCoeffs(object):
                 else:
                     temp = _np.pi/2.
 
-                if type(colat) is list:
+                if isinstance(colat, list):
                     lat = list(map(lambda x: temp - x, colat))
                 else:
                     lat = temp - colat
@@ -2223,7 +2223,7 @@ class SHCoeffs(object):
             if backend is None:
                 backend = preferred_backend()
 
-            if type(grid) is not str:
+            if not isinstance(grid, str):
                 raise ValueError('grid must be a string. Input type is {:s}.'
                                  .format(str(type(grid))))
 
@@ -2295,7 +2295,7 @@ class SHCoeffs(object):
         if backend is None:
             backend = preferred_backend()
 
-        if type(grid) is not str:
+        if not isinstance(grid, str):
             raise ValueError('grid must be a string. Input type is {:s}.'
                              .format(str(type(grid))))
 
@@ -2423,13 +2423,13 @@ class SHCoeffs(object):
 
         if axes_labelsize is None:
             axes_labelsize = _mpl.rcParams['axes.labelsize']
-            if type(axes_labelsize) is str:
+            if isinstance(axes_labelsize, str):
                 axes_labelsize = _mpl.font_manager \
                                  .FontProperties(size=axes_labelsize) \
                                  .get_size_in_points()
         if tick_labelsize is None:
             tick_labelsize = _mpl.rcParams['xtick.labelsize']
-            if type(tick_labelsize) is str:
+            if isinstance(tick_labelsize, str):
                 tick_labelsize = _mpl.font_manager \
                                  .FontProperties(size=tick_labelsize) \
                                  .get_size_in_points()
@@ -2599,13 +2599,13 @@ class SHCoeffs(object):
 
         if axes_labelsize is None:
             axes_labelsize = _mpl.rcParams['axes.labelsize']
-            if type(axes_labelsize) is str:
+            if isinstance(axes_labelsize, str):
                 axes_labelsize = _mpl.font_manager \
                                  .FontProperties(size=axes_labelsize) \
                                  .get_size_in_points()
         if tick_labelsize is None:
             tick_labelsize = _mpl.rcParams['xtick.labelsize']
-            if type(tick_labelsize) is str:
+            if isinstance(tick_labelsize, str):
                 tick_labelsize = _mpl.font_manager \
                                  .FontProperties(size=tick_labelsize) \
                                  .get_size_in_points()
@@ -2795,19 +2795,19 @@ class SHCoeffs(object):
 
         if axes_labelsize is None:
             axes_labelsize = _mpl.rcParams['axes.labelsize']
-            if type(axes_labelsize) is str:
+            if isinstance(axes_labelsize, str):
                 axes_labelsize = _mpl.font_manager \
                                  .FontProperties(size=axes_labelsize) \
                                  .get_size_in_points()
         if tick_labelsize is None:
             tick_labelsize = _mpl.rcParams['xtick.labelsize']
-            if type(tick_labelsize) is str:
+            if isinstance(tick_labelsize, str):
                 tick_labelsize = _mpl.font_manager \
                                  .FontProperties(size=tick_labelsize) \
                                  .get_size_in_points()
         if titlesize is None:
             titlesize = _mpl.rcParams['axes.titlesize']
-            if type(titlesize) is str:
+            if isinstance(titlesize, str):
                 titlesize = _mpl.font_manager \
                                  .FontProperties(size=titlesize) \
                                  .get_size_in_points()
@@ -3296,19 +3296,19 @@ class SHCoeffs(object):
 
         if axes_labelsize is None:
             axes_labelsize = _mpl.rcParams['axes.labelsize']
-            if type(axes_labelsize) is str:
+            if isinstance(axes_labelsize, str):
                 axes_labelsize = _mpl.font_manager \
                                  .FontProperties(size=axes_labelsize) \
                                  .get_size_in_points()
         if tick_labelsize is None:
             tick_labelsize = _mpl.rcParams['xtick.labelsize']
-            if type(tick_labelsize) is str:
+            if isinstance(tick_labelsize, str):
                 tick_labelsize = _mpl.font_manager \
                                  .FontProperties(size=tick_labelsize) \
                                  .get_size_in_points()
         if titlesize is None:
             titlesize = _mpl.rcParams['axes.titlesize']
-            if type(titlesize) is str:
+            if isinstance(titlesize, str):
                 titlesize = _mpl.font_manager \
                                  .FontProperties(size=titlesize) \
                                  .get_size_in_points()
@@ -3788,18 +3788,18 @@ class SHCoeffs(object):
         elif style == 'combined':
             legend_loc = [legend_loc, legend_loc]
         else:
-            if type(legend_loc) is str:
+            if isinstance(legend_loc, str):
                 legend_loc = [legend_loc, legend_loc]
 
         if axes_labelsize is None:
             axes_labelsize = _mpl.rcParams['axes.labelsize']
-            if type(axes_labelsize) is str:
+            if isinstance(axes_labelsize, str):
                 axes_labelsize = _mpl.font_manager \
                                  .FontProperties(size=axes_labelsize) \
                                  .get_size_in_points()
         if tick_labelsize is None:
             tick_labelsize = _mpl.rcParams['xtick.labelsize']
-            if type(tick_labelsize) is str:
+            if isinstance(tick_labelsize, str):
                 tick_labelsize = _mpl.font_manager \
                                  .FontProperties(size=tick_labelsize) \
                                  .get_size_in_points()
@@ -4169,11 +4169,11 @@ class SHRealCoeffs(SHCoeffs):
                              'Input types are {:s} and {:s}.'
                              .format(repr(type(lat)), repr(type(lon))))
 
-        if type(lat) is int or type(lat) is float or type(lat) is _np.float64:
+        if isinstance(lat, (int, float, _np.float64)):
             return _shtools.MakeGridPoint(self.coeffs, lat=latin, lon=lonin,
                                           lmax=lmax_calc, norm=norm,
                                           csphase=self.csphase)
-        elif type(lat) is _np.ndarray:
+        elif isinstance(lat, _np.ndarray):
             values = _np.empty_like(lat, dtype=_np.float64)
             for v, latitude, longitude in _np.nditer([values, latin, lonin],
                                                      op_flags=['readwrite']):
@@ -4182,7 +4182,7 @@ class SHRealCoeffs(SHCoeffs):
                                                 lmax=lmax_calc, norm=norm,
                                                 csphase=self.csphase)
             return values
-        elif type(lat) is list:
+        elif isinstance(lat, list):
             values = []
             for latitude, longitude in zip(latin, lonin):
                 values.append(
@@ -4455,11 +4455,11 @@ class SHComplexCoeffs(SHCoeffs):
                              'Input types are {:s} and {:s}.'
                              .format(repr(type(lat)), repr(type(lon))))
 
-        if type(lat) is int or type(lat) is float or type(lat) is _np.float64:
+        if isinstance(lat, (int, float, _np.float64)):
             return _shtools.MakeGridPointC(self.coeffs, lat=latin, lon=lonin,
                                            lmax=lmax_calc, norm=norm,
                                            csphase=self.csphase)
-        elif type(lat) is _np.ndarray:
+        elif isinstance(lat, _np.ndarray):
             values = _np.empty_like(lat, dtype=_np.complex128)
             for v, latitude, longitude in _np.nditer([values, latin, lonin],
                                                      op_flags=['readwrite']):
@@ -4468,7 +4468,7 @@ class SHComplexCoeffs(SHCoeffs):
                                                  lmax=lmax_calc, norm=norm,
                                                  csphase=self.csphase)
             return values
-        elif type(lat) is list:
+        elif isinstance(lat, list):
             values = []
             for latitude, longitude in zip(latin, lonin):
                 values.append(

--- a/pyshtools/shclasses/shgeoid.py
+++ b/pyshtools/shclasses/shgeoid.py
@@ -17,6 +17,7 @@ class SHGeoid(object):
 
     Attributes:
 
+    name           : The name of the dataset.
     geoid          : SHGrid class instance of the geoid.
     gm             : Gravitational constant time the mass of the body.
     potref         : Potential of the chosen geoid, in m2/s2.
@@ -35,9 +36,9 @@ class SHGeoid(object):
     sampling       : The longitudinal sampling for Driscoll and Healy grids.
                      Either 1 for equally sampled grids (nlat=nlon) or 2 for
                      equally spaced grids in degrees.
-    units          : The units of the gridded data.
     extend         : True if the grid contains the redundant column for 360 E
                      and the unnecessary row for 90 S.
+    units          : The units of the gridded data.
     epoch          : The epoch time of the gravity model.
 
     Methods:
@@ -50,7 +51,7 @@ class SHGeoid(object):
     info()         : Print a summary of the data stored in the SHGrid instance.
     """
     def __init__(self, geoid, gm, potref, a, f, omega, r, order, lmax,
-                 lmax_calc, units=None, epoch=None):
+                 lmax_calc, name=None, units=None, epoch=None):
         """
         Initialize the SHGeoid class.
         """
@@ -73,6 +74,7 @@ class SHGeoid(object):
         self.r = r
         self.lmax = lmax
         self.lmax_calc = lmax_calc
+        self.name = name
         self.units = units
         self.epoch = epoch
 
@@ -97,7 +99,8 @@ class SHGeoid(object):
         print(repr(self))
 
     def __repr__(self):
-        str = ('grid = {:s}\n'
+        str = ('name = {:s}\n'
+               'grid = {:s}\n'
                'sampling = {:d}\n'
                'nlat = {:d}\n'
                'nlon = {:d}\n'
@@ -115,11 +118,11 @@ class SHGeoid(object):
                'order of expansion = {:d}\n'
                'units = {:s}\n'
                'epoch = {:s}'
-               .format(repr(self.grid), self.sampling, self.nlat, self.nlon,
-                       self.n, self.sampling, self.extend, self.lmax,
-                       self.lmax_calc, self.gm, self.potref, self.a, self.f,
-                       repr(self.omega), self.r, self.order, repr(self.units),
-                       repr(self.epoch)))
+               .format(repr(self.name), repr(self.grid), self.sampling,
+                       self.nlat, self.nlon, self.n, self.sampling,
+                       self.extend, self.lmax, self.lmax_calc, self.gm,
+                       self.potref, self.a, self.f, repr(self.omega), self.r,
+                       self.order, repr(self.units), repr(self.epoch)))
         return str
 
     def plot(self, projection=None, tick_interval=[30, 30],

--- a/pyshtools/shclasses/shgradient.py
+++ b/pyshtools/shclasses/shgradient.py
@@ -17,11 +17,11 @@ class SHGradient(object):
 
     Attributes:
 
+    name           : The name of the dataset.
     theta          : SHGrid class instance of the theta component of the
                      horizontal gradient.
     phi            : SHGrid class instance of the phi component of the
                      horizontal gradient.
-    units          : The units of the gridded data.
     lmax           : The maximum spherical harmonic degree resolvable by the
                      grids.
     lmax_calc      : The maximum spherical harmonic degree of the function
@@ -33,6 +33,7 @@ class SHGradient(object):
                      equally spaced grids in degrees.
     extend         : True if the grid contains the redundant column for 360 E
                      and the unnecessary row for 90 S.
+    units          : The units of the gridded data.
 
     Methods:
 
@@ -46,7 +47,7 @@ class SHGradient(object):
     """
 
     def __init__(self, theta, phi, lmax, lmax_calc, units=None,
-                 pot_units=None, epoch=None):
+                 pot_units=None, epoch=None, name=None):
         """
         Initialize the SHGradient class.
         """
@@ -61,6 +62,7 @@ class SHGradient(object):
         self.lmax = lmax
         self.lmax_calc = lmax_calc
         self.units = units
+        self.name = name
 
     def copy(self):
         """
@@ -83,7 +85,8 @@ class SHGradient(object):
         print(repr(self))
 
     def __repr__(self):
-        str = ('grid = {:s}\n'
+        str = ('name = {:s}\n'
+               'grid = {:s}\n'
                'nlat = {:d}\n'
                'nlon = {:d}\n'
                'n = {:d}\n'
@@ -92,9 +95,9 @@ class SHGradient(object):
                'lmax = {:d}\n'
                'lmax_calc = {:d}\n'
                'units = {:s}'
-               .format(self.grid, self.nlat, self.nlon, self.n, self.sampling,
-                       self.extend, self.lmax, self.lmax_calc,
-                       repr(self.units)))
+               .format(repr(self.name), repr(self.grid), self.nlat, self.nlon,
+                       self.n, self.sampling, self.extend, self.lmax,
+                       self.lmax_calc, repr(self.units)))
         return str
 
     def plot_theta(self, projection=None, tick_interval=[30, 30],

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -237,7 +237,7 @@ class SHGravCoeffs(object):
         if _np.iscomplexobj(coeffs):
             raise TypeError('The input array must be real.')
 
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. '
                              'Input type is {:s}.'
                              .format(str(type(normalization))))
@@ -534,7 +534,7 @@ class SHGravCoeffs(object):
             r0_index = None
             gm_index = None
 
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. '
                              'Input type is {:s}.'
                              .format(str(type(normalization))))
@@ -773,7 +773,7 @@ class SHGravCoeffs(object):
         Note that the degree 0 term is set to 1, and the degree-1 terms are
         set to 0.
         """
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. '
                              'Input type is {:s}.'
                              .format(str(type(normalization))))
@@ -925,7 +925,7 @@ class SHGravCoeffs(object):
         except:
             pass
 
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. '
                              'Input type was {:s}'
                              .format(str(type(normalization))))
@@ -1108,28 +1108,26 @@ class SHGravCoeffs(object):
         if backend is None:
             backend = preferred_backend()
 
-        if type(shape) is not _SHRealCoeffs and type(shape) is not _DHRealGrid:
+        if not isinstance(shape, (_SHRealCoeffs, _DHRealGrid)):
             raise ValueError('shape must be of type SHRealCoeffs '
                              'or DHRealGrid. Input type is {:s}.'
                              .format(repr(type(shape))))
 
-        if (not issubclass(type(rho), float) and type(rho) is not int
-                and type(rho) is not _np.ndarray and
-                type(rho) is not _SHRealCoeffs and
-                type(rho is not _DHRealGrid)):
+        if not isinstance(rho, (float, int, _np.ndarray, _SHRealCoeffs,
+                                _DHRealGrid)):
             raise ValueError('rho must be of type float, int, ndarray, '
                              'SHRealCoeffs or DHRealGrid. Input type is {:s}.'
                              .format(repr(type(rho))))
 
-        if type(shape) is _SHRealCoeffs:
+        if isinstance(shape, _SHRealCoeffs):
             shape = shape.expand(lmax=lmax_grid, lmax_calc=lmax_calc,
                                  backend=backend, nthreads=nthreads)
 
-        if type(rho) is _SHRealCoeffs:
+        if isinstance(rho, _SHRealCoeffs):
             rho = rho.expand(lmax=lmax_grid, lmax_calc=lmax_calc,
                              backend=backend, nthreads=nthreads)
 
-        if type(rho) is _DHRealGrid:
+        if isinstance(rho, _DHRealGrid):
             if shape.lmax != rho.lmax:
                 raise ValueError('The grids for shape and rho must have the '
                                  'same size. '
@@ -2179,7 +2177,7 @@ class SHGravCoeffs(object):
         True. This rotation is accomplished by performing the inverse rotation
         using the angles (-gamma, -beta, -alpha).
         """
-        if type(convention) is not str:
+        if not isinstance(convention, str):
             raise ValueError('convention must be a string. Input type is {:s}.'
                              .format(str(type(convention))))
 
@@ -2255,7 +2253,7 @@ class SHGravCoeffs(object):
             lmax = self.lmax
 
         # check argument consistency
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. '
                              'Input type is {:s}.'
                              .format(str(type(normalization))))
@@ -2502,7 +2500,7 @@ class SHGravCoeffs(object):
                 else:
                     temp = _np.pi/2.
 
-                if type(colat) is list:
+                if isinstance(colat, list):
                     lat = list(map(lambda x: temp - x, colat))
                 else:
                     lat = temp - colat
@@ -2848,13 +2846,13 @@ class SHGravCoeffs(object):
 
         if axes_labelsize is None:
             axes_labelsize = _mpl.rcParams['axes.labelsize']
-            if type(axes_labelsize) is str:
+            if isinstance(axes_labelsize, str):
                 axes_labelsize = _mpl.font_manager \
                                  .FontProperties(size=axes_labelsize) \
                                  .get_size_in_points()
         if tick_labelsize is None:
             tick_labelsize = _mpl.rcParams['xtick.labelsize']
-            if type(tick_labelsize) is str:
+            if isinstance(tick_labelsize, str):
                 tick_labelsize = _mpl.font_manager \
                                  .FontProperties(size=tick_labelsize) \
                                  .get_size_in_points()
@@ -3039,19 +3037,19 @@ class SHGravCoeffs(object):
 
         if axes_labelsize is None:
             axes_labelsize = _mpl.rcParams['axes.labelsize']
-            if type(axes_labelsize) is str:
+            if isinstance(axes_labelsize, str):
                 axes_labelsize = _mpl.font_manager \
                                  .FontProperties(size=axes_labelsize) \
                                  .get_size_in_points()
         if tick_labelsize is None:
             tick_labelsize = _mpl.rcParams['xtick.labelsize']
-            if type(tick_labelsize) is str:
+            if isinstance(tick_labelsize, str):
                 tick_labelsize = _mpl.font_manager \
                                  .FontProperties(size=tick_labelsize) \
                                  .get_size_in_points()
         if titlesize is None:
             titlesize = _mpl.rcParams['axes.titlesize']
-            if type(titlesize) is str:
+            if isinstance(titlesize, str):
                 titlesize = _mpl.font_manager \
                                  .FontProperties(size=titlesize) \
                                  .get_size_in_points()
@@ -3540,18 +3538,18 @@ class SHGravCoeffs(object):
         elif style == 'combined':
             legend_loc = [legend_loc, legend_loc]
         else:
-            if type(legend_loc) is str:
+            if isinstance(legend_loc, str):
                 legend_loc = [legend_loc, legend_loc]
 
         if axes_labelsize is None:
             axes_labelsize = _mpl.rcParams['axes.labelsize']
-            if type(axes_labelsize) is str:
+            if isinstance(axes_labelsize, str):
                 axes_labelsize = _mpl.font_manager \
                                  .FontProperties(size=axes_labelsize) \
                                  .get_size_in_points()
         if tick_labelsize is None:
             tick_labelsize = _mpl.rcParams['xtick.labelsize']
-            if type(tick_labelsize) is str:
+            if isinstance(tick_labelsize, str):
                 tick_labelsize = _mpl.font_manager \
                                  .FontProperties(size=tick_labelsize) \
                                  .get_size_in_points()
@@ -3879,7 +3877,7 @@ class SHGravRealCoeffs(SHGravCoeffs):
                                       r=radius, lat=latin, lon=lonin,
                                       lmax=lmax_calc, omega=self.omega)
 
-        elif type(lat) is _np.ndarray:
+        elif isinstance(lat, _np.ndarray):
             values = _np.empty((len(lat), 3), dtype=_np.float64)
             for i, (r, latitude, longitude) in enumerate(zip(radius, latin,
                                                              lonin)):
@@ -3890,7 +3888,7 @@ class SHGravRealCoeffs(SHGravCoeffs):
                                                   omega=self.omega)
             return values
 
-        elif type(lat) is list:
+        elif isinstance(lat, list):
             values = []
             for r, latitude, longitude in zip(radius, latin, lonin):
                 values.append(

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -922,7 +922,7 @@ class SHGravCoeffs(object):
 
         try:
             normalization = ds.coeffs.normalization
-        except:
+        except Exception:
             pass
 
         if not isinstance(normalization, str):
@@ -938,7 +938,7 @@ class SHGravCoeffs(object):
 
         try:
             csphase = ds.coeffs.csphase
-        except:
+        except Exception:
             pass
 
         if csphase != 1 and csphase != -1:
@@ -949,19 +949,19 @@ class SHGravCoeffs(object):
 
         try:
             gm = ds.coeffs.GM
-        except:
+        except Exception:
             raise ValueError("coeffs.GM must be specified in the netcdf file.")
         try:
             r0 = ds.coeffs.r0
-        except:
+        except Exception:
             raise ValueError("coeffs.r0 must be specified in the netcdf file.")
         try:
             omega = ds.coeffs.omega
-        except:
+        except Exception:
             omega = None
         try:
             epoch = ds.coeffs.epoch
-        except:
+        except Exception:
             pass
 
         lmaxout = ds.dims['degree'] - 1
@@ -992,7 +992,7 @@ class SHGravCoeffs(object):
             serrors = serrors[:lmaxout+1, :lmaxout+1]
             errors = _np.array([cerrors, serrors])
             error_kind = ds.errors.error_kind
-        except:
+        except Exception:
             errors = None
             error_kind = None
 

--- a/pyshtools/shclasses/shgravgrid.py
+++ b/pyshtools/shclasses/shgravgrid.py
@@ -19,6 +19,7 @@ class SHGravGrid(object):
 
     Attributes:
 
+    name           : The name of the dataset.
     rad            : SHGrid class instance of the radial component of the
                      gravitational acceleration evaluated on an ellipsoid.
     theta          : SHGrid class instance of the theta component of the
@@ -68,7 +69,7 @@ class SHGravGrid(object):
 
     def __init__(self, rad, theta, phi, total, pot, gm, a, f, omega,
                  normal_gravity, lmax, lmax_calc, units=None, pot_units=None,
-                 epoch=None):
+                 epoch=None, name=None):
         """
         Initialize the SHGravGrid class.
         """
@@ -96,6 +97,7 @@ class SHGravGrid(object):
         self.units = units
         self.pot_units = pot_units
         self.epoch = epoch
+        self.name = name
 
     def copy(self):
         """
@@ -118,7 +120,8 @@ class SHGravGrid(object):
         print(repr(self))
 
     def __repr__(self):
-        str = ('grid = {:s}\n'
+        str = ('name = {:s}\n'
+               'grid = {:s}\n'
                'nlat = {:d}\n'
                'nlon = {:d}\n'
                'n = {:d}\n'
@@ -134,11 +137,12 @@ class SHGravGrid(object):
                'units (gravity) = {:s}\n'
                'units (potential) = {:s}\n'
                'epoch = {:s}'
-               .format(self.grid, self.nlat, self.nlon, self.n, self.sampling,
-                       self.extend, self.lmax, self.lmax_calc, self.gm,
-                       self.a, self.f, repr(self.omega),
-                       repr(self.normal_gravity), repr(self.units),
-                       repr(self.pot_units), repr(self.epoch)))
+               .format(repr(self.name), repr(self.grid), self.nlat, self.nlon,
+                       self.n, self.sampling, self.extend, self.lmax,
+                       self.lmax_calc, self.gm, self.a, self.f,
+                       repr(self.omega), repr(self.normal_gravity),
+                       repr(self.units), repr(self.pot_units),
+                       repr(self.epoch)))
         return str
 
     def plot_rad(self, projection=None, tick_interval=[30, 30],

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -448,7 +448,7 @@ class SHGrid(object):
         """
         try:
             units = data_array.units
-        except:
+        except Exception:
             pass
 
         array = data_array.values
@@ -488,7 +488,7 @@ class SHGrid(object):
 
         try:
             units = data_array.units
-        except:
+        except Exception:
             pass
 
         return self.from_array(array, grid=grid, units=units)

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -42,6 +42,7 @@ class SHGrid(object):
 
     The class instance defines the following class attributes:
 
+    name       : The name of the dataset.
     data       : Gridded array of the data.
     nlat, nlon : The number of latitude and longitude bands in the grid.
     n          : The number of samples in latitude for 'DH' grids.
@@ -53,13 +54,13 @@ class SHGrid(object):
     kind       : Either 'real' or 'complex' for the data type.
     grid       : Either 'DH' or 'GLQ' for Driscoll and Healy grids or Gauss-
                  Legendre Quadrature grids.
-    units      : The units of the gridded data.
     zeros      : The cos(colatitude) nodes used with Gauss-Legendre
                  Quadrature grids. Default is None.
     weights    : The latitudinal weights used with Gauss-Legendre
                  Quadrature grids. Default is None.
     extend     : True if the grid contains the redundant column for 360 E and
                  (for 'DH' grids) the unnecessary row for 90 S.
+    units      : The units of the gridded data.
 
     Each class instance provides the following methods:
 
@@ -103,13 +104,13 @@ class SHGrid(object):
 
     # ---- Factory methods ----
     @classmethod
-    def from_array(self, array, grid='DH', units=None, copy=True):
+    def from_array(self, array, grid='DH', units=None, name=None, copy=True):
         """
         Initialize the class instance from an input array.
 
         Usage
         -----
-        x = SHGrid.from_array(array, [grid, units, copy])
+        x = SHGrid.from_array(array, [grid, units, name, copy])
 
         Returns
         -------
@@ -125,6 +126,8 @@ class SHGrid(object):
             Quadrature grids, respectively.
         units : str, optional, default = None
             The units of the gridded data.
+        name : str, optional, default = None
+            The name of the dataset.
         copy : bool, optional, default = True
             If True (default), make a copy of array when initializing the class
             instance. If False, initialize the class instance with a reference
@@ -147,17 +150,17 @@ class SHGrid(object):
 
         for cls in self.__subclasses__():
             if cls.istype(kind) and cls.isgrid(grid):
-                return cls(array, units=units, copy=copy)
+                return cls(array, units=units, name=name, copy=copy)
 
     @classmethod
     def from_zeros(self, lmax, grid='DH', kind='real', sampling=2,
-                   units=None, extend=True, empty=False):
+                   units=None, name=None, extend=True, empty=False):
         """
         Initialize the class instance using an array of zeros.
 
         Usage
         -----
-        x = SHGrid.from_zeros(lmax, [grid, kind, sampling, units, extend,
+        x = SHGrid.from_zeros(lmax, [grid, kind, sampling, units, name, extend,
                                      empty])
 
         Returns
@@ -180,6 +183,8 @@ class SHGrid(object):
             with extend=True).
         units : str, optional, default = None
             The units of the gridded data.
+        name : str, optional, default = None
+            The name of the dataset.
         extend : bool, optional, default = True
             If True, include the longitudinal band for 360 E (DH and GLQ grids)
             and the latitudinal band for 90 S (DH grids only).
@@ -223,11 +228,11 @@ class SHGrid(object):
 
         for cls in self.__subclasses__():
             if cls.istype(kind) and cls.isgrid(grid):
-                return cls(array, units=units, copy=False)
+                return cls(array, units=units, name=name, copy=False)
 
     @classmethod
     def from_ellipsoid(self, lmax, a, b=None, c=None, grid='DH', kind='real',
-                       sampling=2, units=None, extend=True):
+                       sampling=2, units=None, name=None, extend=True):
         """
         Initialize the class instance with a triaxial ellipsoid whose principal
         axes are aligned with the x, y, and z axes.
@@ -235,7 +240,7 @@ class SHGrid(object):
         Usage
         -----
         x = SHGrid.from_ellipsoid(lmax, a, [b, c, grid, kind, sampling,
-                                            units, extend])
+                                            units, name, extend])
 
         Returns
         -------
@@ -263,12 +268,15 @@ class SHGrid(object):
             with extend=True).
         units : str, optional, default = None
             The units of the gridded data.
+        name : str, optional, default = None
+            The name of the dataset.
         extend : bool, optional, default = True
             If True, include the longitudinal band for 360 E (DH and GLQ grids)
             and the latitudinal band for 90 S (DH grids only).
         """
         temp = self.from_zeros(lmax, grid=grid, kind=kind, sampling=sampling,
-                               units=units, extend=extend, empty=True)
+                               units=units, extend=extend, empty=True,
+                               name=name)
         if c is None and b is None:
             temp.data[:, :] = a
         elif c is not None and b is None:
@@ -293,7 +301,7 @@ class SHGrid(object):
 
     @classmethod
     def from_cap(self, theta, clat, clon, lmax, grid='DH', kind='real',
-                 sampling=2, degrees=True, units=None, extend=True):
+                 sampling=2, degrees=True, units=None, name=None, extend=True):
         """
         Initialize the class instance with an array equal to unity within
         a spherical cap and zero elsewhere.
@@ -301,7 +309,7 @@ class SHGrid(object):
         Usage
         -----
         x = SHGrid.from_cap(theta, clat, clon, lmax, [grid, kind, sampling,
-                            degrees, units, extend])
+                            degrees, units, name, extend])
 
         Returns
         -------
@@ -330,12 +338,14 @@ class SHGrid(object):
             If True, theta, clat, and clon are in degrees.
         units : str, optional, default = None
             The units of the gridded data.
+        name : str, optional, default = None
+            The name of the dataset.
         extend : bool, optional, default = True
             If True, include the longitudinal band for 360 E (DH and GLQ grids)
             and the latitudinal band for 90 S (DH grids only).
         """
         temp = self.from_zeros(lmax, grid=grid, kind=kind, sampling=sampling,
-                               units=units, extend=extend)
+                               units=units, extend=extend, name=name)
 
         if degrees is True:
             theta = _np.deg2rad(theta)
@@ -376,13 +386,14 @@ class SHGrid(object):
         return temp
 
     @classmethod
-    def from_file(self, fname, binary=False, grid='DH', units=None, **kwargs):
+    def from_file(self, fname, binary=False, grid='DH', units=None, name=None,
+                  **kwargs):
         """
         Initialize the class instance from gridded data in a file.
 
         Usage
         -----
-        x = SHGrid.from_file(fname, [binary, grid, units, **kwargs])
+        x = SHGrid.from_file(fname, [binary, grid, units, name, **kwargs])
 
         Returns
         -------
@@ -407,6 +418,8 @@ class SHGrid(object):
             Quadrature grids, respectively.
         units : str, optional, default = None
             The units of the gridded data.
+        name : str, optional, default = None
+            The name of the dataset.
         **kwargs : keyword arguments, optional
             Keyword arguments of numpy.loadtxt() or numpy.load().
         """
@@ -418,16 +431,17 @@ class SHGrid(object):
             raise ValueError('binary must be True or False. '
                              'Input value is {:s}.'.format(binary))
 
-        return self.from_array(data, grid=grid, units=units, copy=False)
+        return self.from_array(data, grid=grid, units=units, name=name,
+                               copy=False)
 
     @classmethod
-    def from_xarray(self, data_array, grid='DH', units=None):
+    def from_xarray(self, data_array, grid='DH', units=None, name=None):
         """
         Initialize the class instance from an xarray DataArray object.
 
         Usage
         -----
-        x = SHGrid.from_xarray(data_array, [grid, units])
+        x = SHGrid.from_xarray(data_array, [grid, units, name])
 
         Returns
         -------
@@ -445,6 +459,8 @@ class SHGrid(object):
             Quadrature grids, respectively.
         units : str, optional, default = None
             The units of the gridded data.
+        name : str, optional, default = None
+            The name of the dataset.
         """
         try:
             units = data_array.units
@@ -455,16 +471,16 @@ class SHGrid(object):
         if data_array.coords[data_array.dims[0]].values[0] == -90.:
             array = _np.flipud(array)
 
-        return self.from_array(array, grid=grid, units=units)
+        return self.from_array(array, grid=grid, units=units, name=name)
 
     @classmethod
-    def from_netcdf(self, netcdf, grid='DH', units=None):
+    def from_netcdf(self, netcdf, grid='DH', units=None, name=None):
         """
         Initialize the class instance from a netcdf formatted file or object.
 
         Usage
         -----
-        x = SHGrid.from_netcdf(netcdf, [grid, units])
+        x = SHGrid.from_netcdf(netcdf, [grid, units, name])
 
         Returns
         -------
@@ -479,6 +495,8 @@ class SHGrid(object):
             Quadrature grids, respectively.
         units : str, optional, default = None
             The units of the gridded data.
+        name : str, optional, default = None
+            The name of the dataset.
         """
         data_array = _xr.open_dataarray(netcdf)
         if data_array.coords[data_array.dims[0]].values[0] == -90.:
@@ -491,7 +509,7 @@ class SHGrid(object):
         except Exception:
             pass
 
-        return self.from_array(array, grid=grid, units=units)
+        return self.from_array(array, grid=grid, units=units, name=name)
 
     # ---- I/O methods ----
     def copy(self):
@@ -683,7 +701,7 @@ class SHGrid(object):
         grid : SHGrid class instance
         """
         return SHGrid.from_array(self.to_array().real, grid=self.grid,
-                                 units=self.units, copy=False)
+                                 units=self.units, name=self.name, copy=False)
 
     def to_imag(self):
         """
@@ -699,7 +717,7 @@ class SHGrid(object):
         grid : SHGrid class instance
         """
         return SHGrid.from_array(self.to_array().imag, grid=self.grid,
-                                 units=self.units, copy=False)
+                                 units=self.units, name=self.name, copy=False)
 
     def info(self):
         """
@@ -863,8 +881,10 @@ class SHGrid(object):
         return SHGrid.from_array(abs(self.data), grid=self.grid)
 
     def __repr__(self):
-        str = ('kind = {:s}\n'
-               'grid = {:s}\n'.format(repr(self.kind), repr(self.grid)))
+        str = ('name = {:s}\n'
+               'kind = {:s}\n'
+               'grid = {:s}\n'.format(repr(self.name), repr(self.kind),
+                                      repr(self.grid)))
         if self.grid == 'DH':
             str += ('n = {:d}\n'
                     'sampling = {:d}\n'.format(self.n, self.sampling))
@@ -963,14 +983,15 @@ class SHGrid(object):
         """
         return self._histogram(bins=bins, range=range)
 
-    def expand(self, normalization='4pi', csphase=1, lmax_calc=None,
+    def expand(self, normalization='4pi', csphase=1, lmax_calc=None, name=None,
                backend=None, nthreads=None):
         """
         Expand the grid into spherical harmonics.
 
         Usage
         -----
-        clm = x.expand([normalization, csphase, lmax_calc, backend, nthreads])
+        clm = x.expand([normalization, csphase, lmax_calc, name, backend,
+                        nthreads])
 
         Returns
         -------
@@ -987,6 +1008,8 @@ class SHGrid(object):
             or -1 to include it.
         lmax_calc : int, optional, default = x.lmax
             Maximum spherical harmonic degree to return.
+        name : str, optional, default = None
+            The name of the dataset.
         backend : str, optional, default = preferred_backend()
             Name of the preferred backend, either 'shtools' or 'ducc'.
         nthreads : int, optional, default = 1
@@ -1021,10 +1044,12 @@ class SHGrid(object):
 
         if backend is None:
             backend = preferred_backend()
+        if name is None:
+            name = self.name
 
         return self._expand(normalization=normalization, csphase=csphase,
                             lmax_calc=lmax_calc, backend=backend,
-                            nthreads=nthreads)
+                            nthreads=nthreads, name=name)
 
     # ---- Plotting routines ----
     def plot3d(self, elevation=20, azimuth=30, cmap='viridis',
@@ -1867,7 +1892,7 @@ class DHRealGrid(SHGrid):
     def isgrid(grid):
         return grid == 'DH'
 
-    def __init__(self, array, units=None, copy=True):
+    def __init__(self, array, units=None, copy=True, name=None):
         self.nlat, self.nlon = array.shape
 
         if self.nlat % 2 != 0:
@@ -1892,6 +1917,7 @@ class DHRealGrid(SHGrid):
         self.grid = 'DH'
         self.kind = 'real'
         self.units = units
+        self.name = name
 
         if copy:
             self.data = _np.copy(array)
@@ -1945,7 +1971,8 @@ class DHRealGrid(SHGrid):
                              weights=da[:, :self.nlon-self.extend],
                              density=True, range=range)
 
-    def _expand(self, normalization, csphase, lmax_calc, backend, nthreads):
+    def _expand(self, normalization, csphase, lmax_calc, backend, nthreads,
+                name):
         """Expand the grid into real spherical harmonics."""
         from .shcoeffs import SHCoeffs
         if normalization.lower() == '4pi':
@@ -1971,7 +1998,7 @@ class DHRealGrid(SHGrid):
         coeffs = SHCoeffs.from_array(cilm,
                                      normalization=normalization.lower(),
                                      csphase=csphase, units=self.units,
-                                     copy=False)
+                                     copy=False, name=name)
         return coeffs
 
     def _plot(self, projection=None, xlabel=None, ylabel=None, ax=None,
@@ -2488,7 +2515,7 @@ class DHComplexGrid(SHGrid):
     def isgrid(grid):
         return grid == 'DH'
 
-    def __init__(self, array, units=None, copy=True):
+    def __init__(self, array, units=None, copy=True, name=None):
         self.nlat, self.nlon = array.shape
 
         if self.nlat % 2 != 0:
@@ -2513,6 +2540,7 @@ class DHComplexGrid(SHGrid):
         self.grid = 'DH'
         self.kind = 'complex'
         self.units = units
+        self.name = name
 
         if copy:
             self.data = _np.copy(array)
@@ -2545,7 +2573,8 @@ class DHComplexGrid(SHGrid):
         """Return an area-weighted histogram normalized to unity."""
         raise NotImplementedError('histogram() does not support complex data.')
 
-    def _expand(self, normalization, csphase, lmax_calc, backend, nthreads):
+    def _expand(self, normalization, csphase, lmax_calc, backend, nthreads,
+                name):
         """Expand the grid into real spherical harmonics."""
         from .shcoeffs import SHCoeffs
         if normalization.lower() == '4pi':
@@ -2570,7 +2599,7 @@ class DHComplexGrid(SHGrid):
                 lmax_calc=lmax_calc)
         coeffs = SHCoeffs.from_array(cilm, normalization=normalization.lower(),
                                      csphase=csphase, units=self.units,
-                                     copy=False)
+                                     copy=False, name=name)
         return coeffs
 
     def _plot(self, projection=None, xlabel=None, ylabel=None, colorbar=None,
@@ -2727,7 +2756,8 @@ class GLQRealGrid(SHGrid):
     def isgrid(grid):
         return grid == 'GLQ'
 
-    def __init__(self, array, zeros=None, weights=None, units=None, copy=True):
+    def __init__(self, array, zeros=None, weights=None, units=None, copy=True,
+                 name=None):
         self.nlat, self.nlon = array.shape
         self.lmax = self.nlat - 1
 
@@ -2752,6 +2782,7 @@ class GLQRealGrid(SHGrid):
         self.grid = 'GLQ'
         self.kind = 'real'
         self.units = units
+        self.name = name
 
         if copy:
             self.data = _np.copy(array)
@@ -2802,7 +2833,8 @@ class GLQRealGrid(SHGrid):
                              weights=da[:, :self.nlon-self.extend],
                              density=True, range=range)
 
-    def _expand(self, normalization, csphase, lmax_calc, backend, nthreads):
+    def _expand(self, normalization, csphase, lmax_calc, backend, nthreads,
+                name):
         """Expand the grid into real spherical harmonics."""
         from .shcoeffs import SHCoeffs
         if normalization.lower() == '4pi':
@@ -2826,7 +2858,7 @@ class GLQRealGrid(SHGrid):
                 norm=norm, csphase=csphase, lmax_calc=lmax_calc)
         coeffs = SHCoeffs.from_array(cilm, normalization=normalization.lower(),
                                      csphase=csphase, units=self.units,
-                                     copy=False)
+                                     copy=False, name=name)
         return coeffs
 
     def _plot(self, projection=None, xlabel=None, ylabel=None, ax=None,
@@ -3084,7 +3116,8 @@ class GLQComplexGrid(SHGrid):
     def isgrid(grid):
         return grid == 'GLQ'
 
-    def __init__(self, array, zeros=None, weights=None, units=None, copy=True):
+    def __init__(self, array, zeros=None, weights=None, units=None, copy=True,
+                 name=None):
         self.nlat, self.nlon = array.shape
         self.lmax = self.nlat - 1
 
@@ -3109,6 +3142,7 @@ class GLQComplexGrid(SHGrid):
         self.grid = 'GLQ'
         self.kind = 'complex'
         self.units = units
+        self.name = name
 
         if copy:
             self.data = _np.copy(array)
@@ -3132,7 +3166,8 @@ class GLQComplexGrid(SHGrid):
         """Return an area-weighted histogram normalized to unity."""
         raise NotImplementedError('histogram() does not support complex data.')
 
-    def _expand(self, normalization, csphase, lmax_calc, backend, nthreads):
+    def _expand(self, normalization, csphase, lmax_calc, backend, nthreads,
+                name):
         """Expand the grid into real spherical harmonics."""
         from .shcoeffs import SHCoeffs
         if normalization.lower() == '4pi':
@@ -3156,7 +3191,7 @@ class GLQComplexGrid(SHGrid):
                 norm=norm, csphase=csphase, lmax_calc=lmax_calc)
         coeffs = SHCoeffs.from_array(cilm, normalization=normalization.lower(),
                                      csphase=csphase, units=self.units,
-                                     copy=False)
+                                     copy=False, name=name)
         return coeffs
 
     def _plot(self, projection=None, minor_xticks=[], minor_yticks=[],

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -135,7 +135,7 @@ class SHGrid(object):
         else:
             kind = 'real'
 
-        if type(grid) is not str:
+        if not isinstance(grid, str):
             raise ValueError('grid must be a string. Input type is {:s}.'
                              .format(str(type(grid))))
 
@@ -187,7 +187,7 @@ class SHGrid(object):
             If True, create the data array using numpy.empty() and do not
             initialize with zeros.
         """
-        if type(grid) is not str:
+        if not isinstance(grid, str):
             raise ValueError('grid must be a string. Input type is {:s}.'
                              .format(str(type(grid))))
 
@@ -1001,7 +1001,7 @@ class SHGrid(object):
         90 N and S are downweighted to zero and have no influence on the
         returned spherical harmonic coefficients.
         """
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. ' +
                              'Input type is {:s}.'
                              .format(str(type(normalization))))
@@ -1353,19 +1353,19 @@ class SHGrid(object):
             minor_tick_interval = [None, None]
         if axes_labelsize is None:
             axes_labelsize = _mpl.rcParams['axes.labelsize']
-            if type(axes_labelsize) is str:
+            if isinstance(axes_labelsize, str):
                 axes_labelsize = _mpl.font_manager \
                                  .FontProperties(size=axes_labelsize) \
                                  .get_size_in_points()
         if tick_labelsize is None:
             tick_labelsize = _mpl.rcParams['xtick.labelsize']
-            if type(tick_labelsize) is str:
+            if isinstance(tick_labelsize, str):
                 tick_labelsize = _mpl.font_manager \
                                  .FontProperties(size=tick_labelsize) \
                                  .get_size_in_points()
         if titlesize is None:
             titlesize = _mpl.rcParams['axes.titlesize']
-            if type(titlesize) is str:
+            if isinstance(titlesize, str):
                 titlesize = _mpl.font_manager \
                                  .FontProperties(size=titlesize) \
                                  .get_size_in_points()
@@ -1672,19 +1672,19 @@ class SHGrid(object):
                                  .format(repr(colorbar)))
         if axes_labelsize is None:
             axes_labelsize = _mpl.rcParams['axes.labelsize']
-            if type(axes_labelsize) is str:
+            if isinstance(axes_labelsize, str):
                 axes_labelsize = _mpl.font_manager \
                                  .FontProperties(size=axes_labelsize) \
                                  .get_size_in_points()
         if tick_labelsize is None:
             tick_labelsize = _mpl.rcParams['xtick.labelsize']
-            if type(tick_labelsize) is str:
+            if isinstance(tick_labelsize, str):
                 tick_labelsize = _mpl.font_manager \
                                  .FontProperties(size=tick_labelsize) \
                                  .get_size_in_points()
         if titlesize is None:
             titlesize = _mpl.rcParams['axes.titlesize']
-            if type(titlesize) is str:
+            if isinstance(titlesize, str):
                 titlesize = _mpl.font_manager \
                                  .FontProperties(size=titlesize) \
                                  .get_size_in_points()
@@ -1804,19 +1804,19 @@ class SHGrid(object):
 
         if axes_labelsize is None:
             axes_labelsize = _mpl.rcParams['axes.labelsize']
-            if type(axes_labelsize) is str:
+            if isinstance(axes_labelsize, str):
                 axes_labelsize = _mpl.font_manager \
                                  .FontProperties(size=axes_labelsize) \
                                  .get_size_in_points()
         if tick_labelsize is None:
             tick_labelsize = _mpl.rcParams['xtick.labelsize']
-            if type(tick_labelsize) is str:
+            if isinstance(tick_labelsize, str):
                 tick_labelsize = _mpl.font_manager \
                                  .FontProperties(size=tick_labelsize) \
                                  .get_size_in_points()
         if titlesize is None:
             titlesize = _mpl.rcParams['axes.titlesize']
-            if type(titlesize) is str:
+            if isinstance(titlesize, str):
                 titlesize = _mpl.font_manager \
                                  .FontProperties(size=titlesize) \
                                  .get_size_in_points()
@@ -2431,7 +2431,7 @@ class DHRealGrid(SHGrid):
             # generate shading from self
             shading_str = "+a{:}+nt{:}+m0".format(shading_azimuth,
                                                   shading_amplitude)
-        elif type(shading) is str:
+        elif isinstance(shading, str):
             shading_str = shading  # external filename
             if shading_azimuth is not None:
                 shading_str += "+a{:}+nt{:}+m0".format(shading_azimuth,

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -231,16 +231,18 @@ class SHGrid(object):
                 return cls(array, units=units, name=name, copy=False)
 
     @classmethod
-    def from_ellipsoid(self, lmax, a, b=None, c=None, grid='DH', kind='real',
-                       sampling=2, units=None, name=None, extend=True):
+    def from_ellipsoid(self, lmax, a, b=None, c=None, alpha=0.,
+                       grid='DH', kind='real', sampling=2, units=None,
+                       name=None, extend=True):
         """
         Initialize the class instance with a triaxial ellipsoid whose principal
-        axes are aligned with the x, y, and z axes.
+        axes are aligned with the x, y, and z axes. Optionally, rotate the
+        a and b principal axes about the z axis by alpha.
 
         Usage
         -----
-        x = SHGrid.from_ellipsoid(lmax, a, [b, c, grid, kind, sampling,
-                                            units, name, extend])
+        x = SHGrid.from_ellipsoid(lmax, a, [b, c, alpha, grid, kind,
+                                            sampling, units, name, extend])
 
         Returns
         -------
@@ -248,14 +250,18 @@ class SHGrid(object):
 
         Parameters
         ----------
+        lmax : int
+            The maximum spherical harmonic degree resolvable by the grid.
         a : float
             Length of the principal axis aligned with the x axis.
         b : float, optional, default = a
             Length of the principal axis aligned with the y axis.
         c : float, optional, default = b
             Length of the principal axis aligned with the z axis.
-        lmax : int
-            The maximum spherical harmonic degree resolvable by the grid.
+        alpha : float, optional, default = 0
+            Rotate the a and b principal axes about the z axis by alpha in
+            degrees. The longitude of the x and y axes will be alpha and
+            90 + alpha, respectively.
         grid : str, optional, default = 'DH'
             'DH' or 'GLQ' for Driscoll and Healy grids or Gauss-Legendre
             Quadrature grids, respectively.
@@ -288,8 +294,8 @@ class SHGrid(object):
         else:
             if c is None:
                 c = b
-            cos2 = _np.cos(_np.deg2rad(temp.lons()))**2
-            sin2 = _np.sin(_np.deg2rad(temp.lons()))**2
+            cos2 = _np.cos(_np.deg2rad(temp.lons() - alpha))**2
+            sin2 = _np.sin(_np.deg2rad(temp.lons() - alpha))**2
             for ilat, lat in enumerate(temp.lats()):
                 temp.data[ilat, :] = 1. / _np.sqrt(
                     _np.cos(_np.deg2rad(lat))**2 * cos2 / a**2 +

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -848,7 +848,7 @@ class SHMagCoeffs(object):
 
         try:
             normalization = ds.coeffs.normalization
-        except:
+        except Exception:
             pass
 
         if not isinstance(normalization, str):
@@ -864,7 +864,7 @@ class SHMagCoeffs(object):
 
         try:
             csphase = ds.coeffs.csphase
-        except:
+        except Exception:
             pass
 
         if csphase != 1 and csphase != -1:
@@ -875,7 +875,7 @@ class SHMagCoeffs(object):
 
         try:
             units = ds.coeffs.units
-        except:
+        except Exception:
             pass
 
         if units.lower() not in ('nt', 't'):
@@ -884,12 +884,12 @@ class SHMagCoeffs(object):
 
         try:
             r0 = ds.coeffs.r0
-        except:
+        except Exception:
             raise ValueError("coeffs.r0 must be specified in the netcdf file.")
 
         try:
             year = ds.coeffs.year
-        except:
+        except Exception:
             pass
 
         lmaxout = ds.dims['degree'] - 1
@@ -920,7 +920,7 @@ class SHMagCoeffs(object):
             serrors = serrors[:lmaxout+1, :lmaxout+1]
             errors = _np.array([cerrors, serrors])
             error_kind = ds.errors.error_kind
-        except:
+        except Exception:
             errors = None
             error_kind = None
 

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -197,7 +197,7 @@ class SHMagCoeffs(object):
         if _np.iscomplexobj(coeffs):
             raise TypeError('The input array must be real.')
 
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. '
                              'Input type is {:s}.'
                              .format(str(type(normalization))))
@@ -475,7 +475,7 @@ class SHMagCoeffs(object):
             r0_index = None
         header2_list = None
 
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. '
                              'Input type is {:s}.'
                              .format(str(type(normalization))))
@@ -697,7 +697,7 @@ class SHMagCoeffs(object):
         of the random realization can be fixed exactly to the input spectrum by
         setting exact_power to True.
         """
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. '
                              'Input type is {:s}.'
                              .format(str(type(normalization))))
@@ -851,7 +851,7 @@ class SHMagCoeffs(object):
         except:
             pass
 
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. '
                              'Input type was {:s}'
                              .format(str(type(normalization))))
@@ -1659,7 +1659,7 @@ class SHMagCoeffs(object):
         True. This rotation is accomplished by performing the inverse rotation
         using the angles (-gamma, -beta, -alpha).
         """
-        if type(convention) is not str:
+        if not isinstance(convention, str):
             raise ValueError('convention must be a string. '
                              'Input type is {:s}.'
                              .format(str(type(convention))))
@@ -1741,7 +1741,7 @@ class SHMagCoeffs(object):
             lmax = self.lmax
 
         # check argument consistency
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. '
                              'Input type is {:s}.'
                              .format(str(type(normalization))))
@@ -2000,7 +2000,7 @@ class SHMagCoeffs(object):
                 else:
                     temp = _np.pi/2.
 
-                if type(colat) is list:
+                if isinstance(colat, list):
                     lat = list(map(lambda x: temp - x, colat))
                 else:
                     lat = temp - colat
@@ -2238,13 +2238,13 @@ class SHMagCoeffs(object):
 
         if axes_labelsize is None:
             axes_labelsize = _mpl.rcParams['axes.labelsize']
-            if type(axes_labelsize) is str:
+            if isinstance(axes_labelsize, str):
                 axes_labelsize = _mpl.font_manager \
                                  .FontProperties(size=axes_labelsize) \
                                  .get_size_in_points()
         if tick_labelsize is None:
             tick_labelsize = _mpl.rcParams['xtick.labelsize']
-            if type(tick_labelsize) is str:
+            if isinstance(tick_labelsize, str):
                 tick_labelsize = _mpl.font_manager \
                                  .FontProperties(size=tick_labelsize) \
                                  .get_size_in_points()
@@ -2430,19 +2430,19 @@ class SHMagCoeffs(object):
 
         if axes_labelsize is None:
             axes_labelsize = _mpl.rcParams['axes.labelsize']
-            if type(axes_labelsize) is str:
+            if isinstance(axes_labelsize, str):
                 axes_labelsize = _mpl.font_manager \
                                  .FontProperties(size=axes_labelsize) \
                                  .get_size_in_points()
         if tick_labelsize is None:
             tick_labelsize = _mpl.rcParams['xtick.labelsize']
-            if type(tick_labelsize) is str:
+            if isinstance(tick_labelsize, str):
                 tick_labelsize = _mpl.font_manager \
                                  .FontProperties(size=tick_labelsize) \
                                  .get_size_in_points()
         if titlesize is None:
             titlesize = _mpl.rcParams['axes.titlesize']
-            if type(titlesize) is str:
+            if isinstance(titlesize, str):
                 titlesize = _mpl.font_manager \
                                  .FontProperties(size=titlesize) \
                                  .get_size_in_points()
@@ -2851,13 +2851,13 @@ class SHMagCoeffs(object):
 
         if axes_labelsize is None:
             axes_labelsize = _mpl.rcParams['axes.labelsize']
-            if type(axes_labelsize) is str:
+            if isinstance(axes_labelsize, str):
                 axes_labelsize = _mpl.font_manager \
                                  .FontProperties(size=axes_labelsize) \
                                  .get_size_in_points()
         if tick_labelsize is None:
             tick_labelsize = _mpl.rcParams['xtick.labelsize']
-            if type(tick_labelsize) is str:
+            if isinstance(tick_labelsize, str):
                 tick_labelsize = _mpl.font_manager \
                                  .FontProperties(size=tick_labelsize) \
                                  .get_size_in_points()
@@ -3014,7 +3014,7 @@ class SHMagRealCoeffs(SHMagCoeffs):
             return _MakeMagGridPoint(coeffs, a=self.r0, r=radius, lat=latin,
                                      lon=lonin, lmax=lmax_calc)
 
-        elif type(lat) is _np.ndarray:
+        elif isinstance(lat, _np.ndarray):
             values = _np.empty((len(lat), 3), dtype=_np.float64)
             for i, (r, latitude, longitude) in enumerate(zip(radius, latin,
                                                              lonin)):
@@ -3023,7 +3023,7 @@ class SHMagRealCoeffs(SHMagCoeffs):
                                                  lmax=lmax_calc)
             return values
 
-        elif type(lat) is list:
+        elif isinstance(lat, list):
             values = []
             for r, latitude, longitude in zip(radius, latin, lonin):
                 values.append(

--- a/pyshtools/shclasses/shmaggrid.py
+++ b/pyshtools/shclasses/shmaggrid.py
@@ -19,6 +19,7 @@ class SHMagGrid(object):
 
     Attributes:
 
+    name           : The name of the dataset.
     rad            : SHGrid class instance of the radial component of the
                      magnetic field evaluated on an ellipsoid.
     theta          : SHGrid class instance of the theta component of the
@@ -62,7 +63,7 @@ class SHMagGrid(object):
     """
 
     def __init__(self, rad, theta, phi, total, pot, a, f, lmax, lmax_calc,
-                 units=None, pot_units=None, year=None):
+                 units=None, pot_units=None, year=None, name=None):
         """
         Initialize the SHMagGrid class.
         """
@@ -84,6 +85,7 @@ class SHMagGrid(object):
         self.units = units
         self.pot_units = pot_units
         self.year = year
+        self.name = name
 
     def copy(self):
         """
@@ -106,7 +108,8 @@ class SHMagGrid(object):
         print(repr(self))
 
     def __repr__(self):
-        str = ('grid = {:s}\n'
+        str = ('name = {:s}\n'
+               'grid = {:s}\n'
                'nlat = {:d}\n'
                'nlon = {:d}\n'
                'n = {:d}\n'
@@ -119,10 +122,10 @@ class SHMagGrid(object):
                'units (magnetic field) = {:s}\n'
                'units (potential) = {:s}\n'
                'year = {:s}'
-               .format(self.grid, self.nlat, self.nlon, self.n, self.sampling,
-                       self.extend, self.lmax, self.lmax_calc, self.a,
-                       self.f, repr(self.units), repr(self.pot_units),
-                       repr(self.year)))
+               .format(repr(self.name), repr(self.grid), self.nlat, self.nlon,
+                       self.n, self.sampling, self.extend, self.lmax,
+                       self.lmax_calc, self.a, self.f, repr(self.units),
+                       repr(self.pot_units), repr(self.year)))
         return str
 
     def plot_rad(self, projection=None, tick_interval=[30, 30],

--- a/pyshtools/shclasses/shtensor.py
+++ b/pyshtools/shclasses/shtensor.py
@@ -3260,6 +3260,7 @@ class SHGravTensor(Tensor):
 
     Attributes:
 
+    name             : The name of the dataset.
     vxx, vxy, vzz,   : The 9 components of the gravity tensor.
     vyx, vyy, vyz,
     vzx, vzy, vzz
@@ -3329,7 +3330,7 @@ class SHGravTensor(Tensor):
     """
 
     def __init__(self, vxx, vyy, vzz, vxy, vxz, vyz, gm, a, f, lmax,
-                 lmax_calc, units='Eötvös', epoch=None):
+                 lmax_calc, units='Eötvös', name=None, epoch=None):
         """
         Initialize the SHGravTensor class.
         """
@@ -3363,6 +3364,7 @@ class SHGravTensor(Tensor):
         self.eigh1 = None
         self.eigh2 = None
         self.eighh = None
+        self.name = name
         self.units = units
         self.epoch = epoch
 
@@ -3390,7 +3392,8 @@ class SHGravTensor(Tensor):
         self._eighh_label = r'$\lambda_{hh}$, ' + self.units
 
     def __repr__(self):
-        str = ('grid = {:s}\n'
+        str = ('name = {:s}\n'
+               'grid = {:s}\n'
                'nlat = {:d}\n'
                'nlon = {:d}\n'
                'n = {:d}\n'
@@ -3403,9 +3406,10 @@ class SHGravTensor(Tensor):
                'f = {:e}\n'
                'units = {:s}\n'
                'epoch = {:s}'
-               .format(self.grid, self.nlat, self.nlon, self.n, self.sampling,
-                       self.extend, self.lmax, self.lmax_calc, self.gm, self.a,
-                       self.f, repr(self.units), repr(self.epoch)))
+               .format(repr(self.name), repr(self.grid), self.nlat, self.nlon,
+                       self.n, self.sampling, self.extend, self.lmax,
+                       self.lmax_calc, self.gm, self.a, self.f,
+                       repr(self.units), repr(self.epoch)))
         return str
 
 
@@ -3417,6 +3421,7 @@ class SHMagTensor(Tensor):
 
     Attributes:
 
+    name             : The name of the dataset.
     vxx, vxy, vzz,   : The 9 components of the magnetic field tensor.
     vyx, vyy, vyz,
     vzx, vzy, vzz
@@ -3485,7 +3490,7 @@ class SHMagTensor(Tensor):
     """
 
     def __init__(self, vxx, vyy, vzz, vxy, vxz, vyz, a, f, lmax,
-                 lmax_calc, units=None, year=None):
+                 lmax_calc, units=None, name=None, year=None):
         """
         Initialize the SHMagTensor class.
         """
@@ -3518,6 +3523,7 @@ class SHMagTensor(Tensor):
         self.eigh1 = None
         self.eigh2 = None
         self.eighh = None
+        self.name = name
         self.units = units
         self.year = year
         if self.units.lower() == 'nt/m':
@@ -3553,7 +3559,8 @@ class SHMagTensor(Tensor):
         self._eighh_label = r'$\lambda_{hh}$, ' + self._units_formatted
 
     def __repr__(self):
-        str = ('grid = {:s}\n'
+        str = ('name = {:s}\n'
+               'grid = {:s}\n'
                'nlat = {:d}\n'
                'nlon = {:d}\n'
                'n = {:d}\n'
@@ -3565,7 +3572,8 @@ class SHMagTensor(Tensor):
                'f = {:e}\n'
                'units = {:s}\n'
                'year = {:s}'
-               .format(self.grid, self.nlat, self.nlon, self.n, self.sampling,
-                       self.extend, self.lmax, self.lmax_calc, self.a,
-                       self.f, repr(self.units), repr(self.year)))
+               .format(repr(self.name), repr(self.grid), self.nlat, self.nlon,
+                       self.n, self.sampling, self.extend, self.lmax,
+                       self.lmax_calc, self.a, self.f, repr(self.units),
+                       repr(self.year)))
         return str

--- a/pyshtools/shclasses/shwindow.py
+++ b/pyshtools/shclasses/shwindow.py
@@ -306,7 +306,7 @@ class SHWindow(object):
             Condon-Shortley phase convention: 1 to exclude the phase factor,
             or -1 to include it.
         """
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. ' +
                              'Input type is {:s}.'
                              .format(str(type(normalization))))
@@ -351,7 +351,7 @@ class SHWindow(object):
             Condon-Shortley phase convention: 1 to exclude the phase factor,
             or -1 to include it.
         """
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. ' +
                              'Input type is {:s}.'
                              .format(str(type(normalization))))
@@ -413,7 +413,7 @@ class SHWindow(object):
         """
         if lmax is None:
             lmax = self.lwin
-        if type(grid) is not str:
+        if not isinstance(grid, str):
             raise ValueError('grid must be a string. Input type is {:s}.'
                              .format(str(type(grid))))
 
@@ -1070,19 +1070,19 @@ class SHWindow(object):
         """
         if axes_labelsize is None:
             axes_labelsize = _mpl.rcParams['axes.labelsize']
-            if type(axes_labelsize) is str:
+            if isinstance(axes_labelsize, str):
                 axes_labelsize = _mpl.font_manager \
                                  .FontProperties(size=axes_labelsize) \
                                  .get_size_in_points()
         if tick_labelsize is None:
             tick_labelsize = _mpl.rcParams['xtick.labelsize']
-            if type(tick_labelsize) is str:
+            if isinstance(tick_labelsize, str):
                 tick_labelsize = _mpl.font_manager \
                                  .FontProperties(size=tick_labelsize) \
                                  .get_size_in_points()
         if titlesize is None:
             titlesize = _mpl.rcParams['axes.titlesize']
-            if type(titlesize) is str:
+            if isinstance(titlesize, str):
                 titlesize = _mpl.font_manager \
                                  .FontProperties(size=titlesize) \
                                  .get_size_in_points()
@@ -1268,19 +1268,19 @@ class SHWindow(object):
 
         if axes_labelsize is None:
             axes_labelsize = _mpl.rcParams['axes.labelsize']
-            if type(axes_labelsize) is str:
+            if isinstance(axes_labelsize, str):
                 axes_labelsize = _mpl.font_manager \
                                  .FontProperties(size=axes_labelsize) \
                                  .get_size_in_points()
         if tick_labelsize is None:
             tick_labelsize = _mpl.rcParams['xtick.labelsize']
-            if type(tick_labelsize) is str:
+            if isinstance(tick_labelsize, str):
                 tick_labelsize = _mpl.font_manager \
                                  .FontProperties(size=tick_labelsize) \
                                  .get_size_in_points()
         if titlesize is None:
             titlesize = _mpl.rcParams['axes.titlesize']
-            if type(titlesize) is str:
+            if isinstance(titlesize, str):
                 titlesize = _mpl.font_manager \
                                  .FontProperties(size=titlesize) \
                                  .get_size_in_points()

--- a/pyshtools/shclasses/slepian.py
+++ b/pyshtools/shclasses/slepian.py
@@ -363,7 +363,7 @@ class Slepian(object):
             Condon-Shortley phase convention: 1 to exclude the phase factor,
             or -1 to include it.
         """
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. ' +
                              'Input type is {:s}.'
                              .format(str(type(normalization))))
@@ -409,7 +409,7 @@ class Slepian(object):
             Condon-Shortley phase convention: 1 to exclude the phase factor,
             or -1 to include it.
         """
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. ' +
                              'Input type is {:s}.'
                              .format(str(type(normalization))))
@@ -466,7 +466,7 @@ class Slepian(object):
         the properties of the output grids, see the documentation for
         SHExpandDH and SHExpandGLQ.
         """
-        if type(grid) is not str:
+        if not isinstance(grid, str):
             raise ValueError('grid must be a string. Input type is {:s}.'
                              .format(str(type(grid))))
 
@@ -854,19 +854,19 @@ class Slepian(object):
         """
         if axes_labelsize is None:
             axes_labelsize = _mpl.rcParams['axes.labelsize']
-            if type(axes_labelsize) is str:
+            if isinstance(axes_labelsize, str):
                 axes_labelsize = _mpl.font_manager \
                                  .FontProperties(size=axes_labelsize) \
                                  .get_size_in_points()
         if tick_labelsize is None:
             tick_labelsize = _mpl.rcParams['xtick.labelsize']
-            if type(tick_labelsize) is str:
+            if isinstance(tick_labelsize, str):
                 tick_labelsize = _mpl.font_manager \
                                  .FontProperties(size=tick_labelsize) \
                                  .get_size_in_points()
         if titlesize is None:
             titlesize = _mpl.rcParams['axes.titlesize']
-            if type(titlesize) is str:
+            if isinstance(titlesize, str):
                 titlesize = _mpl.font_manager \
                                  .FontProperties(size=titlesize) \
                                  .get_size_in_points()
@@ -1018,19 +1018,19 @@ class Slepian(object):
         """
         if axes_labelsize is None:
             axes_labelsize = _mpl.rcParams['axes.labelsize']
-            if type(axes_labelsize) is str:
+            if isinstance(axes_labelsize, str):
                 axes_labelsize = _mpl.font_manager \
                                  .FontProperties(size=axes_labelsize) \
                                  .get_size_in_points()
         if tick_labelsize is None:
             tick_labelsize = _mpl.rcParams['xtick.labelsize']
-            if type(tick_labelsize) is str:
+            if isinstance(tick_labelsize, str):
                 tick_labelsize = _mpl.font_manager \
                                  .FontProperties(size=tick_labelsize) \
                                  .get_size_in_points()
         if titlesize is None:
             titlesize = _mpl.rcParams['axes.titlesize']
-            if type(titlesize) is str:
+            if isinstance(titlesize, str):
                 titlesize = _mpl.font_manager \
                                  .FontProperties(size=titlesize) \
                                  .get_size_in_points()

--- a/pyshtools/shclasses/slepian.py
+++ b/pyshtools/shclasses/slepian.py
@@ -31,6 +31,7 @@ class Slepian(object):
 
     Each class instance defines the following class attributes:
 
+    name            : The name of the class isntance.
     kind            : Either 'cap' or 'mask'.
     tapers          : Matrix containing the spherical harmonic coefficients
                       (in packed form) of either the unrotated spherical cap
@@ -109,7 +110,7 @@ class Slepian(object):
     @classmethod
     def from_cap(cls, theta, lmax, clat=None, clon=None, nmax=None,
                  theta_degrees=True, coord_degrees=True, dj_matrix=None,
-                 slepian_degrees=None):
+                 slepian_degrees=None, name=None):
         """
         Construct spherical cap Slepian functions.
 
@@ -117,7 +118,7 @@ class Slepian(object):
         -----
         x = Slepian.from_cap(theta, lmax, [clat, clon, nmax, theta_degrees,
                                            coord_degrees, dj_matrix,
-                                           slepian_degrees])
+                                           slepian_degrees, name])
 
         Returns
         -------
@@ -145,6 +146,8 @@ class Slepian(object):
                           default = None
             Boolean or int array defining which spherical harmonic degrees were
             used (True or 1) to construct the Slepian functions.
+        name : str, optional, default = None
+            The name of the class instance.
         """
         if theta_degrees:
             tapers, eigenvalues, taper_order = _shtools.SHReturnTapers(
@@ -155,17 +158,18 @@ class Slepian(object):
 
         return SlepianCap(theta, tapers, eigenvalues, taper_order, clat, clon,
                           nmax, theta_degrees, coord_degrees, dj_matrix,
-                          slepian_degrees, copy=False)
+                          slepian_degrees, copy=False, name=name)
 
     @classmethod
-    def from_mask(cls, dh_mask, lmax, nmax=None, slepian_degrees=None):
+    def from_mask(cls, dh_mask, lmax, nmax=None, slepian_degrees=None,
+                  name=None):
         """
         Construct Slepian functions that are optimally concentrated within
         the region specified by a mask.
 
         Usage
         -----
-        x = Slepian.from_mask(dh_mask, lmax, [nmax, slepian_degrees])
+        x = Slepian.from_mask(dh_mask, lmax, [nmax, slepian_degrees, name])
 
         Returns
         -------
@@ -187,6 +191,8 @@ class Slepian(object):
                           default = None
             Boolean or int array defining which spherical harmonic degrees were
             used (True or 1) to construct the Slepian functions.
+        name : str, optional, default = None
+            The name of the class instance.
         """
         if nmax is None:
             nmax = (lmax + 1)**2
@@ -220,7 +226,7 @@ class Slepian(object):
             data, lmax, ntapers=nmax, degrees=slepian_degrees)
 
         return SlepianMask(tapers, eigenvalues, area, slepian_degrees,
-                           copy=False)
+                           copy=False, name=name)
 
     def copy(self):
         """Return a deep copy of the class instance."""
@@ -265,13 +271,13 @@ class Slepian(object):
         """
         return len(self.eigenvalues[self.eigenvalues >= concentration])
 
-    def expand(self, flm, nmax=None):
+    def expand(self, flm, nmax=None, name=None):
         """
         Return the Slepian expansion coefficients of the input function.
 
         Usage
         -----
-        s = x.expand(flm, [nmax])
+        s = x.expand(flm, [nmax, name])
 
         Returns
         -------
@@ -284,6 +290,8 @@ class Slepian(object):
             The input function to expand in Slepian functions.
         nmax : int, optional, default = (x.lmax+1)**2
             The number of Slepian expansion coefficients to compute.
+        name : str, optional, default = None
+            The name of the SlepianCoeff class instance.
 
         Notes
         -----
@@ -302,9 +310,12 @@ class Slepian(object):
                 .format(repr(self.lmax), repr(nmax))
                 )
 
+        if name is None:
+            name = self.name
+
         coeffsin = flm.to_array(normalization='4pi', csphase=1, lmax=self.lmax)
 
-        return self._expand(coeffsin, nmax)
+        return self._expand(coeffsin, nmax, name)
 
     def coupling_matrix(self, nmax=None):
         """
@@ -383,14 +394,14 @@ class Slepian(object):
         return self._to_array(
             alpha, normalization=normalization.lower(), csphase=csphase)
 
-    def to_shcoeffs(self, alpha, normalization='4pi', csphase=1):
+    def to_shcoeffs(self, alpha, normalization='4pi', csphase=1, name=None):
         """
         Return the spherical harmonic coefficients of Slepian function i as a
         SHCoeffs class instance.
 
         Usage
         -----
-        clm = x.to_shcoeffs(alpha, [normalization, csphase])
+        clm = x.to_shcoeffs(alpha, [normalization, csphase, name])
 
         Returns
         -------
@@ -408,6 +419,8 @@ class Slepian(object):
         csphase : int, optional, default = 1
             Condon-Shortley phase convention: 1 to exclude the phase factor,
             or -1 to include it.
+        name : str, optional, default = None
+            The name of the SHCoeffs class instance.
         """
         if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. ' +
@@ -429,16 +442,16 @@ class Slepian(object):
         coeffs = self.to_array(alpha, normalization=normalization.lower(),
                                csphase=csphase)
         return SHCoeffs.from_array(coeffs, normalization=normalization.lower(),
-                                   csphase=csphase, copy=False)
+                                   csphase=csphase, copy=False, name=name)
 
-    def to_shgrid(self, alpha, grid='DH2', zeros=None, extend=True):
+    def to_shgrid(self, alpha, grid='DH2', zeros=None, extend=True, name=None):
         """
         Evaluate the coefficients of Slepian function i on a grid and return
         an SHGrid class instance.
 
         Usage
         -----
-        f = x.to_shgrid(alpha, [grid, zeros])
+        f = x.to_shgrid(alpha, [grid, zeros, extend, name])
 
         Returns
         -------
@@ -459,6 +472,8 @@ class Slepian(object):
         extend : bool, optional, default = True
             If True, compute the longitudinal band for 360 E (DH and GLQ grids)
             and the latitudinal band for 90 S (DH grids only).
+        name : str, optional, default = None
+            The name of the SHGrid class instance.
 
         Notes
         -----
@@ -473,17 +488,18 @@ class Slepian(object):
         if grid.upper() in ('DH', 'DH1'):
             gridout = _shtools.MakeGridDH(self.to_array(alpha), sampling=1,
                                           norm=1, csphase=1, extend=extend)
-            return SHGrid.from_array(gridout, grid='DH', copy=False)
+            return SHGrid.from_array(gridout, grid='DH', copy=False, name=name)
         elif grid.upper() == 'DH2':
             gridout = _shtools.MakeGridDH(self.to_array(alpha), sampling=2,
                                           norm=1, csphase=1, extend=extend)
-            return SHGrid.from_array(gridout, grid='DH', copy=False)
+            return SHGrid.from_array(gridout, grid='DH', copy=False, name=name)
         elif grid.upper() == 'GLQ':
             if zeros is None:
                 zeros, weights = _shtools.SHGLQ(self.lmax)
             gridout = _shtools.MakeGridGLQ(self.to_array(alpha), zeros,
                                            norm=1, csphase=1, extend=extend)
-            return SHGrid.from_array(gridout, grid='GLQ', copy=False)
+            return SHGrid.from_array(gridout, grid='GLQ', copy=False,
+                                     name=name)
         else:
             raise ValueError(
                 "grid must be 'DH', 'DH1', 'DH2', or 'GLQ'. " +
@@ -1109,7 +1125,7 @@ class SlepianCap(Slepian):
 
     def __init__(self, theta, tapers, eigenvalues, taper_order, clat, clon,
                  nmax, theta_degrees, coord_degrees, dj_matrix,
-                 slepian_degrees, copy=True):
+                 slepian_degrees, copy=True, name=None):
         self.kind = 'cap'
         self.theta = theta
         self.clat = clat
@@ -1120,6 +1136,7 @@ class SlepianCap(Slepian):
         self.dj_matrix = dj_matrix
         self.nrot = None
         self.slepian_degrees = slepian_degrees
+        self.name = name
 
         if (self.theta_degrees):
             self.area = 2 * _np.pi * (1 - _np.cos(_np.radians(self.theta)))
@@ -1158,7 +1175,7 @@ class SlepianCap(Slepian):
                         coord_degrees=self.coord_degrees,
                         dj_matrix=self.dj_matrix)
 
-    def _expand(self, coeffsin, nmax):
+    def _expand(self, coeffsin, nmax, name):
         """
         Determine the Slepian expansion coefficients of a function.
         """
@@ -1171,7 +1188,7 @@ class SlepianCap(Slepian):
                              .format(nmax, self.nrot))
         falpha = _shtools.SlepianCoeffs(self.coeffs, coeffsin, nmax)
 
-        return SlepianCoeffs(falpha, self)
+        return SlepianCoeffs(falpha, self, name=name)
 
     def _coupling_matrix(self, nmax):
         """Return the coupling matrix."""
@@ -1308,13 +1325,14 @@ class SlepianCap(Slepian):
         else:
             str += 'theta = {:f} radians'.format(self.theta)
 
-        str += ('lmax = {:d}\n'
+        str += ('name = {:s}\n'
+                'lmax = {:d}\n'
                 'nmax = {:d}\n'
                 'nrot = {:s}\n'
                 'shannon = {:f}\n'
                 'area (radians) = {:e}\n'
-                .format(self.lmax, self.nmax, repr(self.nrot), self.shannon,
-                        self.area))
+                .format(repr(self.name), self.lmax, self.nmax, repr(self.nrot),
+                        self.shannon, self.area))
 
         if self.clat is not None:
             if self.coord_degrees:
@@ -1350,11 +1368,13 @@ class SlepianMask(Slepian):
     def istype(kind):
         return kind == 'mask'
 
-    def __init__(self, tapers, eigenvalues, area, slepian_degrees, copy=True):
+    def __init__(self, tapers, eigenvalues, area, slepian_degrees, copy=True,
+                 name=None):
         self.kind = 'mask'
         self.lmax = _np.sqrt(tapers.shape[0]).astype(int) - 1
         self.nmax = tapers.shape[1]
         self.slepian_degrees = slepian_degrees
+        self.name = name
 
         if copy:
             self.tapers = _np.copy(tapers)
@@ -1370,13 +1390,13 @@ class SlepianMask(Slepian):
         else:
             self.shannon = sum(self.eigenvalues)
 
-    def _expand(self, coeffsin, nmax):
+    def _expand(self, coeffsin, nmax, name):
         """
         Determine the Slepian expansion coefficients of a function.
         """
         falpha = _shtools.SlepianCoeffs(self.tapers, coeffsin, nmax)
 
-        return SlepianCoeffs(falpha, self)
+        return SlepianCoeffs(falpha, self, name=name)
 
     def _coupling_matrix(self, nmax):
         """Return the coupling matrix."""
@@ -1415,11 +1435,13 @@ class SlepianMask(Slepian):
         print(repr(self))
 
     def __repr__(self):
-        str = ('kind = {:s}\n'
+        str = ('name = {:s}\n'
+               'kind = {:s}\n'
                'lmax = {:d}\n'
                'nmax = {:d}\n'
                'shannon = {:f}\n'
-               'area (radians) = {:e}\n'.format(repr(self.kind), self.lmax,
+               'area (radians) = {:e}\n'.format(repr(self.name),
+                                                repr(self.kind), self.lmax,
                                                 self.nmax, self.shannon,
                                                 self.area))
 

--- a/pyshtools/shclasses/slepiancoeffs.py
+++ b/pyshtools/shclasses/slepiancoeffs.py
@@ -120,7 +120,7 @@ class SlepianCoeffs(object):
             parameter to 0 will use as many threads as there are hardware
             threads on the system.
         """
-        if type(grid) is not str:
+        if not isinstance(grid, str):
             raise ValueError('grid must be a string. ' +
                              'Input type was {:s}'
                              .format(str(type(grid))))
@@ -188,7 +188,7 @@ class SlepianCoeffs(object):
             Condon-Shortley phase convention: 1 to exclude the phase factor,
             or -1 to include it.
         """
-        if type(normalization) is not str:
+        if not isinstance(normalization, str):
             raise ValueError('normalization must be a string. ' +
                              'Input type was {:s}'
                              .format(str(type(normalization))))

--- a/pyshtools/shio/convert.py
+++ b/pyshtools/shio/convert.py
@@ -62,7 +62,7 @@ def convert(coeffs_in, normalization_in=None, normalization_out=None,
 
     # check argument consistency
     if normalization_in is not None:
-        if type(normalization_in) is not str:
+        if not isinstance(normalization_in, str):
             raise ValueError('normalization_in must be a string. ' +
                              'Input type was {:s}'
                              .format(str(type(normalization_in))))
@@ -77,7 +77,7 @@ def convert(coeffs_in, normalization_in=None, normalization_out=None,
             raise ValueError("normalization_in and normalization_out " +
                              "must both be specified.")
     if normalization_out is not None:
-        if type(normalization_out) is not str:
+        if not isinstance(normalization_out, str):
             raise ValueError('normalization_out must be a string. ' +
                              'Input type was {:s}'
                              .format(str(type(normalization_out))))

--- a/pyshtools/shio/dov.py
+++ b/pyshtools/shio/dov.py
@@ -149,7 +149,7 @@ def read_dov(filename, lmax=None, error=False, header=False, header2=False,
                 while f.read(1) != b'\n':
                     try:
                         f.seek(-2, _os.SEEK_CUR)
-                    except:
+                    except Exception:
                         f.seek(-1, _os.SEEK_CUR)  # beginning of file
                         break
 
@@ -166,7 +166,7 @@ def read_dov(filename, lmax=None, error=False, header=False, header2=False,
                     line = line.replace(',', ' ')
                     try:
                         f.seek(-len(line)-2, _os.SEEK_CUR)
-                    except:
+                    except Exception:
                         raise RuntimeError('Encountered beginning of file '
                                            'while attempting to determine '
                                            'lmax.')

--- a/pyshtools/shio/shtools.py
+++ b/pyshtools/shio/shtools.py
@@ -148,7 +148,7 @@ def shread(filename, lmax=None, error=False, header=False, header2=False,
                 while f.read(1) != b'\n':
                     try:
                         f.seek(-2, _os.SEEK_CUR)
-                    except:
+                    except Exception:
                         f.seek(-1, _os.SEEK_CUR)  # beginning of file
                         break
 
@@ -165,7 +165,7 @@ def shread(filename, lmax=None, error=False, header=False, header2=False,
                     line = line.replace(',', ' ')
                     try:
                         f.seek(-len(line)-2, _os.SEEK_CUR)
-                    except:
+                    except Exception:
                         raise RuntimeError('Encountered beginning of file '
                                            'while attempting to determine '
                                            'lmax.')


### PR DESCRIPTION
* Use `isinstance` when comparing types.
* Use `except Exception` to avoid bare except.
* Improve `setuptools_scm` version detection when working with non-git-versioned projects.
* Improve handling of the class attribute `name`. This attribute was added to classes that did not define name, and every method that returns a class instance now has the ability to set the name of the new instance. When creating grids from coefficients, the name of the grid class is inherited from the name of the coefficient class.
* Add the option to rotate the ellipoid generated by `SHGrid.from_ellipsoid()` about the z axis by the angle `alpha`.
