### PR TITLE
Better normal gravity on a sphere

### DIFF
--- a/pyshtools/doc/normalgravity.doc
+++ b/pyshtools/doc/normalgravity.doc
@@ -1,5 +1,4 @@
-Calculate the normal gravity on a flattened ellipsoid in geocentric coordinates
-using the formula of Somigliana.
+Calculate the normal gravity on an ellipsoid or sphere using geocentric coordinates.
 
 Usage
 -----
@@ -27,14 +26,20 @@ b : float
 
 Description
 -----------
-NormalGravity will calculate the magnitude of the predicted gravity (in m/s^2)
-on a flattened ellipsoid using Somigliana's formula. The latitude is input in
-geocentric coordinates in degrees, which is later converted to geodetic
-coordinates in the routine for use with Somigliana's formula. Other input
-parameters include gm, the product of the gravitational constant and the
-planet's mass, and the semi-major and semi-minor axes of the planet, a and b,
-respectively. For further details, see sections 2.7 and 2.8 of Physical Geodesy
-(Hofmann-Wellenhof and Moritz).
+NormalGravity will compute the magnitude of the total gravity (gravitation and
+centrifugal) on the surface of a rotating ellipsoid (in m/s^2).  The latitude
+is input in geocentric coordinates in degrees.
+
+For a rotating ellipsoid, the surface corresponds to a constant potential, and
+the gravity vector is normal to the surface. The normal gravity is computed
+using Somigliana's formula, as taken from Physical Geodesy (Hofmann-Wellenhof
+and Moritz, 2nd ed., sections 2.7 and 2.8). In this routine, the geodetic
+latitude is computed internally from the input geocentric latitude.
+
+For the case of a sphere (a is equal to b), the normal gravity is defined as
+the magnitude of the sum of the normal gravitation (GM/r^2) and the centrifugal
+gravity. For a rotating sphere, the surface does not correspond to a constant
+potential and the gravity vector is not normal to the surface.
 
 References
 ----------

--- a/src/NormalGravity.f95
+++ b/src/NormalGravity.f95
@@ -1,12 +1,24 @@
 function NormalGravity(geocentric_lat, GM, omega, a, b)
 !------------------------------------------------------------------------------
 !
-!   Compute the total predicted gravity normal to the ellipsoid at a given
-!   GEOCENTRIC latitude (input in DEGREES), using Somigliana's formula.
-!   This is taken from Physical Geodesy (Hofmann-Wellenhof and Moritz,
-!   sec. ed.), sections 2.7 and 2.8.
+!   Compute the normal gravity at a given GEOCENTRIC latitude (input in
+!   degrees). The normal gravity is the norm of the total gravity (gravitation
+!   and centrifugal) on the surface of a rotating ellipsoid.
 !
-!   Copyright (c) 2005-2019, SHTOOLS
+!   For a rotating ellipsoid, the surface corresponds to a constant potential,
+!   and the gravity vector is normal to the surface. The normal gravity is
+!   computed using Somigliana's formula, as taken from Physical Geodesy
+!   (Hofmann-Wellenhof and Moritz, 2nd ed., sections 2.7 and 2.8). In this
+!   routine, the geodetic latitude is computed from the input geocentric
+!   latitude.
+!
+!   For the case of a sphere (a is equal to b), the normal gravity is defined
+!   as the magnitude of the sum of the normal gravitation (GM/r**2) and
+!   centrifugal gravity. For a rotating sphere, the surface does not correspond
+!   to a constant potential and the gravity vector is not normal to the
+!   surface.
+!
+!   Copyright (c) 2005-2024, SHTOOLS
 !   All rights reserved.
 !
 !------------------------------------------------------------------------------
@@ -24,18 +36,18 @@ function NormalGravity(geocentric_lat, GM, omega, a, b)
                 "semiminor axis B."
     end if
 
+    pi = acos(-1.0_dp)
+
     if (a == b .and. omega == 0.0_dp) then
         NormalGravity = GM / a**2
 
     else if (a == b .and. omega /= 0.0_dp) then
-        print*, "Warning --- NormalGravity"
-        print*, "A can not be equal to B when OMEGA is non zero."
-        print*, "Setting OMEGA equal to zero."
-        NormalGravity = GM / a**2
+        NormalGravity = GM**2 / a**4 &
+          + a * omega**2 * cos(geocentric_lat * pi / 180.0_dp)**2 &
+          * (a * omega**2 - 2.0_dp * GM / a**2)
+        NormalGravity = sqrt(NormalGravity)
 
     else
-        pi = acos(-1.0_dp)
-
         m = omega**2 * a**2 * b / GM
 
         bigE = sqrt(a**2 - b**2) ! linear eccentricity

