### PR TITLE
Boule

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,3 +22,4 @@ dependencies:
     - jupyter
     - pip
     - flake8
+    - boule

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
   'requests',
   'pooch>=1.1',
   'tqdm',
+  'boule',
 ]
 
 [project.urls]

--- a/pyshtools/doc/makegravgriddh.doc
+++ b/pyshtools/doc/makegravgriddh.doc
@@ -1,11 +1,11 @@
 Create 2D cylindrical maps on a flattened and rotating ellipsoid of all three
-components of the gravity, the gravity disturbance, and the gravitational
+components of the gravity, the gravity disturbance, and the gravity
 potential.
 
 Usage
 -----
 rad, theta, phi, total, pot = MakeGravGridDH (cilm, gm, r0, [a, f, lmax,
-sampling, lmax_calc, omega, normal_gravity, extend])
+sampling, lmax_calc, omega, normal_gravity, normal_gravity_gm, extend])
 
 Returns
 -------
@@ -32,16 +32,18 @@ total : float, dimension (nlat, nlong)
     A 2D equally sampled or equally spaced grid of the magnitude of the gravity
     acceleration.
 pot : float, dimension (nlat, nlong)
-    A 2D equally sampled or equally spaced grid of the gravitational potential.
+    A 2D equally sampled or equally spaced grid of the gravity potential.
 
 Parameters
 ----------
 cilm : float, dimension (2, lmaxin+1, lmaxin+1)
     The real 4-pi normalized gravitational potential spherical harmonic
-    coefficients. The coefficients c1lm and c2lm refer to the cosine and sine
-    coefficients, respectively, with c1lm=cilm[0,l,m] and c2lm=cilm[1,l,m].
+    coefficients. The coefficients c1lm and c2lm correspond to the cosine and
+    sine coefficients, respectively, with c1lm=cilm[0,l,m] and
+    c2lm=cilm[1,l,m].
 gm : float
-    The gravitational constant multiplied by the mass of the planet.
+    The gravitational constant multiplied by the mass of the gravitational
+    potential model.
 r0: float
     The reference radius of the spherical harmonic coefficients.
 a : optional, float, default = r0
@@ -62,22 +64,25 @@ lmax_calc : optional, integer, default = lmax
 omega : optional, float, default = 0
     The angular rotation rate of the planet.
 normal_gravity : optional, integer, default = 1
-    If 1, the normal gravity (the gravitational acceleration on the ellipsoid)
-    will be subtracted from the total gravity, yielding the "gravity
+    If 1, the normal gravity (the gravitational acceleration on the rotating
+    ellipsoid) will be subtracted from the total gravity, yielding the "gravity
     disturbance." This is done using Somigliana's formula (after converting
     geocentric to geodetic coordinates).
+normal_gravity_gm : optional, float, default = gm
+    The GM to use when computing the normal gravity. If not specified, the GM
+    of the gravitational potential model will be used.
 extend : input, optional, bool, default = False
     If True, compute the longitudinal band for 360 E and the latitudinal band
     for 90 S. This increases each of the dimensions of griddh by 1.
 
 Description
 -----------
-MakeGravGridDH will create 2-dimensional cylindrical maps from the spherical
-harmonic coefficients cilm, equally sampled (n by n) or equally spaced (n by 2n)
-in latitude and longitude, for the three vector components of the gravity vector
-(gravitational force + centrifugal force), the magnitude of the gravity vector,
-and the gravity potential (all using geocentric coordinates). The gravitational
-potential is given by
+MakeGravGridDH will compute 2-dimensional cylindrical maps of the three
+spherical vector components, the vector magnitude, and the potential of either
+the gravity (gravitational force + centrifugal force) or gravitation from the
+input spherical harmonic coefficients cilm. The grids are equally sampled
+(n by n) or equally spaced (n by 2n) in latitude and longitude, where latitude
+is geocentric spherical. The gravitational potential is given by
 
 V = GM/r Sum_{l=0}^lmax (r0/r)^l Sum_{m=-l}^l C_{lm} Y_{lm},
 
@@ -86,16 +91,17 @@ and the gravitational acceleration is
 B = Grad V.
 
 The coefficients are referenced to a radius r0, and the function is computed on
-a flattened ellipsoid with semi-major axis a (i.e., the mean equatorial radius)
-and flattening f. All grids are output in SI units, and the sign of the radial
-components is positive when directed upwards.
+a flattened ellipsoid with semi-major axis a and flattening f. All grids are
+output in SI units, and the sign of the radial components is positive when
+directed upwards.
 
 If the optional angular rotation rate omega is specified, the potential and
 gravity vectors will be calculated in a body-fixed rotating reference frame and
-will include the contribution from the centrifugal force. If normal_gravity is
-set to 1, the normal gravity will be removed from the magnitude of the gravity
-vector, yielding the gravity disturbance. To convert m/s^2 to mGals, multiply
-the gravity grids by 10^5.
+will include the contribution from the centrifugal force. If not specified, the
+output grids will correspond to the external gravitation without the
+centrifugal force. If normal_gravity is set to 1, the normal gravity will be
+removed from the magnitude of the gravity vector, yielding the gravity
+disturbance. To convert m/s^2 to mGals, multiply the gravity grids by 10^5.
 
 The calculated values should be considered exact only when the radii on the
 ellipsoid are greater than the maximum radius of the planet (the potential

--- a/pyshtools/shclasses/shcoeffs.py
+++ b/pyshtools/shclasses/shcoeffs.py
@@ -1,5 +1,7 @@
 """
-    Spherical Harmonic Coefficients classes
+Spherical Harmonic Coefficients classes
+
+    SHCoeffs: SHRealCoeffs, SHComplexCoeffs
 """
 import os as _os
 import numpy as _np

--- a/pyshtools/shclasses/shgeoid.py
+++ b/pyshtools/shclasses/shgeoid.py
@@ -13,7 +13,7 @@ class SHGeoid(object):
     """
     Class for the height of the geoid. The class is initialized from a class
     instance of SHGravCoeffs using the method geoid(). Geoid heights are
-    referenced to a flattened ellipsoid of semimajor axis a and flattening f.
+    with respect to a flattened ellipsoid of semimajor axis a and flattening f.
 
     Attributes:
 

--- a/pyshtools/shclasses/shgeoid.py
+++ b/pyshtools/shclasses/shgeoid.py
@@ -1,5 +1,5 @@
 """
-    Class for the height of the geoid.
+Class for the height of the geoid.
 """
 import numpy as _np
 import copy as _copy

--- a/pyshtools/shclasses/shgradient.py
+++ b/pyshtools/shclasses/shgradient.py
@@ -1,5 +1,5 @@
 """
-    Class for grids of the two components of the horizontal gradient.
+Class for grids of the two components of the horizontal gradient.
 """
 import matplotlib as _mpl
 import matplotlib.pyplot as _plt

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -1,5 +1,5 @@
 """
-    Class for spherical harmonic coefficients of the gravitational potential.
+Class for spherical harmonic coefficients of the gravitational potential.
 """
 import numpy as _np
 import matplotlib as _mpl
@@ -1013,7 +1013,7 @@ class SHGravCoeffs(object):
         """
         Initialize a class of gravitational potential spherical harmonic
         coefficients by calculuting the gravitational potential associatiated
-        with relief along an interface.
+        with relief along a spherical interface.
 
         Usage
         -----
@@ -2406,9 +2406,9 @@ class SHGravCoeffs(object):
                sampling=2, extend=True, name=None):
         """
         Create 2D cylindrical maps on a flattened and rotating ellipsoid of the
-        three components of the gravity vector, the gravity disturbance, and
-        the gravity potential. Alternatively, compute the gravity vector at
-        specified coordinates.
+        three spherical components of the gravity vector, the gravity
+        disturbance, and the gravity potential. Alternatively, compute the
+        gravity vector at specified coordinates.
 
         Usage
         -----

--- a/pyshtools/shclasses/shgravgrid.py
+++ b/pyshtools/shclasses/shgravgrid.py
@@ -1,6 +1,6 @@
 """
