### PR TITLE
in docs : fix inconsistencies in for csphase values

### DIFF
--- a/docs/pages/fortran/fortran-complex-spherical-harmonics.md
+++ b/docs/pages/fortran/fortran-complex-spherical-harmonics.md
@@ -123,8 +123,8 @@ Finally, SHTOOLS defines the *energy* of a function as the integral of its squar
 
 The above definitions of the Legendre functions and spherical harmonic functions do not include the Condon-Shortley phase factor of $$(-1)^m$$ that is often employed in the physics and seismology communities [Varshalovich et al. 1988, Dahlen and Tromp 1998]. Nevertheless, this phase can be included in most SHTOOLS routines by specifying the optional parameter
 
-* `csphase = 0` : exclude the Condon-Shortley phase factor (default)
-* `csphase = 1` : append the Condon-Shortley phase factor to the Legendre functions.
+* `csphase = 1` : exclude the Condon-Shortley phase factor (default)
+* `csphase = -1` : append the Condon-Shortley phase factor to the Legendre functions.
 
 The choice of the Condon-Shortley phase factor does not affect the numerical value of the power spectrum.
 

--- a/docs/pages/fortran/fortran-real-spherical-harmonics.md
+++ b/docs/pages/fortran/fortran-real-spherical-harmonics.md
@@ -112,8 +112,8 @@ Finally, SHTOOLS defines the *energy* of a function as the integral of its squar
 
 The above definitions of the Legendre functions and spherical harmonic functions do not include the Condon-Shortley phase factor of $$(-1)^m$$ that is often employed in the physics and seismology communities [Varshalovich et al. 1988, Dahlen and Tromp 1998]. Nevertheless, this phase can be included in most SHTOOLS routines by specifying the optional parameter
 
-* `csphase = 0` : exclude the Condon-Shortley phase factor (default)
-* `csphase = 1` : append the Condon-Shortley phase factor to the Legendre functions.
+* `csphase = 1` : exclude the Condon-Shortley phase factor (default)
+* `csphase = -1` : append the Condon-Shortley phase factor to the Legendre functions.
 
 The choice of the Condon-Shortley phase factor does not affect the numerical value of the power spectrum.
 

--- a/docs/pages/mydoc/complex-spherical-harmonics.md
+++ b/docs/pages/mydoc/complex-spherical-harmonics.md
@@ -123,8 +123,8 @@ Finally, pyshtools defines the *energy* of a function as the integral of its squ
 
 The above definitions of the Legendre functions and spherical harmonic functions do not include the Condon-Shortley phase factor of $$(-1)^m$$ that is often employed in the physics and seismology communities [Varshalovich et al. 1988, Dahlen and Tromp 1998]. Nevertheless, this phase can be included in most pyshtools routines by specifying the optional parameter
 
-* `csphase=0` : exclude the Condon-Shortley phase factor (default)
-* `csphase=1` : append the Condon-Shortley phase factor to the Legendre functions.
+* `csphase = 1` : exclude the Condon-Shortley phase factor (default)
+* `csphase = -1` : append the Condon-Shortley phase factor to the Legendre functions.
 
 The choice of the Condon-Shortley phase factor does not affect the numerical value of the power spectrum.
 

--- a/docs/pages/mydoc/python-shcoeffs.md
+++ b/docs/pages/mydoc/python-shcoeffs.md
@@ -46,7 +46,7 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | `errors` | The uncertainties of the spherical harmonic coefficients. |
 | `error_kind` | An arbitrary string describing the kind of errors, such as `None`, `'unspecified'`, `'calibrated'` or `'formal'`. |
 | `normalization` | The normalization of the coefficients: `'4pi'`, `'ortho'`, `'schmidt'`, or `'unnorm'`. |
-| `csphase` | Defines whether the Condon-Shortley phase is used (`1`) or not (`-1`). |
+| `csphase` | Defines whether the Condon-Shortley phase is excluded (`1`) or appended (`-1`). |
 | `mask` | A boolean mask that is `True` for the permissible values of degree `l` and order `m`. |
 | `kind` | The coefficient data type: either `'complex'` or `'real'`. |
 | `units` | The units of the spherical harmonic coefficients. |

--- a/docs/pages/mydoc/python-shgravcoeffs.md
+++ b/docs/pages/mydoc/python-shgravcoeffs.md
@@ -47,7 +47,7 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | `r0` | The reference radius of the gravitational potential coefficients. |
 | `omega` | The angular rotation rate of the body. |
 | `normalization` | The normalization of the coefficients: `'4pi'`, `'ortho'`, `'schmidt'`, or `'unnorm'`.|
-| `csphase` | Defines whether the Condon-Shortley phase is used (`1`) or not (`-1`). |
+| `csphase` | Defines whether the Condon-Shortley phase is excluded (`1`) or appended (`-1`). |
 | `mask` | A boolean mask that is `True` for the permissible values of degree `l` and order `m`. |
 | `kind` | The coefficient data type (only `'real'` is permissible). |
 | `epoch` | The epoch time of the spherical harmonic coefficients. |