--- a/src/fdoc/normalgravity.md
+++ b/src/fdoc/normalgravity.md
@@ -1,6 +1,6 @@
 # NormalGravity
 
-Calculate the normal gravity on a flattened ellipsoid in geocentric coordinates using the formula of Somigliana.
+Calculate the normal gravity on an ellipsoid or sphere using geocentric coordinates.
 
 # Usage
 
@@ -21,14 +21,18 @@ Calculate the normal gravity on a flattened ellipsoid in geocentric coordinates 
 :   The angular rotation rate of the planet.
 
 `a` : input, real(dp)
-:   The semi-major axis of the flattened ellipsoid on which the normal gravity is computed.
+:   The semi-major axis of the ellipsoid on which the normal gravity is computed.
 
 `b` : input, real(dp)
-:   The semi-minor axis of the flattened ellipsoid on which the normal gravity is computed.
+:   The semi-minor axis of the ellipsoid on which the normal gravity is computed.
 
 # Description
 
-`NormalGravity` will calculate the magnitude of the predicted gravity (in m/s^2) on a flattened ellipsoid using Somigliana's formula. The latitude is input in geocentric coordinates in degrees, which is later converted to geodetic coordinates in the routine for use with Somigliana's formula. Other input parameters include `gm`, the product of the gravitational constant and the planet's mass, and the semi-major and semi-minor axes of the planet, `a` and `b`, respectively. For further details, see sections 2.7 and 2.8 of Physical Geodesy (Hofmann-Wellenhof and Moritz).
+`NormalGravity` will compute the magnitude of the total gravity (gravitation and centrifugal) on the surface of a rotating ellipsoid (in m/s^2).  The latitude is input in geocentric coordinates in degrees.
+
+For a rotating ellipsoid, the surface corresponds to a constant potential, and the gravity vector is normal to the surface. The normal gravity is computed using Somigliana's formula, as taken from Physical Geodesy (Hofmann-Wellenhof and Moritz, 2nd ed., sections 2.7 and 2.8). In this routine, the geodetic latitude is computed internally from the input geocentric latitude.
+
+For the case of a sphere (a is equal to b), the normal gravity is defined as the magnitude of the sum of the normal gravitation (GM/r^2) and the centrifugal gravity. For a rotating sphere, the surface does not correspond to a constant potential and the gravity vector is not normal to the surface.
 
 # References
 

--- a/src/pydoc/pynormalgravity.md
+++ b/src/pydoc/pynormalgravity.md
@@ -1,6 +1,6 @@
 # NormalGravity()
 
-Calculate the normal gravity on a flattened ellipsoid in geocentric coordinates using the formula of Somigliana.
+Calculate the normal gravity on an ellipsoid or sphere using geocentric coordinates.
 
 # Usage
 
@@ -30,7 +30,11 @@ b : float
 
 # Description
 
-NormalGravity will calculate the magnitude of the predicted gravity (in m/s^2) on a flattened ellipsoid using Somigliana's formula. The latitude is input in geocentric coordinates in degrees, which is later converted to geodetic coordinates in the routine for use with Somigliana's formula. Other input parameters include gm, the product of the gravitational constant and the planet's mass, and the semi-major and semi-minor axes of the planet, a and b, respectively. For further details, see sections 2.7 and 2.8 of Physical Geodesy (Hofmann-Wellenhof and Moritz).
+NormalGravity will compute the magnitude of the total gravity (gravitation and centrifugal) on the surface of a rotating ellipsoid (in m/s^2).  The latitude is input in geocentric coordinates in degrees.
+
+For a rotating ellipsoid, the surface corresponds to a constant potential, and the gravity vector is normal to the surface. The normal gravity is computed using Somigliana's formula, as taken from Physical Geodesy (Hofmann-Wellenhof and Moritz, 2nd ed., sections 2.7 and 2.8). In this routine, the geodetic latitude is computed internally from the input geocentric latitude.
+
+For the case of a sphere (a is equal to b), the normal gravity is defined as the magnitude of the sum of the normal gravitation (GM/r^2) and the centrifugal gravity. For a rotating sphere, the surface does not correspond to a constant potential and the gravity vector is not normal to the surface.
 
 # References
 


### PR DESCRIPTION
This PR changes the way that the normal gravity is computed when the reference ellipsoid is a sphere. 

The normal gravity is defined as the magnitude of the total gravity (gravitation + centrifugal) on the surface. In contrast to the case of an ellipsoid, the surface of the sphere does not correspond to an equipotential surface, and the gravity vector is not normal to the surface. See https://www.fatiando.org/boule/latest/api/generated/boule.Sphere.html#boule.Sphere.normal_gravity