-    Class for grids of the three components of the gravity field, the
-    gravitational disturbance, and the gravitational potential.
+Class for grids of the three components of the gravity field, the
+gravitational disturbance, and the gravitational potential.
 """
 import matplotlib as _mpl
 import matplotlib.pyplot as _plt

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -1315,6 +1315,11 @@ class SHGrid(object):
         projection : Cartopy projection class, optional, default = None
             The Cartopy projection class used to project the gridded data,
             for Driscoll and Healy sampled grids only.
+        ellipsoid : boule class instance, optional, default = None
+            Plot spherical heights with respect to an ellipsoid defined by a
+            boule Sphere, Ellipsoid, or TriaxialEllipsoid class instance. The
+            boule class instance contains the lengths of the principal axes a,
+            b, and c, and the rotation angle alpha.
         a, b, c : float, optional, default = None
             Plot spherical heights with respect to an ellipsoid with principal
             semiaxis lengths a, b, and c.
@@ -1322,10 +1327,6 @@ class SHGrid(object):
             Rotate the a and b principal axes about the z axis by the angle
             alpha in degrees. The longitude of the x and y axes will be alpha
             and 90 + alpha, respectively.
-        ellipsoid : boule class instance, optional, default = None
-            A boule Sphere, Ellipsoid, or TriaxialEllipsoid class instance that
-            contains the lengths of the principal axes a, b, and c, and the
-            rotation angle alpha.
         tick_interval : list or tuple, optional, default = [30, 30]
             Intervals to use when plotting the x and y ticks. If set to None,
             ticks will not be plotted.
@@ -1567,6 +1568,11 @@ class SHGrid(object):
         projection : str, optional, default = 'mollweide'
             The name of a projection (see Notes). Only the first three
             characters are necessary to identify the projection.
+        ellipsoid : boule class instance, optional, default = None
+            Plot spherical heights with respect to an ellipsoid defined by a
+            boule Sphere, Ellipsoid, or TriaxialEllipsoid class instance. The
+            boule class instance contains the lengths of the principal axes a,
+            b, and c, and the rotation angle alpha.
         a, b, c : float, optional, default = None
             Plot spherical heights with respect to an ellipsoid with principal
             semiaxis lengths a, b, and c.
@@ -1574,10 +1580,6 @@ class SHGrid(object):
             Rotate the a and b principal axes about the z axis by the angle
             alpha in degrees. The longitude of the x and y axes will be alpha
             and 90 + alpha, respectively.
-        ellipsoid : boule class instance, optional, default = None
-            A boule Sphere, Ellipsoid, or TriaxialEllipsoid class instance that
-            contains the lengths of the principal axes a, b, and c, and the
-            rotation angle alpha.
         region : str or list, optional, default = 'g'
             The map region, which can be the string 'g' for the entire sphere,
             a bounded region specified by the list [west, east, south, north],
@@ -1849,6 +1851,12 @@ class SHGrid(object):
              defined by numpy.histogram_bin_edges.
         range : (float, float), optional, default = None
             The lower and upper range of the bins.
+        ellipsoid : boule class instance, optional, default = None
+            Compute the histogram using spherical heights with respect to an
+            ellipsoid defined by a boule Sphere, Ellipsoid, or
+            TriaxialEllipsoid class instance. The boule class instance contains
+            the lengths of the principal axes a, b, and c, and the rotation
+            angle alpha.
         a, b, c : float, optional, default = None
             Compute the histogram using spherical heights with respect to an
             ellipsoid with principal semiaxis lengths a, b, and c.
@@ -1856,10 +1864,6 @@ class SHGrid(object):
             Rotate the a and b principal axes about the z axis by the angle
             alpha in degrees. The longitude of the x and y axes will be alpha
             and 90 + alpha, respectively.
-        ellipsoid : boule class instance, optional, default = None
-            A boule Sphere, Ellipsoid, or TriaxialEllipsoid class instance that
-            contains the lengths of the principal axes a, b, and c, and the
-            rotation angle alpha.
         cumulative : bool or -1, optional, default = False
             If True, then a histogram is computed where each bin gives the
             counts in that bin plus all bins for smaller values. If cumulative

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -1790,7 +1790,8 @@ class SHGrid(object):
                        legend_loc='best', xlabel=None,
                        ylabel='Fraction', title=None, grid=False,
                        axes_labelsize=None, tick_labelsize=None,
-                       titlesize=None, ax=None, show=True, fname=None):
+                       titlesize=None, ax=None, hist_dict=dict(), show=True,
+                       fname=None):
         """
         Plot an area-weighted histogram of the gridded data, normalized such
         that the integral over the range is unity. If ellipsoid parameters are
@@ -1801,8 +1802,8 @@ class SHGrid(object):
         x.plot_histogram([bins, range, a, b, c, alpha, ellipsoid, cumulative,
                           histtype, orientation, xscale, yscale, color, legend,
                           legend_loc, xlabel, ylabel, title, grid,
-                          axes_labelsize, tick_labelsize, titlesize, ax, show,
-                          fname])
+                          axes_labelsize, tick_labelsize, titlesize, ax,
+                          hist_dict, show, fname])
 
         Parameters
         ----------
@@ -1864,6 +1865,8 @@ class SHGrid(object):
             The font size of the title.
         ax : matplotlib axes object, optional, default = None
             A single matplotlib axes object where the plot will appear.
+        hist_dict : dict, optional, default = dict()
+            Optional arguments passed to matplotlib.pyplot.hist().
         show : bool, optional, default = True
             If True, plot to the screen.
         fname : str, optional, default = None
@@ -1908,7 +1911,8 @@ class SHGrid(object):
                                          alpha=alpha, ellipsoid=ellipsoid)
         axes.hist(bin_edges[:-1], bin_edges, weights=hist,
                   cumulative=cumulative, histtype=histtype,
-                  orientation=orientation, color=color, label=legend)
+                  orientation=orientation, color=color, label=legend,
+                  **hist_dict)
 
         if xscale == 'log':
             axes.set_xscale('log')

--- a/pyshtools/shclasses/shgrid.py
+++ b/pyshtools/shclasses/shgrid.py
@@ -1091,14 +1091,15 @@ class SHGrid(object):
     def plot3d(self, elevation=20, azimuth=30, cmap='viridis',
                cmap_limits=None, cmap_rlimits=None, cmap_reverse=False,
                title=False, titlesize=None, scale=4., ax=None, show=True,
-               fname=None):
+               plot_surface_dict=dict(), fname=None):
         """
         Plot a 3-dimensional representation of the data.
 
         Usage
         -----
         x.plot3d([elevation, azimuth, cmap, cmap_limits, cmap_rlimits,
-                  cmap_reverse, title, titlesize, scale, ax, show, fname])
+                  cmap_reverse, title, titlesize, scale, ax, show,
+                  plot_surface_dict, fname])
 
         Parameters
         ----------
@@ -1130,6 +1131,8 @@ class SHGrid(object):
             Axes3DSubplot object.
         show : bool, optional, default = True
             If True, plot the image to the screen.
+        plot_surface_dict : dict, optional, default = dict()
+            Optional arguments passed to Axes3D.plot_surface().
         fname : str, optional, default = None
             If present, and if ax is not specified, save the image to the
             specified file.
@@ -1260,7 +1263,7 @@ class SHGrid(object):
 
         # plot data
         ax3d.plot_surface(x, y, z, rstride=1, cstride=1, facecolors=colors,
-                          shade=False)
+                          shade=False, **plot_surface_dict)
         ax3d.set(xlim=(-1., 1.), ylim=(-1., 1.), zlim=(-1., 1.),
                  xticks=[-1, 1], yticks=[-1, 1], zticks=[-1, 1])
         ax3d.set_axis_off()
@@ -1287,7 +1290,8 @@ class SHGrid(object):
              cb_ylabel=None, cb_tick_interval=None,
              cb_minor_tick_interval=None, cb_offset=None, cb_width=None,
              grid=False, axes_labelsize=None, tick_labelsize=None, xlabel=True,
-             ylabel=True, ax=None, ax2=None, show=True, fname=None):
+             ylabel=True, ax=None, ax2=None, imshow_dict=dict(), show=True,
+             fname=None):
         """
         Plot the data using a Cartopy projection or a matplotlib cylindrical
         projection.
