### PR TITLE
Add new LDEM_pa shape model for the Moon

### DIFF
--- a/docs/pages/mydoc/python-datasets.md
+++ b/docs/pages/mydoc/python-datasets.md
@@ -76,7 +76,7 @@ The following is the list of implemented datasets. Additional older or deprecate
 
 | Dataset | Description |
 | ---------- | ----------- |
-| LOLA_shape_pa | 5759 degree and order spherical harmonic model of the shape of Earth's Moon in a principal axis coordinate system (Wieczorek 2024). |
+| LDEM_shape_pa | 11519 degree and order spherical harmonic model of the shape of Earth's Moon in a principal axis coordinate system (Wieczorek 2024). |
 | LOLA_shape | 5759 degree and order spherical harmonic model of the shape of Earth's Moon in mean Earth/polar axis coordinate system (Wieczorek 2024). |
 | GRGM900C | GSFC 900 degree and order spherical harmonic model of the gravitational potential of the Moon. This model applies a Kaula constraint for degrees greater than 600 (Lemoine et al. 2014). |
 | GRGM1200B | GSFC 1200 degree and order spherical harmonic model of the gravitational potential of the Moon (Goossens et al. 2020). This model applies a Kaula constraint for degrees greater than 600. |

--- a/pyshtools/datasets/Moon/__init__.py
+++ b/pyshtools/datasets/Moon/__init__.py
@@ -3,7 +3,7 @@ Datasets related to Earth's Moon.
 
 Shape
 -----
-LOLA_shape_pa     :  Wieczorek (2024)
+LDEM_shape_pa     :  Wieczorek (2024)
 LOLA_shape        :  Wieczorek (2024)
 
 Gravity
@@ -31,18 +31,19 @@ from ...constants.Moon import angular_velocity as _omega
 from . import historical  # noqa: F401
 
 
-def LOLA_shape_pa(lmax=719):
+def LDEM_shape_pa(lmax=719):
     '''
-    LOLA_shape_pa is a spherical harmonic model of the shape of Earth's Moon in
+    LDEM_shape_pa is a spherical harmonic model of the shape of Earth's Moon in
     a principal axis coordinate system based on LOLA laser altimetry data
-    obtained by the Lunar Reconaissance Orbiter mission. The maximum spherical
-    harmonic degree of the model is 5759, which has an effective spatial
-    resolution of 64 pixels per degree. Three lower resolution models are
-    available in this archive (with lmax of 719, 1439 and 2879), and only the
-    smallest that is required by the user input lmax will be downloaded. If
-    lmax is not specified, the lowest resolution model (719) will be returned.
-    If a negative value for lmax is specified, the maximum resolution model
-    will be returned. The coefficients are in units of meters.
+    obtained by the Lunar Reconaissance Orbiter mission and terrain camera data
+    from the Kaguya mission. The maximum spherical harmonic degree of the model
+    is 11519, which has an effective spatial resolution of 128 pixels per
+    degree. Four lower resolution models are available in this archive (with
+    lmax of 719, 1439, 2879, 5759), and only the smallest that is required by
+    the user input lmax will be downloaded. If lmax is not specified, the
+    lowest resolution model (719) will be returned. If a negative value for
+    lmax is specified, the maximum resolution model will be returned. The
+    coefficients are in units of meters.
 
     This shape model uses the same coordinate system as most lunar gravity
     models. For a mean Earth/polar axis model, use LOLA_shape instead.
@@ -55,39 +56,45 @@ def LOLA_shape_pa(lmax=719):
     Reference
     ---------
     Wieczorek, M. (2024). Spherical harmonic models of the shape of the Moon
-        (principal axis coordinate system) [LOLA] (1.0.1) [Data set]. Zenodo.
-        https://doi.org/10.5281/zenodo.10820750
-    LRO LOLA Team (2013). LRO-L-LOLA-4-GDR-V1.0, NASA Planetary Data System.
+        (principal axis coordinate system) [LDEM128] (1.0.0) [Data set].
+        Zenodo. https://doi.org/10.5281/zenodo.11533784
+    Neumann, G. (2024). LOLA MOON_PA gridded dataset [Data set]. NASA Goddard
+        Space Flight Center Planetary Geodesy Data Archive.
+        doi:10.60903/LOLA_PA.
     '''
     archive = _create(
         path=_os_cache('pyshtools'),
-        base_url="doi:10.5281/zenodo.10820750",
+        base_url="doi:10.5281/zenodo.11533784",
         registry={
-            "Moon_LOLA_shape_pa_5759.bshc.gz": "sha256:1569338a88475e184ac8b7424327b0e03cb1f8f0a3cec70bd9bfe41635f68671",  # noqa: E501
-            "Moon_LOLA_shape_pa_2879.bshc.gz": "sha256:6ee87880956fdbdf85f9c0b2e9996514735198fbcb19fd0d0c7881bf50c50496",  # noqa: E501
-            "Moon_LOLA_shape_pa_1439.bshc.gz": "sha256:6c4619f845c9902d999879cbf6956c368290a17fc2887d41267800aade386c56",  # noqa: E501
-            "Moon_LOLA_shape_pa_719.bshc.gz": "sha256:71877e8c1dd80205941b6ca0e7df73943abc52be125d1d8cc76bea2dcee5942b",  # noqa: E501
+            "Moon_LDEM128_shape_pa_11519.sh.gz": "sha256:a819b6e7f153df63632f035647e6ad6319c698e6d264228e7c5e2646afb787ad",  # noqa: E501
+            "Moon_LDEM128_shape_pa_5759.sh.gz": "sha256:c3aaca21de1355e8e235104432d2d5ac3f76ef43717da69b313e9a1a44b6c7e3",  # noqa: E501
+            "Moon_LDEM128_shape_pa_2879.sh.gz": "sha256:fa52e88be6db0f1b8e3b8cf6785c4c89904581aa910a3153671c65a33e462b50",  # noqa: E501
+            "Moon_LDEM128_shape_pa_1439.sh.gz": "sha256:093c46ccc753a40e8041be6106334375f38e3f828c57cc28994799406f7703b4",  # noqa: E501
+            "Moon_LDEM128_shape_pa_719.sh.gz": "sha256:b3a3842363f91d95b992831f77a6ff9aacaae83bf0a93123372aa142149298c3",  # noqa: E501
             },
         )
 
     if lmax < 0:
-        lmax = 5759
+        lmax = 11519
 
     if lmax >= 0 and lmax <= 719:
-        fname = archive.fetch("Moon_LOLA_shape_pa_719.bshc.gz",
+        fname = archive.fetch("Moon_LDEM128_shape_pa_719.sh.gz",
                               downloader=_DOIDownloader(progressbar=True))
     elif lmax > 719 and lmax <= 1439:
-        fname = archive.fetch("Moon_LOLA_shape_pa_1439.bshc.gz",
+        fname = archive.fetch("Moon_LDEM128_shape_pa_1439.sh.gz",
                               downloader=_DOIDownloader(progressbar=True))
     elif lmax > 1439 and lmax <= 2879:
-        fname = archive.fetch("Moon_LOLA_shape_pa_2879.bshc.gz",
+        fname = archive.fetch("Moon_LDEM128_shape_pa_2879.sh.gz",
+                              downloader=_DOIDownloader(progressbar=True))
+    elif lmax > 2879 and lmax <= 5759:
+        fname = archive.fetch("Moon_LDEM128_shape_pa_5759.sh.gz",
                               downloader=_DOIDownloader(progressbar=True))
     else:
-        fname = archive.fetch("Moon_LOLA_shape_pa_5759.bshc.gz",
+        fname = archive.fetch("Moon_LDEM128_shape_pa_11519.sh.gz",
                               downloader=_DOIDownloader(progressbar=True))
-        lmax = min(lmax, 5759)
+        lmax = min(lmax, 11519)
 
-    return _SHCoeffs.from_file(fname, lmax=lmax, name='LOLA_shape_pa (Moon)',
+    return _SHCoeffs.from_file(fname, lmax=lmax, name='LDEM_shape_pa (Moon)',
                                units='m', format='bshc')
 
 
@@ -106,7 +113,7 @@ def LOLA_shape(lmax=719):
 
     This shape model should not be used in conjuction with most lunar gravity
     models, which use a principal axis coordinate system. For a principal axis
-    model, use LOLA_shape_pa instead.
+    model, use LDEM_shape_pa instead.
 
     Parameters
     ----------
@@ -393,6 +400,6 @@ def GL1500E(lmax=1500):
                                    name='GL1500E (Moon)', encoding='utf-8')
 
 
-__all__ = ['LOLA_shape_pa', 'LOLA_shape', 'T2015_449', 'Ravat2020', 'GRGM900C',
+__all__ = ['LDEM_shape_pa', 'LOLA_shape', 'T2015_449', 'Ravat2020', 'GRGM900C',
            'GRGM1200B', 'GRGM1200B_RM1_1E0', 'GL0900D', 'GL1500E',
            'historical']

--- a/pyshtools/datasets/Moon/historical/shape.py
+++ b/pyshtools/datasets/Moon/historical/shape.py
@@ -5,12 +5,73 @@ Shape
 -----
 GLTM2B (Clementine)       :  Smith et al. (1997)
 MoonTopo2600p (LRO)       :  Wieczorek (2015)
+LOLA_shape_pa (LRO)       :  Wieczorek (2024)
 '''
 from pooch import os_cache as _os_cache
 from pooch import retrieve as _retrieve
 from pooch import HTTPDownloader as _HTTPDownloader
 from pooch import DOIDownloader as _DOIDownloader
 from ....shclasses import SHCoeffs as _SHCoeffs
+
+
+def LOLA_shape_pa(lmax=719):
+    '''
+    LOLA_shape_pa is a spherical harmonic model of the shape of Earth's Moon in
+    a principal axis coordinate system based on LOLA laser altimetry data
+    obtained by the Lunar Reconaissance Orbiter mission. The maximum spherical
+    harmonic degree of the model is 5759, which has an effective spatial
+    resolution of 64 pixels per degree. Three lower resolution models are
+    available in this archive (with lmax of 719, 1439 and 2879), and only the
+    smallest that is required by the user input lmax will be downloaded. If
+    lmax is not specified, the lowest resolution model (719) will be returned.
+    If a negative value for lmax is specified, the maximum resolution model
+    will be returned. The coefficients are in units of meters.
+
+    This shape model uses the same coordinate system as most lunar gravity
+    models. For a mean Earth/polar axis model, use LOLA_shape instead.
+
+    Parameters
+    ----------
+    lmax : int, optional, default = 719
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    Wieczorek, M. (2024). Spherical harmonic models of the shape of the Moon
+        (principal axis coordinate system) [LOLA] (1.0.1) [Data set]. Zenodo.
+        https://doi.org/10.5281/zenodo.10820750
+    LRO LOLA Team (2013). LRO-L-LOLA-4-GDR-V1.0, NASA Planetary Data System.
+    '''
+    archive = _create(
+        path=_os_cache('pyshtools'),
+        base_url="doi:10.5281/zenodo.10820750",
+        registry={
+            "Moon_LOLA_shape_pa_5759.bshc.gz": "sha256:1569338a88475e184ac8b7424327b0e03cb1f8f0a3cec70bd9bfe41635f68671",  # noqa: E501
+            "Moon_LOLA_shape_pa_2879.bshc.gz": "sha256:6ee87880956fdbdf85f9c0b2e9996514735198fbcb19fd0d0c7881bf50c50496",  # noqa: E501
+            "Moon_LOLA_shape_pa_1439.bshc.gz": "sha256:6c4619f845c9902d999879cbf6956c368290a17fc2887d41267800aade386c56",  # noqa: E501
+            "Moon_LOLA_shape_pa_719.bshc.gz": "sha256:71877e8c1dd80205941b6ca0e7df73943abc52be125d1d8cc76bea2dcee5942b",  # noqa: E501
+            },
+        )
+
+    if lmax < 0:
+        lmax = 5759
+
+    if lmax >= 0 and lmax <= 719:
+        fname = archive.fetch("Moon_LOLA_shape_pa_719.bshc.gz",
+                              downloader=_DOIDownloader(progressbar=True))
+    elif lmax > 719 and lmax <= 1439:
+        fname = archive.fetch("Moon_LOLA_shape_pa_1439.bshc.gz",
+                              downloader=_DOIDownloader(progressbar=True))
+    elif lmax > 1439 and lmax <= 2879:
+        fname = archive.fetch("Moon_LOLA_shape_pa_2879.bshc.gz",
+                              downloader=_DOIDownloader(progressbar=True))
+    else:
+        fname = archive.fetch("Moon_LOLA_shape_pa_5759.bshc.gz",
+                              downloader=_DOIDownloader(progressbar=True))
+        lmax = min(lmax, 5759)
+
+    return _SHCoeffs.from_file(fname, lmax=lmax, name='LOLA_shape_pa (Moon)',
+                               units='m', format='bshc')
 
 
 def MoonTopo2600p(lmax=2600):
@@ -74,4 +135,4 @@ def GLTM2B(lmax=70):
     return clm
 
 
-__all__ = ['GLTM2B', 'MoonTopo2600p']
+__all__ = ['GLTM2B', 'MoonTopo2600p', 'LOLA_shape_pa']

--- a/src/PlmBar.f95
+++ b/src/PlmBar.f95
@@ -17,7 +17,7 @@ subroutine PlmBar(p, lmax, z, csphase, cnorm, exitstatus)
 !   subsequent rescaling factors of sin(theta) will be directly applied to Plm,
 !   and then this number will be multipled by the old value of rescalem.
 !
-!   Temporary variables in saved in an allocated array. In order to explicitly
+!   Temporary variables are saved in an allocated array. In order to explicitly
 !   deallocate this memory, call this routine with a spherical harmonic degree
 !   of -1.
 !

--- a/src/PlmBar_d1.f95
+++ b/src/PlmBar_d1.f95
@@ -17,7 +17,7 @@ subroutine PlmBar_d1(p, dp1, lmax, z, csphase, cnorm, exitstatus)
 !   subsequent rescaling factors of sin(theta) will be directly applied to Plm,
 !   and then this number will be multipled by the old value of rescalem.
 !
-!   Temporary variables in saved in an allocated array. In order to explicitly
+!   Temporary variables are saved in an allocated array. In order to explicitly
 !   deallocate this memory, call this routine with a spherical harmonic degree
 !   of -1.
 !
@@ -162,7 +162,7 @@ subroutine PlmBar_d1(p, dp1, lmax, z, csphase, cnorm, exitstatus)
         end if
 
     end if
- 
+
     if (present(csphase)) then
         if (csphase == -1) then
             phase = -1
@@ -240,7 +240,7 @@ subroutine PlmBar_d1(p, dp1, lmax, z, csphase, cnorm, exitstatus)
                 k = k + 1
                 f1(k) = sqr(2*l+1) * sqr(2*l-1) / sqr(l+m) / sqr(l-m)
                 f2(k) = sqr(2*l+1) * sqr(l-m-1) * sqr(l+m-1) &
-                        / sqr(2*l-3) / sqr(l+m) / sqr(l-m) 
+                        / sqr(2*l-3) / sqr(l+m) / sqr(l-m)
             end do
 
             k = k + 2

--- a/src/PlmON.f95
+++ b/src/PlmON.f95
@@ -17,7 +17,7 @@ subroutine PlmON(p, lmax, z, csphase, cnorm, exitstatus)
 !   subsequent rescaling factors of sin(theta) will be directly applied to Plm,
 !   and then this number will be multipled by the old value of rescalem.
 !
-!   Temporary variables in saved in an allocated array. In order to explicitly
+!   Temporary variables are saved in an allocated array. In order to explicitly
 !   deallocate this memory, call this routine with a spherical harmonic degree
 !   of -1.
 !
@@ -206,7 +206,7 @@ subroutine PlmON(p, lmax, z, csphase, cnorm, exitstatus)
                 k = k + 1
                 f1(k) = sqr(2*l+1) * sqr(2*l-1) / sqr(l+m) / sqr(l-m)
                 f2(k) = sqr(2*l+1) * sqr(l-m-1) * sqr(l+m-1) &
-                            / sqr(2*l-3) / sqr(l+m) / sqr(l-m) 
+                            / sqr(2*l-3) / sqr(l+m) / sqr(l-m)
             end do
 
             k = k + 2

--- a/src/PlmON_d1.f95
+++ b/src/PlmON_d1.f95
@@ -17,7 +17,7 @@ subroutine PlmON_d1(p, dp1, lmax, z, csphase, cnorm, exitstatus)
 !   subsequent rescaling factors of sin(theta) will be directly applied to Plm,
 !   and then this number will be multipled by the old value of rescalem.
 !
-!   Temporary variables in saved in an allocated array. In order to explicitly
+!   Temporary variables are saved in an allocated array. In order to explicitly
 !   deallocate this memory, call this routine with a spherical harmonic degree
 !   of -1.
 !

--- a/src/PlmSchmidt.f95
+++ b/src/PlmSchmidt.f95
@@ -17,7 +17,7 @@ subroutine PlmSchmidt(p, lmax, z, csphase, cnorm, exitstatus)
 !   subsequent rescaling factors of sin(theta) will be directly applied to Plm,
 !   and then this number will be multipled by the old value of rescalem.
 !
-!   Temporary variables in saved in an allocated array. In order to explicitly
+!   Temporary variables are saved in an allocated array. In order to explicitly
 !   deallocate this memory, call this routine with a spherical harmonic
 !   degree of -1.
 !
@@ -50,9 +50,9 @@ subroutine PlmSchmidt(p, lmax, z, csphase, cnorm, exitstatus)
 !
 !   Notes:
 !
-!   1.  The employed normalization is the "geophysical convention." The integral
-!       of (PlmSchmidt*cos(m theta))**2 or (PlmSchmidt*sin (m theta))**2 over
-!       all space is 4 pi.
+!   1.  The employed normalization is the "Schmidt semi-normalized convention."
+!       The integral of (PlmSchmidt*cos(m theta))**2 or
+!       (PlmSchmidt*sin (m theta))**2 over all space is 4 pi/(2l+1).
 !   2.  The integral of PlmSchmidt**2 over (-1,1) is 2 * (2 - delta(0,m)) /
 !       (2l+1). If CNORM=1, then this is equal to 2/(2l+1).
 !   3.  The index of the array p corresponds to l*(l+1)/2 + m + 1. As such
@@ -273,7 +273,7 @@ subroutine PlmSchmidt(p, lmax, z, csphase, cnorm, exitstatus)
 
         ! Calculate P(m+1,m)
         k = kstart + m + 1
-        pm1 = z * sqr(2*m+1) * pm2 
+        pm1 = z * sqr(2*m+1) * pm2
         p(k) = pm1 * rescalem
 
         ! Calculate P(l,m)

--- a/src/PlmSchmidt_d1.f95
+++ b/src/PlmSchmidt_d1.f95
@@ -17,12 +17,12 @@ subroutine PlmSchmidt_d1(p, dp1, lmax, z, csphase, cnorm, exitstatus)
 !   subsequent rescaling factors of sin(theta) will be directly applied to Plm,
 !   and then this number will be multipled by the old value of rescalem.
 !
-!   Temporary variables in saved in an allocated array. In order to explicitly
+!   Temporary variables are saved in an allocated array. In order to explicitly
 !   deallocate this memory, call this routine with a spherical harmonic degree
 !   of -1.
 !
 !   Calling Parameters
-!   
+!
 !       IN
 !           lmax        Maximum spherical harmonic degree to compute.
 !           z           cos(colatitude) or sin(latitude).
@@ -55,9 +55,9 @@ subroutine PlmSchmidt_d1(p, dp1, lmax, z, csphase, cnorm, exitstatus)
 !
 !   1.  The employed normalization is the "Schmidt semi-normalized convention."
 !       The integral of (PlmSchmidt*cos(m theta))**2 or
-!       (PlmSchmidt*sin (m theta))**2 over all space is 4 pi/(2L+1).
+!       (PlmSchmidt*sin (m theta))**2 over all space is 4 pi/(2l+1).
 !   2.  The integral of PlmSchmidt**2 over (-1,1) is 2 * (2 - delta(0,m)) /
-!       (2L+1). If CNORM = 1, then this is equal to 2/(2l+1).
+!       (2l+1). If CNORM = 1, then this is equal to 2/(2l+1).
 !   3.  The index of the array p corresponds to l*(l+1)/2 + m + 1. As such
 !       the array p should be dimensioned as (lmax+1)*(lmax+2)/2 in the
 !       calling routine.
@@ -312,7 +312,7 @@ subroutine PlmSchmidt_d1(p, dp1, lmax, z, csphase, cnorm, exitstatus)
 
         ! Calculate P(m+1,m)
         k = kstart + m + 1
-        pm1 = z * sqr(2*m+1) * pm2 
+        pm1 = z * sqr(2*m+1) * pm2
         p(k) = pm1 * rescalem
         dp1(k) = (p(k-m-1) * sqr(2*m+1) - z * (m+1) * p(k)) / u**2
 


### PR DESCRIPTION
* Add the LDEM_pa ultrahigh degree shape model of the Moon (11519) to the datasets module, and move the previous LOLA_pa shape model to historical.



**Reminders**

- [ ] Base all changes on the `develop` branch: the `master` branch is used only when releasing new versions.
- [ ] Run `make check` to ensure that the python code follows standard formatting conventions.
- [ ] If adding new features, update the docstring to provide all information that is required to use the feature.