--- a/docs/pages/mydoc/python-shgravcoeffs.md
+++ b/docs/pages/mydoc/python-shgravcoeffs.md
@@ -53,7 +53,6 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | `epoch` | The epoch time of the spherical harmonic coefficients. |
 | `header` | A list of values from the header line of the input file used to initialize the class. |
 | `header2` | A list of values from the second header line of the input file used to initialize the class. |
-| `epoch` | The epoch time of the spherical harmonic coefficients. |
 
 ## Class methods
 

--- a/docs/pages/mydoc/python-shmagcoeffs.md
+++ b/docs/pages/mydoc/python-shmagcoeffs.md
@@ -44,7 +44,7 @@ table:nth-of-type(n) th:nth-of-type(2) {
 | `error_kind` | An arbitrary string describing the kind of errors, such as `None`, `'unspecified'`, `'calibrated'` or `'formal'`. |
 | `r0` | The reference radius of the magnetic potential coefficients. |
 | `normalization` | The normalization of the coefficients: `'4pi'`, `'ortho'`, `'schmidt'`, or `'unnorm'`.|
-| `csphase` | Defines whether the Condon-Shortley phase is used (`1`) or not (`-1`). |
+| `csphase` | Defines whether the Condon-Shortley phase is excluded (`1`) or appended (`-1`). |
 | `mask` | A boolean mask that is `True` for the permissible values of degree `l` and order `m`. |
 | `kind` | The coefficient data type (only `'real'` is permissible). |
 | `units` | The units of the spherical harmonic coefficients. |

--- a/docs/pages/mydoc/real-spherical-harmonics.md
+++ b/docs/pages/mydoc/real-spherical-harmonics.md
@@ -112,8 +112,8 @@ Finally, pyshtools defines the *energy* of a function as the integral of its squ
 
 The above definitions of the Legendre functions and spherical harmonic functions do not include the Condon-Shortley phase factor of $$(-1)^m$$ that is often employed in the physics and seismology communities [Varshalovich et al. 1988, Dahlen and Tromp 1998]. Nevertheless, this phase can be included in most pyshtools routines by specifying the optional parameter
 
-* `csphase=0` : exclude the Condon-Shortley phase factor (default)
-* `csphase=1` : append the Condon-Shortley phase factor to the Legendre functions.
+* `csphase = 1` : exclude the Condon-Shortley phase factor (default)
+* `csphase = -1` : append the Condon-Shortley phase factor to the Legendre functions.
 
 The choice of the Condon-Shortley phase factor does not affect the numerical value of the power spectrum.
 

--- a/pyshtools/shclasses/shcoeffs.py
+++ b/pyshtools/shclasses/shcoeffs.py
@@ -72,8 +72,8 @@ class SHCoeffs(object):
                     'unknown', 'unspecified', 'calibrated', 'formal' or None.
     normalization : The normalization of the coefficients: '4pi', 'ortho',
                     'schmidt', or 'unnorm'.
-    csphase       : Defines whether the Condon-Shortley phase is used (1)
-                    or not (-1).
+    csphase       : Defines whether the Condon-Shortley phase is excluded (1)
+                    or appended (-1).
     mask          : A boolean mask that is True for the permissible values of
                     degree l and order m.
     kind          : The coefficient data type: either 'complex' or 'real'.

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -90,8 +90,8 @@ class SHGravCoeffs(object):
     omega         : The angular rotation rate of the body.
     normalization : The normalization of the coefficients: '4pi', 'ortho',
                     'schmidt', or 'unnorm'.
-    csphase       : Defines whether the Condon-Shortley phase is used (1)
-                    or not (-1).
+    csphase       : Defines whether the Condon-Shortley phase is excluded (1)
+                    or appended (-1).
     mask          : A boolean mask that is True for the permissible values of
                     degree l and order m.
     kind          : The coefficient data type (only 'real' is permissible).

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -78,8 +78,8 @@ class SHMagCoeffs(object):
                     coefficients.
     normalization : The normalization of the coefficients: '4pi', 'ortho',
                     'schmidt', or 'unnorm'.
-    csphase       : Defines whether the Condon-Shortley phase is used (1)
-                    or not (-1).
+    csphase       : Defines whether the Condon-Shortley phase is excluded (1)
+                    or appended (-1).
     mask          : A boolean mask that is True for the permissible values of
                     degree l and order m.
     kind          : The coefficient data type (only 'real' is permissible).


### PR DESCRIPTION
Hi!

Noticed some inconsistencies in the documentation for either excluding or applying the csphase. Specifically:

- some parts of the docs say, respectively, (0) and (1)
- some say respectively (-1) and (1)
- and others say what I believe to be correct, respectively (1) and (-1). Please let me know if I misunderstood or missed anything.

Otherwise, the changes below should fix that.

(and minor change : the `epoch` entry was listed twice in the docs for [SHGravCoeffs class](https://shtools.github.io/SHTOOLS/python-shgravcoeffs.html))

Best regards,
PL


**Reminders**

- [x] Base all changes on the `develop` branch: the `master` branch is used only when releasing new versions.
- [x] Run `make check` to ensure that the python code follows standard formatting conventions.
- [ n/a] If adding new features, update the docstring to provide all information that is required to use the feature.