@@ -1301,7 +1305,7 @@ class SHGrid(object):
                           cb_triangles, cb_label, cb_ylabel, cb_tick_interval,
                           cb_minor_tick_interval, cb_offset, cb_width, grid,
                           titlesize, axes_labelsize, tick_labelsize, ax, ax2,
-                          show, fname])
+                          imsow_dict, show, fname])
 
         Parameters
         ----------
@@ -1388,6 +1392,8 @@ class SHGrid(object):
             A single matplotlib axes object where the plot will appear. If the
             grid is complex, the complex component of the grid will be plotted
             on this axes.
+        imshow_dict : dict, optional, default = dict()
+            Optional arguments passed to matplotlib.pyplot.imshow().
         show : bool, optional, default = True
             If True, plot the image to the screen.
         fname : str, optional, default = None
@@ -1462,7 +1468,8 @@ class SHGrid(object):
                 cmap_limits_complex=cmap_limits_complex,
                 cmap_rlimits_complex=cmap_rlimits_complex,
                 cmap_reverse=cmap_reverse, cmap_scale=cmap_scale,
-                cb_offset=cb_offset, cb_width=cb_width)
+                cb_offset=cb_offset, cb_width=cb_width,
+                imshow_dict=imshow_dict)
         else:
             if self.kind == 'complex':
                 if (ax is None and ax2 is not None) or (ax2 is None and
@@ -1485,7 +1492,8 @@ class SHGrid(object):
                        cmap_limits_complex=cmap_limits_complex,
                        cmap_rlimits_complex=cmap_limits_complex,
                        cmap_reverse=cmap_reverse, cmap_scale=cmap_scale,
-                       cb_width=cb_width, cb_ylabel=cb_ylabel)
+                       cb_width=cb_width, cb_ylabel=cb_ylabel,
+                       imshow_dict=imshow_dict)
 
         if ax is None:
             fig.tight_layout(pad=0.5)
@@ -2071,7 +2079,7 @@ class DHRealGrid(SHGrid):
               cb_ylabel=None, cb_minor_tick_interval=None, cmap_limits=None,
               cmap_rlimits=None, cmap_rlimits_complex=None,
               cmap_limits_complex=None, cmap_scale=None, cb_offset=None,
-              cmap_reverse=None, cb_width=None):
+              cmap_reverse=None, cb_width=None, imshow_dict=None):
         """Plot the data as a matplotlib cylindrical projection,
            or with Cartopy when projection is specified."""
         if ax is None:
@@ -2229,7 +2237,8 @@ class DHRealGrid(SHGrid):
             axes.set_global()
             cim = axes.imshow(
                 self.data, transform=_ccrs.PlateCarree(central_longitude=0.0),
-                origin='upper', extent=extent, cmap=cmap_scaled, norm=norm)
+                origin='upper', extent=extent, cmap=cmap_scaled, norm=norm,
+                **imshow_dict)
             if isinstance(projection, _ccrs.PlateCarree):
                 axes.set_xticks(
                     xticks, crs=_ccrs.PlateCarree(central_longitude=0.0))
@@ -2248,7 +2257,7 @@ class DHRealGrid(SHGrid):
                                crs=_ccrs.PlateCarree(central_longitude=0.0))
         else:
             cim = axes.imshow(self.data, origin='upper', extent=extent,
-                              cmap=cmap_scaled, norm=norm)
+                              cmap=cmap_scaled, norm=norm, **imshow_dict)
             axes.set(xlim=(0, 360), ylim=(-90, 90))
             axes.set_xlabel(xlabel, fontsize=axes_labelsize)
             axes.set_ylabel(ylabel, fontsize=axes_labelsize)
@@ -2673,7 +2682,7 @@ class DHComplexGrid(SHGrid):
               cb_tick_interval=None, cb_minor_tick_interval=None,
               cmap_limits=None, cmap_rlimits=None, cmap_rlimits_complex=None,
               cmap_reverse=None, cmap_limits_complex=None, cmap_scale=None,
-              cb_offset=None, cb_width=None):
+              cb_offset=None, cb_width=None, imshow_dict=None):
         """Plot the raw data as a matplotlib simple cylindrical projection,
            or with Cartopy when projection is specified."""
         if ax is None:
@@ -2707,7 +2716,7 @@ class DHComplexGrid(SHGrid):
                             cb_width=cb_width, cmap=cmap,
                             cmap_limits=cmap_limits, cmap_rlimits=cmap_rlimits,
                             cmap_reverse=cmap_reverse, cmap_scale=cmap_scale,
-                            ax=axreal)
+                            ax=axreal, imshow_dict=imshow_dict)
 
         self.to_imag().plot(projection=projection, tick_interval=tick_interval,
                             minor_tick_interval=minor_tick_interval,
@@ -2723,7 +2732,8 @@ class DHComplexGrid(SHGrid):
                             cmap_rlimits=cmap_rlimits_complex,
                             cmap_scale=cmap_scale, cmap_reverse=cmap_reverse,
                             cb_offset=cb_offset, cb_width=cb_width,
-                            xlabel=xlabel, ylabel=ylabel, ax=axcomplex)
+                            xlabel=xlabel, ylabel=ylabel, ax=axcomplex,
+                            imshow_dict=imshow_dict)
 
         if ax is None:
             return fig, axes
@@ -2942,7 +2952,8 @@ class GLQRealGrid(SHGrid):
               cb_tick_interval=None, ticks=None, cb_minor_tick_interval=None,
               cmap_limits=None, cmap_rlimits=None, cmap_limits_complex=None,
               cmap_rlimits_complex=None, cmap_scale=None, cb_ylabel=None,
-              cb_offset=None, cb_width=None, cmap_reverse=None):
+              cb_offset=None, cb_width=None, cmap_reverse=None,
+              imshow_dict=None):
         """Plot the data using a matplotlib cylindrical projection."""
         if ax is None:
             if colorbar is not None:
@@ -3073,7 +3084,7 @@ class GLQRealGrid(SHGrid):
         # plot image, ticks, and annotations
         extent = (-0.5, self.nlon-0.5, -0.5, self.nlat-0.5)
         cim = axes.imshow(self.data, extent=extent, origin='upper',
-                          cmap=cmap_scaled, norm=norm)
+                          cmap=cmap_scaled, norm=norm, **imshow_dict)
         axes.set(xticks=xticks, yticks=yticks)
         axes.set_xlabel(xlabel, fontsize=axes_labelsize)
         axes.set_ylabel(ylabel, fontsize=axes_labelsize)
@@ -3277,7 +3288,7 @@ class GLQComplexGrid(SHGrid):
               cb_minor_tick_interval=None, cmap_limits=None, cmap_rlimits=None,
               cmap_limits_complex=None, cmap_rlimits_complex=None,
               cmap_reverse=None, cmap_scale=None, cb_offset=None,
-              cb_width=None):
+              cb_width=None, imshow_dict=None):
         """Plot the raw data using a simply cylindrical projection."""
         if ax is None:
             if colorbar is not None:
@@ -3310,7 +3321,7 @@ class GLQComplexGrid(SHGrid):
                             cb_width=cb_width, cmap=cmap,
                             cmap_limits=cmap_limits, cmap_rlimits=cmap_rlimits,
                             cmap_reverse=cmap_reverse, cmap_scale=cmap_scale,
-                            ax=axreal)
+                            ax=axreal, imshow_dict=imshow_dict)
 
         self.to_imag().plot(projection=projection, tick_interval=tick_interval,
                             minor_tick_interval=minor_tick_interval,
@@ -3326,7 +3337,8 @@ class GLQComplexGrid(SHGrid):
                             cmap_rlimits=cmap_rlimits_complex,
                             cmap_reverse=cmap_reverse, cmap_scale=cmap_scale,
                             cb_ylabel=cb_ylabel, cb_width=cb_width,
-                            xlabel=xlabel, ylabel=ylabel, ax=axcomplex)
+                            xlabel=xlabel, ylabel=ylabel, ax=axcomplex,
+                            imshow_dict=imshow_dict)
 
         if ax is None:
             return fig, axes

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -1,5 +1,5 @@
 """
-    Class for spherical harmonic coefficients of the magnetic potential.
+Class for spherical harmonic coefficients of the magnetic potential.
 """
 import numpy as _np
 import matplotlib as _mpl

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -1929,43 +1929,48 @@ class SHMagCoeffs(object):
         return clm
 
     # ---- Routines that return different magnetic-related class instances ----
-    def expand(self, a=None, f=None, r=None, lat=None, colat=None, lon=None,
-               degrees=True, lmax=None, lmax_calc=None, sampling=2,
-               extend=True, name=None):
+    def expand(self, ellipsoid=None, a=None, f=None, r=None, lat=None,
+               colat=None, lon=None, degrees=True, lmax=None, lmax_calc=None,
+               sampling=2, extend=True, name=None):
         """
         Create 2D cylindrical maps on a flattened ellipsoid of all three
-        components of the magnetic field, the total magnetic intensity,
-        and the magnetic potential. Alternatively, compute the magnetic field
-        vector at specified coordinates.
+        spherical components of the magnetic field, the total magnetic
+        intensity, and the magnetic potential. Alternatively, compute the
+        magnetic field vector at specified coordinates.
 
         Usage
         -----
-        grids = x.expand([a, f, lmax, lmax_calc, sampling, extend, name])
-        g = x.expand(lat, lon, [a, f, r, lmax, lmax_calc, degrees])
-        g = x.expand(colat, lon, [a, f, r, lmax, lmax_calc, degrees])
+        grids = x.expand([ellipsoid, a, f, lmax, lmax_calc, sampling, extend,
+                          name])
+        g = x.expand([lat, lon, ellipsoid, a, f, r, lmax, lmax_calc, degrees])
+        g = x.expand([colat, lon, ellipsoid, a, f, r, lmax, lmax_calc,
+                      degrees])
 
         Returns
         -------
         grids : SHMagGrid class instance.
-        g     : (r, theta, phi) components of the magnetic field at the
-                specified points.
+        g     : Matrix of [r, theta, phi] components of the magnetic field
+                vector at the specified points.
 
         Parameters
         ----------
+        ellipsoid : boule class instance, optional, default = None
+            A boule Sphere or Ellipsoid class instance that contains the
+            reference elllipsoid semimajor axis length a and flattening f.
         a : optional, float, default = self.r0
             The semi-major axis of the flattened ellipsoid on which the field
             is computed.
         f : optional, float, default = 0
-            The flattening of the reference ellipsoid: f=(a-b)/a.
+            The flattening of the reference ellipsoid, (a-b)/a.
         r : float, ndarray, or list, optional, default = None
             The radii where the magnetic field is to be evaluated. When
-            present, a and f are ignored. r must be the same shape as lat,
+            present, a and f are ignored, and r must be the same shape as lat,
             colat, and lon.
-        lat : int, float, ndarray, or list, optional, default = None
+        lat : float, ndarray, or list, optional, default = None
             Latitude coordinates where the magnetic field is to be evaluated.
-        colat : int, float, ndarray, or list, optional, default = None
+        colat : float, ndarray, or list, optional, default = None
             Colatitude coordinates where the magnetic field is to be evaluated.
-        lon : int, float, ndarray, or list, optional, default = None
+        lon : float, ndarray, or list, optional, default = None
             Longitude coordinates where the magnetic field is to be evaluated.
         degrees : bool, optional, default = True
             True if lat, colat and lon are in degrees, False if in radians.
@@ -1988,11 +1993,11 @@ class SHMagCoeffs(object):
         Notes
         -----
         This method will create 2-dimensional cylindrical maps of the three
-        components of the magnetic field, the total field, and the magnetic
-        potential, and return these as an SHMagGrid class instance. Each
-        map is stored as an SHGrid class instance using Driscoll and Healy
-        grids that are either equally sampled (n by n) or equally spaced
-        in degreess latitude and longitude. All grids use geocentric
+        spherical components of the magnetic field, the total field, and the
+        magnetic potential, and return these as an SHMagGrid class instance.
+        Each map is stored as an SHGrid class instance using Driscoll and Healy
+        grids that are either equally sampled (n by n) or equally spaced in
+        degreess latitude and longitude. All grids use geocentric spherical
         coordinates, and the units are either in nT (for the magnetic field),
         or nT m (for the potential). If latitude and longitude coordinates
         are specified, this method will instead return only the magnetic field
@@ -2007,41 +2012,39 @@ class SHMagCoeffs(object):
         B = - Grad V.
 
         The coefficients are referenced to a radius r0, and the function is
-        computed on a flattened ellipsoid with semi-major axis a (i.e., the
-        mean equatorial radius) and flattening f.
+        computed on a flattened ellipsoid with semi-major axis a and flattening
+        f.
         """
         if lat is not None and colat is not None:
             raise ValueError('lat and colat can not both be specified.')
 
-        if a is None:
-            a = self.r0
-        if f is None:
-            f = 0.
+        if lmax is None:
+            lmax = self.lmax
+        if lmax_calc is None:
+            lmax_calc = lmax
+
+        if ellipsoid is not None:
+            a = ellipsoid.semimajor_axis
+            f = ellipsoid.flattening
+        else:
+            if a is None:
+                a = self.r0
+            if f is None:
+                f = 0.
 
         if (lat is not None or colat is not None) and lon is not None:
-            if lmax_calc is None:
-                lmax_calc = self.lmax
-
             if colat is not None:
                 if degrees:
                     temp = 90.
                 else:
                     temp = _np.pi/2.
-
-                if isinstance(colat, list):
-                    lat = list(map(lambda x: temp - x, colat))
-                else:
-                    lat = temp - colat
+                lat = temp - _np.array(colat)
 
             values = self._expand_coord(a=a, f=f, radius=r, lat=lat, lon=lon,
                                         degrees=degrees, lmax_calc=lmax_calc)
             return values
 
         else:
-            if lmax is None:
-                lmax = self.lmax
-            if lmax_calc is None:
-                lmax_calc = lmax
             if name is None:
                 name = self.name
 
@@ -2056,8 +2059,8 @@ class SHMagCoeffs(object):
                           units=self.units, pot_units=self.units+' m',
                           year=self.year, name=name)
 
-    def tensor(self, a=None, f=None, lmax=None, lmax_calc=None, sampling=2,
-               extend=True, name=None):
+    def tensor(self, ellipsoid=None, a=None, f=None, lmax=None, lmax_calc=None,
+               sampling=2, extend=True, name=None):
         """
         Create 2D cylindrical maps on a flattened ellipsoid of the 9
         components of the magnetic field tensor in a local north-oriented
@@ -2065,7 +2068,8 @@ class SHMagCoeffs(object):
 
         Usage
         -----
-        tensor = x.tensor([a, f, lmax, lmax_calc, sampling, extend, name])
+        tensor = x.tensor([ellipsoid, a, f, lmax, lmax_calc, sampling, extend,
+                           name])
 
         Returns
         -------
@@ -2073,11 +2077,14 @@ class SHMagCoeffs(object):
 
         Parameters
         ----------
+        ellipsoid : boule class instance, optional, default = None
+            A boule Sphere or Ellipsoid class instance that contains the
+            reference elllipsoid semimajor axis length a and flattening f.
         a : optional, float, default = self.r0
             The semi-major axis of the flattened ellipsoid on which the field
             is computed.
         f : optional, float, default = 0
-            The flattening of the reference ellipsoid: f=(a-b)/a.
+            The flattening of the reference ellipsoid, (a-b)/a.
         lmax : optional, integer, default = self.lmax
             The maximum spherical harmonic degree that determines the number of
             samples of the output grids, n=2lmax+2, and the latitudinal
@@ -2104,7 +2111,7 @@ class SHMagCoeffs(object):
             (Vyx, Vyy, Vyz)
             (Vzx, Vzy, Vzz)
 
-        where the reference frame is north-oriented, where x points north, y
+        and the reference frame is north-oriented, where x points north, y
         points west, and z points upward (all tangent or perpendicular to a
         sphere of radius r, where r is the local radius of the flattened
         ellipsoid). The magnetic potential is defined as
@@ -2143,16 +2150,21 @@ class SHMagCoeffs(object):
         gravity gradients in the local north-oriented and orbital reference
         frames, J. Geod., 80, 117-127, 2006.
         """
-        if a is None:
-            a = self.r0
-        if f is None:
-            f = 0.
         if lmax is None:
             lmax = self.lmax
         if lmax_calc is None:
             lmax_calc = lmax
         if name is None:
             name = self.name
+
+        if ellipsoid is not None:
+            a = ellipsoid.semimajor_axis
+            f = ellipsoid.flattening
+        else:
+            if a is None:
+                a = self.r0
+            if f is None:
+                f = 0.
 
         coeffs = self.to_array(normalization='schmidt', csphase=1,
                                errors=False)
@@ -3079,7 +3091,7 @@ class SHMagRealCoeffs(SHMagCoeffs):
             return _MakeMagGridPoint(coeffs, a=self.r0, r=radius, lat=latin,
                                      lon=lonin, lmax=lmax_calc)
 
-        elif isinstance(lat, _np.ndarray):
+        elif isinstance(lat, (_np.ndarray, list, tuple)):
             values = _np.empty((len(lat), 3), dtype=_np.float64)
             for i, (r, latitude, longitude) in enumerate(zip(radius, latin,
                                                              lonin)):
@@ -3088,17 +3100,9 @@ class SHMagRealCoeffs(SHMagCoeffs):
                                                  lmax=lmax_calc)
             return values
 
-        elif isinstance(lat, list):
-            values = []
-            for r, latitude, longitude in zip(radius, latin, lonin):
-                values.append(
-                    _MakeMagGridPoint(coeffs, a=self.r0, r=r, lat=latitude,
-                                      lon=longitude, lmax=lmax_calc))
-            return values
-
         else:
-            raise ValueError('r, lat and lon must be either an int, float, '
-                             'ndarray, or list. Input types are '
+            raise ValueError('r, lat and lon must be either a float, '
+                             'ndarray, list, or tuple. Input types are '
                              '{:s}, {:s} and {:s}.'
                              .format(repr(type(radius)), repr(type(lat)),
                                      repr(type(lon))))

--- a/pyshtools/shclasses/shmaggrid.py
+++ b/pyshtools/shclasses/shmaggrid.py
@@ -1,6 +1,6 @@
 """
-    Class for grids of the three components of the magnetic field, the
-    magnetic intensity, and the magnetic potential.
+Class for grids of the three components of the magnetic field, the
+magnetic intensity, and the magnetic potential.
 """
 import matplotlib as _mpl
 import matplotlib.pyplot as _plt

--- a/pyshtools/shclasses/shtensor.py
+++ b/pyshtools/shclasses/shtensor.py
@@ -1,5 +1,5 @@
 """
-    Class for the gravity and magnetic field 'gradient' tensors.
+Class for the gravity and magnetic field 'gradient' tensors.
 """
 import numpy as _np
 import matplotlib as _mpl

--- a/pyshtools/shclasses/shwindow.py
+++ b/pyshtools/shclasses/shwindow.py
@@ -1,7 +1,7 @@
 """
-    Class for localized spectral analyses on the sphere.
+Class for localized spectral analyses on the sphere.
 
-        SHWindow: SHWindowCap, SHWindowMask
+    SHWindow: SHWindowCap, SHWindowMask
 """
 import numpy as _np
 import matplotlib as _mpl

--- a/pyshtools/shclasses/slepian.py
+++ b/pyshtools/shclasses/slepian.py
@@ -1,7 +1,7 @@
 """
-    Class for Slepian functions on the sphere.
+Class for Slepian functions on the sphere.
 
-        Slepian: SlepianCap, SlepianMask
+    Slepian: SlepianCap, SlepianMask
 """
 import numpy as _np
 import matplotlib as _mpl

--- a/pyshtools/shclasses/slepiancoeffs.py
+++ b/pyshtools/shclasses/slepiancoeffs.py
@@ -1,5 +1,5 @@
 """
-    Class for Slepian expansion coefficients.
+Class for Slepian expansion coefficients.
 """
 import numpy as _np
 import copy as _copy

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ducc0>=0.15
 palettable>=3.3
 jupyter
 flake8
+boule

--- a/src/MakeGeoidGrid.f95
+++ b/src/MakeGeoidGrid.f95
@@ -3,22 +3,22 @@ subroutine MakeGeoidGrid(geoid, cilm, lmax, r0pot, GM, PotRef, omega, r, &
                          a, f, extend, exitstatus)
 !------------------------------------------------------------------------------
 !
-!   This subrouine will calculate the height to an equipotential surface with
+!   This subroutine will calculate the height of an equipotential surface with
 !   respect to a spherical reference radius R for a body rotating with angular
 !   rotation rate OMEGA. This method uses a first-, second-, or third-order
 !   Taylor series expansion of the potential, evaluated at radius R. The output
 !   gridype is specificied by GRIDTYPE, which can be either Cartesian 2D,
 !   Guass-Legendre quadrature, or Driscoll and Healy. If the optional
-!   parameters A and F are specified, the geoid will be referenced to a
-!   flattened ellispoid with semimajor axis A and flattening F.
+!   parameters A and F are specified, the geoid heights will be with respect
+!   to a flattened ellipsoid with semimajor axis A and flattening F.
 !
 !   Note that this routine is only strictly valid when the geoid is above the
-!   surface! To calculated the height of the geoid when it is below the
+!   surface. To calculated the height of the geoid when it is below the
 !   surface, one would need to know the density structure of the planet.
 !   Furthermore, the calculation of the potential (and its derivatives) is
 !   only strictly valid when R lies above the maximum radius of the planet.
 !
-!   Latitude is geocentric latitude.
+!   Latitude is geocentric spherical latitude.
 !
 !   Calling Parameters
 !
@@ -394,7 +394,7 @@ subroutine MakeGeoidGrid(geoid, cilm, lmax, r0pot, GM, PotRef, omega, r, &
 
     end select
 
-    ! Create Grid B 
+    ! Create Grid B
     do l = 0, lmax_comp
         cilm2(1:2,l+1,1:l+1) = -(GM / r**2) * dble(l+1) &
                                * cilm1(1:2,l+1,1:l+1) * (r0pot / r)**l

--- a/src/MakeGravGradGridDH.f95
+++ b/src/MakeGravGradGridDH.f95
@@ -4,21 +4,21 @@ subroutine MakeGravGradGridDH(cilm, lmax, gm, r0, a, f, vxx, vyy, vzz, vxy, &
 !------------------------------------------------------------------------------
 !
 !   Given the 4pi normalized gravitational spherical harmonic coefficients
-!   CILM, this subroutine will compute 2D Driscol and Healy sampled grids of
-!   the six components of the gravity "gradient" tensor in a local
+!   CILM, this subroutine will compute 2D Driscoll and Healy sampled grids of
+!   the six components of the gravitational "gradient" tensor in a local
 !   north-oriented reference frame:
 !
 !       (Vxx,   Vxy,    Vxz)
 !       (Vyx,   Vyy,    Vyz)
 !       (Vzx,   Vzy,    Vzz)
-!   
+!
 !   where X points NORTH, Y points WEST, and Z points UPWARD. The gravitational
 !   potential is defined as
 !
 !       V = GM/r Sum_{l=0}^LMAX (R0/r)^l Sum_{m=-l}^l C_{lm} Y_{lm},
 !
-!   Laplace's equation implies that Vxx + Vyy + Vzz = 0, and the gravity tensor
-!   is symmetric. The components are calculated according to eq. 1 in
+!   Laplace's equation implies that Vxx + Vyy + Vzz = 0, and the gravitational
+!   tensor is symmetric. The components are calculated according to eq. 1 in
 !   Petrovskaya and Vershkov (2006, J. Geod, 80, 117-127), which is based on
 !   eq. 3.28 in Reed (1973, Ohio State Univ., Dept. Geod. Sci., Rep. 201,
 !   Columbus, OH). Note that Reed's equations are in terms of latitude, and
@@ -34,7 +34,7 @@ subroutine MakeGravGradGridDH(cilm, lmax, gm, r0, a, f, vxx, vyy, vzz, vxy, &
 !   where r, t, p stand for radius, theta, and phi, and subscripts on V denote
 !   partial derivatives.
 !
-!   The output grid are in units of 1/s and are cacluated on a flattened
+!   The output grid are in units of 1/s and are calxuated on a flattened
 !   ellipsoid with semi-major axis A and flattening F. To obtain units of
 !   Eotvos (10^-9 s^-1), multiply by 10^9.
 !
@@ -594,7 +594,7 @@ subroutine MakeGravGradGridDH(cilm, lmax, gm, r0, a, f, vxx, vyy, vzz, vxy, &
                         * (-lmax_comp-1) * prefactor(lmax_comp) * lmax_comp
         coefrp(lmax_comp+1) = coefrp(lmax_comp+1) + tempc
 
-        dpl2 = -(lmax_comp*(lmax_comp+1)-(lmax_comp**2)) * pmm 
+        dpl2 = -(lmax_comp*(lmax_comp+1)-(lmax_comp**2)) * pmm
         tempc = cmplx(cilm(1,lmax_comp+1,lmax_comp+1), &
                         - cilm(2,lmax_comp+1,lmax_comp+1), dp) * dpl2 &
                         * prefactor(lmax_comp)
@@ -923,7 +923,7 @@ subroutine MakeGravGradGridDH(cilm, lmax, gm, r0, a, f, vxx, vyy, vzz, vxy, &
             pm1 = z * ff1(m1+1,m1) * pm2
             tempc = cmplx(cilm(1,m1+1,m1), - cilm(2,m1+1,m1), dp) * pm1 &
                     * (-m-2) * prefactor(m+1)  ! (m+1,m)
-            coefr(m1) = coefr(m1) + tempc 
+            coefr(m1) = coefr(m1) + tempc
             coefrs(m1) = coefrs(m1) - tempc ! fsymsign = -1
 
             tempc = cmplx(cilm(1,m1+1,m1), - cilm(2,m1+1,m1), dp) * pm1 &
@@ -1018,7 +1018,7 @@ subroutine MakeGravGradGridDH(cilm, lmax, gm, r0, a, f, vxx, vyy, vzz, vxy, &
                 coeftps(m1) = coeftps(m1) - tempc * fsymsign(l1,m1)
 
                 dpl2 = -(l * l1 -(m**2)/u**2) * p + z * dpl
-                dpl2s = dpl2 * fsymsign(l1,m1) 
+                dpl2s = dpl2 * fsymsign(l1,m1)
                 tempc = cmplx(cilm(1,l1,m1), - cilm(2,l1,m1), dp) &
                         * prefactor(l)
                 coeftt(m1) = coeftt(m1) + tempc * dpl2

--- a/src/PythonWrapper.f95
+++ b/src/PythonWrapper.f95
@@ -1689,9 +1689,9 @@
 
     subroutine pyMakeGravGridDH(exitstatus,cilm,lmax,gm,r0,a,f,rad,theta,phi,&
                                 total,pot,n,sampling,lmax_calc,omega,&
-                                normal_gravity,extend,phi_d0,phi_d1,total_d0,&
-                                total_d1,rad_d0,rad_d1,cilm_d0,cilm_d1,&
-                                cilm_d2,theta_d0,theta_d1,pot_d0,pot_d1)
+                                normal_gravity,normal_gravity_gm,extend,phi_d0,&
+                                phi_d1,total_d0,total_d1,rad_d0,rad_d1,cilm_d0,&
+                                cilm_d1,cilm_d2,theta_d0,theta_d1,pot_d0,pot_d1)
         use shtools, only: MakeGravGridDH
         use ftypes
         implicit none
@@ -1725,10 +1725,12 @@
         integer(int32),intent(in) :: lmax_calc
         real(dp),intent(in) :: omega
         integer(int32),intent(in) :: normal_gravity
+        real(dp),intent(in)  :: normal_gravity_gm
         integer(int32),intent(in) :: extend
         call MakeGravGridDH(cilm,lmax,gm,r0,a,f,rad,theta,phi,total,n,&
                             sampling=sampling,lmax_calc=lmax_calc,omega=omega,&
-                            normal_gravity=normal_gravity,pot=pot,&
+                            normal_gravity=normal_gravity,&
+                            normal_gravity_gm=normal_gravity_gm,pot=pot,&
                             extend=extend,exitstatus=exitstatus)
     end subroutine pyMakeGravGridDH
 

--- a/src/SHTOOLS.f95
+++ b/src/SHTOOLS.f95
@@ -825,11 +825,12 @@ module SHTOOLS
 
         subroutine MakeGravGridDH(cilm, lmax, gm, r0, a, f, rad, theta, phi, &
                                   total, n, sampling, lmax_calc, omega, &
-                                  normal_gravity, pot, extend, exitstatus)
+                                  normal_gravity, normal_gravity_gm, pot, &
+                                  extend, exitstatus)
             use iso_fortran_env, only: int32, dp=>real64
             real(dp), intent(in) :: cilm(:,:,:), gm, r0, a, f
             real(dp), intent(out) :: rad(:,:), theta(:,:), phi(:,:), total(:,:)
-            real(dp), intent(in), optional :: omega
+            real(dp), intent(in), optional :: omega, normal_gravity_gm
             real(dp), intent(out), optional :: pot(:,:)
             integer(int32), intent(in) :: lmax
             integer(int32), intent(out) :: n

--- a/src/fdoc/makegravgriddh.md
+++ b/src/fdoc/makegravgriddh.md
@@ -4,18 +4,18 @@ Create 2D cylindrical maps on a flattened and rotating ellipsoid of all three co
 
 # Usage
 
-call MakeGravGridDH (`cilm`, `lmax`, `gm`, `r0`, `a`, `f`, `rad`, `theta`, `phi`, `total`, `n`, `sampling`, `lmax_calc`, `omega`, `normal_gravity`, `pot_grid`, `extend`, `exitstatus`)
+call MakeGravGridDH (`cilm`, `lmax`, `gm`, `r0`, `a`, `f`, `rad`, `theta`, `phi`, `total`, `n`, `sampling`, `lmax_calc`, `omega`, `normal_gravity`, `normal_gravity_gm`, `pot_grid`, `extend`, `exitstatus`)
 
 # Parameters
 
 `cilm` : input, real(dp), dimension (2, `lmax`+1, `lmax`+1)
-:   The real 4-pi normalized gravitational potential spherical harmonic coefficients. The coefficients c1lm and c2lm refer to the cosine and sine coefficients, respectively, with `c1lm=cilm(1,l+1,m+1)` and `c2lm=cilm(2,l+1,m+1)`.
+:   The real 4-pi normalized gravitational potential spherical harmonic coefficients. The coefficients c1lm and c2lm correspond to the cosine and sine coefficients, respectively, with `c1lm=cilm(1,l+1,m+1)` and `c2lm=cilm(2,l+1,m+1)`.
 
 `lmax` : input, integer(int32)
 :   The maximum spherical harmonic degree of the coefficients `cilm`. This determines the number of samples of the output grids, `n=2lmax+2`, and the latitudinal sampling interval, `90/(lmax+1)`.
 
 `gm` : input, real(dp)
-:   The gravitational constant multiplied by the mass of the planet.
+:   The gravitational constant multiplied by the mass of the planet of the gravitational potential model.
 
 `r0`: input, real(dp)
 :   The reference radius of the spherical harmonic coefficients.
@@ -27,7 +27,7 @@ call MakeGravGridDH (`cilm`, `lmax`, `gm`, `r0`, `a`, `f`, `rad`, `theta`, `phi`
 :   The flattening of the reference ellipsoid: `f=(R_equator-R_pole)/R_equator`.
 
 `rad` : output, real(dp), dimension (nlat, nlong)
-:   A 2D map of radial component of the gravity field that conforms to the sampling theorem of Driscoll and Healy (1994). If `sampling` is 1, the grid is equally sampled and is dimensioned as (`n` by `n`), where `n` is `2lmax+2`. If sampling is 2, the grid is equally spaced and is dimensioned as (`n` by 2`n`). The first latitudinal band of the grid corresponds to 90 N, the latitudinal sampling interval is 180/`n` degrees, and the default behavior is to exclude the latitudinal band for 90 S. The first longitudinal band of the grid is 0 E, by default the longitudinal band for 360 E is not included, and the longitudinal sampling interval is 360/`n` for an equally sampled and 180/`n` for an equally spaced grid, respectively. If `extend` is 1, the longitudinal band for 360 E and the latitudinal band for 90 S will be included, which increases each of the dimensions of the grid by 1.
+:   A 2D map of the radial component of the gravity field that conforms to the sampling theorem of Driscoll and Healy (1994). If `sampling` is 1, the grid is equally sampled and is dimensioned as (`n` by `n`), where `n` is `2lmax+2`. If sampling is 2, the grid is equally spaced and is dimensioned as (`n` by 2`n`). The first latitudinal band of the grid corresponds to 90 N, the latitudinal sampling interval is 180/`n` degrees, and the default behavior is to exclude the latitudinal band for 90 S. The first longitudinal band of the grid is 0 E, by default the longitudinal band for 360 E is not included, and the longitudinal sampling interval is 360/`n` for an equally sampled and 180/`n` for an equally spaced grid, respectively. If `extend` is 1, the longitudinal band for 360 E and the latitudinal band for 90 S will be included, which increases each of the dimensions of the grid by 1.
 
 `theta` : output, real(dp), dimension (nlat, nlong)
 :   A 2D equally sampled or equally spaced grid of the theta component of the gravity field.
@@ -51,10 +51,13 @@ call MakeGravGridDH (`cilm`, `lmax`, `gm`, `r0`, `a`, `f`, `rad`, `theta`, `phi`
 :   The angular rotation rate of the planet.
 
 `normal_gravity` : optional, input, integer(int32)
-:   If 1, the normal gravity (the gravitational acceleration on the ellipsoid) will be subtracted from the total gravity, yielding the "gravity disturbance." This is done using Somigliana's formula (after converting geocentric to geodetic coordinates).
+:   If 1, the normal gravity (the gravitational acceleration on the rotating ellipsoid) will be subtracted from the total gravity, yielding the "gravity disturbance." This is done using Somigliana's formula (after converting geocentric to geodetic coordinates).
+
+`normal_gravity_gm` : optional, input, real(dp)
+:   The GM to use when computing the normal gravity. If not specified, the GM of the gravitational potential model will be used.
 
 `pot_grid` : output, real(dp), dimension (nlat, nlong)
-:   A 2D equally sampled or equaly spaced grid of the gravitational potential.
+:   A 2D equally sampled or equally spaced grid of the gravity potential.
 
 `extend` : input, optional, integer(int32), default = 0
 :   If 1, compute the longitudinal band for 360 E and the latitudinal band for 90 S. This increases each of the dimensions of the grids by 1.
@@ -64,7 +67,7 @@ call MakeGravGridDH (`cilm`, `lmax`, `gm`, `r0`, `a`, `f`, `rad`, `theta`, `phi`
 
 # Description
 
-`MakeGravGridDH` will create 2-dimensional cylindrical maps from the spherical harmonic coefficients `cilm`, equally sampled (`n` by `n`) or equally spaced (`n` by 2`n`) in latitude and longitude, for the three vector components of the gravity vector (gravitational force + centrifugal force), the magnitude of the gravity vector, and the gravity potential (all using geocentric coordinates). The gravitational potential is given by
+`MakeGravGridDH` will compute 2-dimensional cylindrical maps of the three spherical vector components, the vector magnitude, and the potential of either the gravity (gravitational force + centrifugal force) or gravitation from the input spherical harmonic coefficients `cilm`. The grids are equally sampled (`n` by `n`) or equally spaced (`n` by 2`n`) in latitude and longitude, where latitude is geocentric spherical. The gravitational potential is given by
 
 `V = GM/r Sum_{l=0}^lmax (r0/r)^l Sum_{m=-l}^l C_{lm} Y_{lm}`,
 
@@ -72,9 +75,9 @@ and the gravitational acceleration is
 
 `B = Grad V`.
 
-The coefficients are referenced to a radius `r0`, and the function is computed on a flattened ellipsoid with semi-major axis `a` (i.e., the mean equatorial radius) and flattening `f`. All grids are output in SI units, and the sign of the radial components is positive when directed upwards.
+The coefficients are referenced to a radius `r0`, and the function is computed on a flattened ellipsoid with semi-major axis `a` and flattening `f`. All grids are output in SI units, and the sign of the radial components is positive when directed upwards.
 
-If the optional angular rotation rate `omega` is specified, the potential and gravity vectors will be calculated in a body-fixed rotating reference frame and will include the contribution from the centrifugal force. If `normal_gravity` is set to 1, the normal gravity will be removed from the magnitude of the gravity vector, yielding the gravity disturbance. To convert m/s^2 to mGals, multiply the gravity grids by 10^5.
+If the optional angular rotation rate `omega` is specified, the potential and gravity vectors will be calculated in a body-fixed rotating reference frame and will include the contribution from the centrifugal force. If not specified, the output grids will correspond to the external gravitation without the centrifugal force. If `normal_gravity` is set to 1, the normal gravity will be removed from the magnitude of the gravity vector, yielding the gravity disturbance. To convert from m/s^2 to mGals, multiply the gravity grids by 10^5.
 
 The calculated values should be considered exact only when the radii on the ellipsoid are greater than the maximum radius of the planet (the potential coefficients are simply downward/upward continued in the spectral domain). The components of the gravity vector are calculated using spherical coordinates whose origin is at the center of the planet, and the components are thus not normal to the reference ellipsoid.
 

--- a/src/pydoc/pymakegravgriddh.md
+++ b/src/pydoc/pymakegravgriddh.md
@@ -1,10 +1,10 @@
 # MakeGravGridDH()
 
-Create 2D cylindrical maps on a flattened and rotating ellipsoid of all three components of the gravity, the gravity disturbance, and the gravitational potential.
+Create 2D cylindrical maps on a flattened and rotating ellipsoid of all three components of the gravity, the gravity disturbance, and the gravity potential.
 
 # Usage
 
-rad, theta, phi, total, pot = MakeGravGridDH (cilm, gm, r0, [a, f, lmax, sampling, lmax_calc, omega, normal_gravity, extend])
+rad, theta, phi, total, pot = MakeGravGridDH (cilm, gm, r0, [a, f, lmax, sampling, lmax_calc, omega, normal_gravity, normal_gravity_gm, extend])
 
 # Returns
 
@@ -21,15 +21,15 @@ total : float, dimension (nlat, nlong)
 :   A 2D equally sampled or equally spaced grid of the magnitude of the gravity acceleration.
 
 pot : float, dimension (nlat, nlong)
-:   A 2D equally sampled or equally spaced grid of the gravitational potential.
+:   A 2D equally sampled or equally spaced grid of the gravity potential.
 
 # Parameters
 
 cilm : float, dimension (2, lmaxin+1, lmaxin+1)
-:   The real 4-pi normalized gravitational potential spherical harmonic coefficients. The coefficients c1lm and c2lm refer to the cosine and sine coefficients, respectively, with c1lm=cilm[0,l,m] and c2lm=cilm[1,l,m].
+:   The real 4-pi normalized gravitational potential spherical harmonic coefficients. The coefficients c1lm and c2lm correspond to the cosine and sine coefficients, respectively, with c1lm=cilm[0,l,m] and c2lm=cilm[1,l,m].
 
 gm : float
-:   The gravitational constant multiplied by the mass of the planet.
+:   The gravitational constant multiplied by the mass of the gravitational potential model.
 
 r0: float
 :   The reference radius of the spherical harmonic coefficients.
@@ -53,14 +53,17 @@ omega : optional, float, default = 0
 :   The angular rotation rate of the planet.
 
 normal_gravity : optional, integer, default = 1
-:   If 1, the normal gravity (the gravitational acceleration on the ellipsoid) will be subtracted from the total gravity, yielding the "gravity disturbance." This is done using Somigliana's formula (after converting geocentric to geodetic coordinates).
+:   If 1, the normal gravity (the gravitational acceleration on the rotating ellipsoid) will be subtracted from the total gravity, yielding the "gravity disturbance." This is done using Somigliana's formula (after converting geocentric to geodetic coordinates).
+
+normal_gravity_gm : optional, float, default = gm
+:   The GM to use when computing the normal gravity. If not specified, the GM of the gravitational potential model will be used.
 
 extend : input, optional, bool, default = False
 :   If True, compute the longitudinal band for 360 E and the latitudinal band for 90 S. This increases each of the dimensions of griddh by 1.
 
 # Description
 
-MakeGravGridDH will create 2-dimensional cylindrical maps from the spherical harmonic coefficients cilm, equally sampled (n by n) or equally spaced (n by 2n) in latitude and longitude, for the three vector components of the gravity vector (gravitational force + centrifugal force), the magnitude of the gravity vector, and the gravity potential (all using geocentric coordinates). The gravitational potential is given by
+MakeGravGridDH will compute 2-dimensional cylindrical maps of the three spherical vector components, the vector magnitude, and the potential of either the gravity (gravitational force + centrifugal force) or gravitation from the input spherical harmonic coefficients cilm. The grids are equally sampled (n by n) or equally spaced (n by 2n) in latitude and longitude, where latitude is geocentric spherical. The gravitational potential is given by
 
 `V = GM/r Sum_{l=0}^lmax (r0/r)^l Sum_{m=-l}^l C_{lm} Y_{lm}`,
 
@@ -68,9 +71,9 @@ and the gravitational acceleration is
 
 `B = Grad V`.
 
-The coefficients are referenced to a radius r0, and the function is computed on a flattened ellipsoid with semi-major axis a (i.e., the mean equatorial radius) and flattening f. All grids are output in SI units, and the sign of the radial components is positive when directed upwards.
+The coefficients are referenced to a radius r0, and the function is computed on a flattened ellipsoid with semi-major axis a and flattening f. All grids are output in SI units, and the sign of the radial components is positive when directed upwards.
 
-If the optional angular rotation rate omega is specified, the potential and gravity vectors will be calculated in a body-fixed rotating reference frame and will include the contribution from the centrifugal force. If normal_gravity is set to 1, the normal gravity will be removed from the magnitude of the gravity vector, yielding the gravity disturbance. To convert m/s^2 to mGals, multiply the gravity grids by 10^5.
+If the optional angular rotation rate omega is specified, the potential and gravity vectors will be calculated in a body-fixed rotating reference frame and will include the contribution from the centrifugal force. If not specified, the output grids will correspond to the external gravitation without the centrifugal force. If normal_gravity is set to 1, the normal gravity will be removed from the magnitude of the gravity vector, yielding the gravity disturbance. To convert from m/s^2 to mGals, multiply the gravity grids by 10^5.
 
 The calculated values should be considered exact only when the radii on the ellipsoid are greater than the maximum radius of the planet (the potential coefficients are simply downward continued in the spectral domain). The components of the gravity vector are calculated using spherical coordinates whose origin is at the center of the planet, and the components are thus not normal to the reference ellipsoid.
 

--- a/src/pyshtools.pyf
+++ b/src/pyshtools.pyf
@@ -1437,7 +1437,7 @@ python module _SHTOOLS
             integer(int32),optional,intent(in),depend(lmax),intent(hide),check(lmax>=0) :: coef_d0 = lmax+1
         end subroutine SphericalCapCoef
 
-        subroutine MakeGravGridDH(exitstatus,cilm,lmax,gm,r0,a,f,rad,theta,phi,total,pot,n,sampling,lmax_calc,omega,normal_gravity,extend,phi_d0,phi_d1,total_d0,total_d1,rad_d0,rad_d1,cilm_d0,cilm_d1,cilm_d2,theta_d0,theta_d1,pot_d0,pot_d1)
+        subroutine MakeGravGridDH(exitstatus,cilm,lmax,gm,r0,a,f,rad,theta,phi,total,pot,n,sampling,lmax_calc,omega,normal_gravity,normal_gravity_gm,extend,phi_d0,phi_d1,total_d0,total_d1,rad_d0,rad_d1,cilm_d0,cilm_d1,cilm_d2,theta_d0,theta_d1,pot_d0,pot_d1)
             threadsafe
             fortranname pymakegravgriddh
             integer, parameter :: dp = selected_real_kind(p=15)
@@ -1459,6 +1459,7 @@ python module _SHTOOLS
             integer(int32),optional,intent(in),depend(lmax) :: lmax_calc = lmax
             real(dp),optional,intent(in) :: omega = 0.0
             integer(int32),optional,intent(in) :: normal_gravity = 1
+            real(dp),optional,intent(in),depend(gm) :: normal_gravity_gm = gm
             integer(int32),optional,intent(in) :: extend = 0
             integer(int32),intent(in),intent(hide),depend(lmax,extend),check(lmax>=0) :: phi_d0 = 2*(lmax+1)+extend
             integer(int32),intent(in),intent(hide),depend(sampling,lmax,extend) :: phi_d1 = sampling*2*(lmax+1)+extend


### PR DESCRIPTION
This PR adds functional support of [boule](https://www.fatiando.org/boule/latest/) Ellipsoid classes in many pyshtools routines. To use this PR, you must first install this PR for boule: https://github.com/fatiando/boule/pull/192

### Create a grid of an ellipsoid using one of the boule predefined ellipsoids:
```
grid = pysh.SHGrid.from_ellipsoid(ellipsoid=boule.Mars2009, lmax=100)
grid.plot()
```
### Create an area-weighted histogram of spherical elevations with respect to an ellipsoid:
```
grid = pysh.datasets.Mars.MOLA_shape().expand()
hist, bin_edges = grid.histogram(ellipsoid=boule.Mars2009)
fig, ax = grid.plot_histogram(ellipsoid=boule.Mars2009, bins=100)
```
### Plot spherical heights with respect to an ellipsoid
```
fig, ax = grid.plot(ellipsoid=boule.Mars2009, colorbar='bottom')
figure = grid.plotgmt(ellipsoid=boule.Mars2009, colorbar='right')
figure.show()
```
### Create grids of the spherical gravity vector components, gravity disturbance, and gravity potential  on a rotating ellipsoid
```
clm = pysh.datasets.Mars.MRO120F()
grids = clm.expand(ellipsoid=boule.Mars2009)
grids.plot()
```
### Create grids of the gravity gradient tensor on a flattened ellipsoid
```
grids = clm.tensor(ellipsoid=boule.Mars2009, degree0=True)
grids.plot()
```
### Create a grid of the geoid height with respect to an ellipsoid
```
geoid = clm.geoid(boule.Mars2009)
geoid.plot()
```
### Create grids of the magnetic field tensor on a flattened ellipsoid
```
glm = pysh.datasets.Mars.Langlais2019()
grids = glm.tensor(ellipsoid=boule.Mars2009)
grids.plot()
```

# Notes
* Almost all of the real calculations are performed using pre-existing pyshtools routines (fortran or python). The boule ellipsoids are used only to obtain ellipsoid parameters such as `a`, `b`, `c`, `f`, `omega`, `GM`, `reference_normal_gravity_potential`.
* Neither boule nor pyshtools compute the normal gravity of a triaxial ellipsoid (yet).
* The vector components of the gravity and magnetic field are for spherical components, r-hat, theta-hat, and phi-hat. r-hat and theta-hat are not normal and tangent to the ellipsoid. The transformation from spherical components to geodetic components will be implemented in a future release or PR.
* All heights above the ellipsoid are spherical heights, and not geodetic (ellipsoidal) heights that are measured normal to the ellipsoid.
* `SHGravCoeff.geoid()` is not yet working for the `Sphere` class. 
