### PR TITLE
Development updates

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -86,7 +86,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: 3.12
-          mamba-version: "*"
           channels: conda-forge
           channel-priority: strict
           auto-update-conda: true

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -28,7 +28,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v2.23
         env:
           CIBW_MANYLINUX_AARCH64_IMAGE: "manylinux_2_28"
           CIBW_ARCHS_LINUX: "aarch64"
@@ -55,7 +55,7 @@ jobs:
           fetch-tags: true
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v2.23
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_28"  # ensure we don't use CentOS-based manylinux
           CIBW_BEFORE_ALL_MACOS: brew reinstall gcc fftw lapack

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -28,7 +28,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.17.0
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_MANYLINUX_AARCH64_IMAGE: "manylinux_2_28"
           CIBW_ARCHS_LINUX: "aarch64"
@@ -55,7 +55,7 @@ jobs:
           fetch-tags: true
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.17.0
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_28"  # ensure we don't use CentOS-based manylinux
           CIBW_BEFORE_ALL_MACOS: brew reinstall gcc fftw lapack

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -29,7 +29,6 @@ jobs:
       uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
-        mamba-version: "*"
         channels: conda-forge
         channel-priority: strict
         auto-update-conda: true

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ FLAKE8_FILES = pyshtools examples/python
 # if the short name of the compiler is in $(F95).
 ifeq ($(findstring gfortran,$(F95)),gfortran)
 	# Default gfortran flags
-	F95FLAGS ?= -m64 -fPIC -O3 -std=gnu -ffast-math
+	F95FLAGS ?= -fPIC -O3 -std=gnu -ffast-math
 	# -march=native
 	MODFLAG = -I$(MODPATH)
 	SYSMODFLAG = -I$(SYSMODPATH)
@@ -181,7 +181,7 @@ ifeq ($(findstring gfortran,$(F95)),gfortran)
 	LAPACK ?= -llapack
 else ifeq ($(findstring f95,$(F95)),f95)
 	# Default Absoft f95 flags
-	F95FLAGS ?= -m64 -O3 -YEXT_NAMES=LCS -YEXT_SFX=_ -fpic -speed_math=10
+	F95FLAGS ?= -O3 -YEXT_NAMES=LCS -YEXT_SFX=_ -fpic -speed_math=10
 	#-march=host
 	MODFLAG = -p $(MODPATH)
 	SYSMODFLAG = -p $(SYSMODPATH)
@@ -190,7 +190,7 @@ else ifeq ($(findstring f95,$(F95)),f95)
 	LAPACK ?= -llapack
 else ifeq ($(findstring ifort,$(F95)),ifort)
 	# Default intel fortran flags
-	F95FLAGS ?= -m64 -fpp -free -O3 -Tf
+	F95FLAGS ?= -fpp -free -O3 -Tf
 	MODFLAG = -I$(MODPATH)
 	SYSMODFLAG = -I$(SYSMODPATH)
 	OPENMPFLAGS ?= -qopenmp
@@ -198,7 +198,7 @@ else ifeq ($(findstring ifort,$(F95)),ifort)
 	BLAS ?=
 else ifeq ($(findstring ifx,$(F95)),ifx)
 	# Default intel fortran flags
-	F95FLAGS ?= -m64 -fpp -free -O3 -Tf
+	F95FLAGS ?= -fpp -free -O3 -Tf
 	MODFLAG = -I$(MODPATH)
 	SYSMODFLAG = -I$(SYSMODPATH)
 	OPENMPFLAGS ?= -qopenmp
@@ -221,7 +221,7 @@ else ifeq ($(findstring pgf90,$(F95)),pgf90)
 	BLAS ?= -lblas
 	LAPACK ?= -llapack
 else ifeq ($(origin F95FLAGS), undefined)
-	F95FLAGS = -m64 -O3
+	F95FLAGS = -O3
 	MODFLAG = -I$(MODPATH)
 	SYSMODFLAG = -I$(SYSMODPATH)
 	OPENMPFLAGS ?=

--- a/docs/pages/fortran/fortran-95-problems.md
+++ b/docs/pages/fortran/fortran-95-problems.md
@@ -3,7 +3,7 @@ title: "Fortran 95 problems"
 keywords: spherical harmonics software package, spherical harmonic transform, legendre functions, multitaper spectral analysis, fortran, Python, gravity, magnetic field
 sidebar: fortran_sidebar
 permalink: fortran-95-problems.html
-summary: 
+summary:
 toc: true
 folder: fortran
 ---
@@ -71,7 +71,7 @@ where the find command searches the directory `/usr`. This pathname can then be 
 
 For some compilers, the location of the source file following the compiler name is important. When this is the case, if the source file is not in its correct position, you could receive link errors that resemble the following:
 ```
-gfortran -L../lib -lSHTOOLS TimingAccuracy/TimingAccuracyGLQC.f95 -I../modules/ -L../lib -lfftw3 -lm -m64 -O3 -o TimingAccuracy/TimingAccuracyGLQC
+gfortran -L../lib -lSHTOOLS TimingAccuracy/TimingAccuracyGLQC.f95 -I../modules/ -L../lib -lfftw3 -lm -O3 -o TimingAccuracy/TimingAccuracyGLQC
 /tmp/cchgdOpg.o: In function `MAIN__':
 TimingAccuracyGLQC.f95:(.text+0x5b3): undefined reference to `randomgaussian_'
 TimingAccuracyGLQC.f95:(.text+0xb9b): undefined reference to `shglq_'
@@ -81,7 +81,7 @@ collect2: error: ld returned 1 exit status
 ```
 For this example, successful compilation can be achieved by placing the source file before the library calls:
 ```
-gfortran  TimingAccuracy/TimingAccuracyGLQC.f95 -L../lib -lSHTOOLS -I../modules/ -L../lib -lfftw3 -lm -m64 -O3 -o TimingAccuracy/TimingAccuracyGLQC
+gfortran  TimingAccuracy/TimingAccuracyGLQC.f95 -L../lib -lSHTOOLS -I../modules/ -L../lib -lfftw3 -lm -O3 -o TimingAccuracy/TimingAccuracyGLQC
 ```
 
 ## The linker can't seem to find either the LAPACK, BLAS, or FFTW libraries

--- a/docs/pages/fortran/fortran-installing.md
+++ b/docs/pages/fortran/fortran-installing.md
@@ -150,7 +150,7 @@ LAPACK_UNDERSCORE=1  # add an extra underscore to the LAPACK routine names
 ```
 For this case, compiler flags should probably be set so that underscores are not appended to routine names. See [Fortran 95 problems](fortran-95-problems.html) for further information.
 
-To generate 64 bit code, use the compiler option
+To generate 64 bit code (which is usually the default), use the compiler option
 ```bash
 -m64
 ```

--- a/docs/pages/fortran/using-with-f95.md
+++ b/docs/pages/fortran/using-with-f95.md
@@ -34,22 +34,22 @@ Typical examples of compiling and linking a program `MyProgram.f95` to the neces
 
 ### gfortran
 ```bash
-gfortran MyProgram.f95 -I$SHTOOLSMODPATH -L$SHTOOLSLIBPATH -lSHTOOLS -lfftw3 -lm -llapack -lblas -O3 -m64 -o MyProgram
+gfortran MyProgram.f95 -I$SHTOOLSMODPATH -L$SHTOOLSLIBPATH -lSHTOOLS -lfftw3 -lm -llapack -lblas -O3 -o MyProgram
 ```
 
 ### Absoft Pro Fortran (f95)
 ```bash
-f95 MyProgram.f95 -p $SHTOOLSMODPATH -L$SHTOOLSLIBPATH -YEXT_NAMES=LCS -YEXT_SFX=_ -lSHTOOLS -lfftw3 -lm -llapack -lblas -O3 -m64 -o MyProgram
+f95 MyProgram.f95 -p $SHTOOLSMODPATH -L$SHTOOLSLIBPATH -YEXT_NAMES=LCS -YEXT_SFX=_ -lSHTOOLS -lfftw3 -lm -llapack -lblas -O3 -o MyProgram
 ```
 
 ### g95
 ```bash
-g95 MyProgram.f95 -I$SHTOOLSMODPATH -L$SHTOOLSLIBPATH -fno-second-underscore -lSHTOOLS -lfftw3 -lm -llapack -lblas -O3 -m64 -o MyProgram
+g95 MyProgram.f95 -I$SHTOOLSMODPATH -L$SHTOOLSLIBPATH -fno-second-underscore -lSHTOOLS -lfftw3 -lm -llapack -lblas -O3 -o MyProgram
 ```
 
 ### Intel Fortran (ifort)
 ```bash
-ifort -fpp -free -I$SHTOOLSMODPATH -L$SHTOOLSLIBPATH -lSHTOOLS -lfftw3 -lm -llapack -lblas -O3 -m64 -Tf MyProgram.f95 -o MyProgram
+ifort -fpp -free -I$SHTOOLSMODPATH -L$SHTOOLSLIBPATH -lSHTOOLS -lfftw3 -lm -llapack -lblas -O3 -Tf MyProgram.f95 -o MyProgram
 ```
 Note that the position of the source file in the above examples might be important for some compilers. Note also that on macOS, linking to the preinstalled LAPACK and BLAS libraries can be accomplished using `-framework Accelerate`. (See [installing SHTOOLS](installing-fortran.html) for more details).
 

--- a/docs/pages/mydoc/python-datasets.md
+++ b/docs/pages/mydoc/python-datasets.md
@@ -83,6 +83,7 @@ The following is the list of implemented datasets. Additional older or deprecate
 | GRGM1200B_RM1_1E0 | GSFC 1200 degree and order spherical harmonic model of the gravitational potential of the Moon (Goossens et al. 2020). This model uses a rank-minus-1 constraint based on gravity from surface topography for degrees greater than 600 with a value of lambda equal to 1. |
 | GL0900D | JPL 900 degree and order spherical harmonic model of the gravitational potential of the Moon (Konopliv et al. 2014). This model applies a Kaula constraint for degrees greater than 700. |
 | GL1500E | JPL 1500 degree and order spherical harmonic model of the gravitational potential of the Moon (Konopliv et al. 2014). This model applies a Kaula constraint for degrees greater than 700. |
+| GL1800F | JPL 1800 degree and order spherical harmonic model of the gravitational potential of the Moon (Park et al. 2025). This model uses a rank-minus-1 constraint based on gravity from surface topography for degrees greater than 600. |
 | T2015_449 | 449 degree and order spherical harmonic model of the magnetic potential of the Moon. This model was used in Wieczorek (2018) and is a spherical harmonic expansion of the global magnetic field model of Tsunakawa et al. (2015). |
 | Ravat2020 | 450 degree and order spherical harmonic model of the magnetic potential of the Moon. This model is based on using magnetic monopoles with an L1-norm regularization. |
 

--- a/pyshtools/datasets/Moon/__init__.py
+++ b/pyshtools/datasets/Moon/__init__.py
@@ -13,6 +13,7 @@ GRGM1200B         :  Goossens et al. (2020)
 GRGM1200B_RM1_1E0 :  Goossens et al. (2020)
 GL0900D           :  Konopliv et al. (2014)
 GL1500E           :  Konopliv et al. (2014)
+GL1800F           :  Park et al. (2025)
 
 Magnetic field
 --------------
@@ -400,6 +401,39 @@ def GL1500E(lmax=1500):
                                    name='GL1500E (Moon)', encoding='utf-8')
 
 
+def GL1800F(lmax=1800):
+    '''
+    GL1800F is a JPL 1800 degree and order spherical harmonic model of
+    the gravitational potential of the Moon. This model uses a rank-minus-1
+    constraint based on gravity from surface topography for degrees greater
+    than 600.
+
+    Parameters
+    ----------
+    lmax : int, optional
+        The maximum spherical harmonic degree to return.
+
+    Reference
+    ---------
+    R. S. Park, A. Berne, A. S. Konopliv, J. T. Keane, I. Matsuyama, F. Nimmo,
+        M. Rovira-Navarro, M. P. Panning, M. Simons, D. J. Stevenson,
+        R. C. Weber, Thermal asymmetry in the Moon's mantle inferred from
+        monthly tidal response, Nature, 2025.
+    '''
+    if lmax < 0:
+        lmax = 1800
+
+    fname = _retrieve(
+        url="https://pds-geosciences.wustl.edu/grail/grail-l-lgrs-5-rdr-v1/grail_1001/shadr/jggrx_1800f_sha.tab",  # noqa: E501
+        known_hash="sha256:d2a552067a78bf1d2755807ae14ee1d6843a8f6a4228e01ce59a665516738fec",  # noqa: E501
+        downloader=_HTTPDownloader(progressbar=True),
+        path=_os_cache('pyshtools'),
+    )
+    return _SHGravCoeffs.from_file(fname, lmax=lmax, header_units='km',
+                                   errors=True, omega=_omega.value,
+                                   name='GL1800F (Moon)', encoding='utf-8')
+
+
 __all__ = ['LDEM_shape_pa', 'LOLA_shape', 'T2015_449', 'Ravat2020', 'GRGM900C',
-           'GRGM1200B', 'GRGM1200B_RM1_1E0', 'GL0900D', 'GL1500E',
+           'GRGM1200B', 'GRGM1200B_RM1_1E0', 'GL0900D', 'GL1500E', 'GL1800F',
            'historical']

--- a/pyshtools/shclasses/shcoeffs.py
+++ b/pyshtools/shclasses/shcoeffs.py
@@ -4366,7 +4366,7 @@ class SHRealCoeffs(SHCoeffs):
                 .format(repr(self.normalization)))
 
         if backend == "shtools" and zeros is None:
-            zeros, weights = _shtools.SHGLQ(self.lmax)
+            zeros, weights = _shtools.SHGLQ(lmax)
         data = backend_module(
             backend=backend, nthreads=nthreads).MakeGridGLQ(
                 self.coeffs, zero=zeros, norm=norm,
@@ -4660,7 +4660,7 @@ class SHComplexCoeffs(SHCoeffs):
                 .format(repr(self.normalization)))
 
         if backend == "shtools" and zeros is None:
-            zeros, weights = _shtools.SHGLQ(self.lmax)
+            zeros, weights = _shtools.SHGLQ(lmax)
         data = backend_module(
                 backend=backend, nthreads=nthreads).MakeGridGLQC(
                     self.coeffs, zero=zeros, norm=norm,

--- a/pyshtools/shclasses/shcoeffs.py
+++ b/pyshtools/shclasses/shcoeffs.py
@@ -1608,24 +1608,25 @@ class SHCoeffs(object):
         Notes
         -----
         This method returns either the power spectrum, energy spectrum, or
-        l2-norm spectrum. Total power is defined as the integral of the
-        function squared over all space, divided by the area the function
-        spans. If the mean of the function is zero, this is equivalent to the
-        variance of the function. The total energy is the integral of the
-        function squared over all space and is 4pi times the total power. For
-        normalized coefficients ('4pi', 'ortho', or 'schmidt'), the l2-norm is
-        the sum of the magnitude of the coefficients squared.
+        l2-norm spectrum of a function that is expressed in spherical
+        harmonics. Total power is defined as the integral of the function
+        squared over all space, divided by the area the function spans. If the
+        mean of the function is zero, this is equivalent to the variance of the
+        function. The total energy is the integral of the function squared over
+        all space and is 4 pi times the total power. For normalized
+        coefficients ('4pi', 'ortho', or 'schmidt'), the l2-norm is the sum of
+        the magnitude of the coefficients squared.
 
         The output spectrum can be expresed using one of three units. 'per_l'
-        returns the contribution to the total spectrum from all angular orders
-        at degree l. 'per_lm' returns the average contribution to the total
-        spectrum from a single coefficient at degree l, which is equal to the
-        'per_l' spectrum divided by (2l+1). 'per_dlogl' returns the
-        contribution to the total spectrum from all angular orders over an
-        infinitessimal logarithmic degree band. The contrubution in the band
-        dlog_a(l) is spectrum(l, 'per_dlogl')*dlog_a(l), where a is the base,
-        and where spectrum(l, 'per_dlogl) is equal to
-        spectrum(l, 'per_l')*l*log(a).
+        returns the contribution to the total power, energy or l2-norm from all
+        angular orders at degree l. 'per_lm' returns the average contribution
+        to the total power, energy or l2-norm from a single coefficient at
+        degree l, and is equal to the 'per_l' spectrum divided by (2l+1).
+        'per_dlogl' returns the contribution to the total power, energy or
+        l2-norm from all angular orders over an infinitessimal logarithmic
+        degree band. The contrubution in the band dlog_a(l) is
+        spectrum(l, 'per_dlogl')*dlog_a(l), where a is the base, and where
+        spectrum(l, 'per_dlogl) is equal to spectrum(l, 'per_l')*l*log(a).
         """
         s = _spectrum(self.coeffs, normalization=self.normalization,
                       convention=convention, unit=unit, base=base,
@@ -1676,25 +1677,28 @@ class SHCoeffs(object):
         Notes
         -----
         This method returns either the cross-power spectrum, cross-energy
-        spectrum, or l2-cross-norm spectrum. Total cross-power is defined as
-        the integral of the function times the conjugate of clm over all space,
-        divided by the area the functions span. If the means of the functions
-        are zero, this is equivalent to the covariance of the two functions.
-        The total cross-energy is the integral of this function times the
-        conjugate of clm over all space and is 4pi times the total power. The
-        l2-cross-norm is the sum of this function times the conjugate of clm
-        over all angular orders as a function of spherical harmonic degree.
+        spectrum, or l2-cross-norm spectrum of two functions expressed in
+        spherical harmonics. Total cross-power is defined as the integral of
+        the function times the conjugate of the input function (clm) over all
+        space, divided by the area the functions span. If the means of the two
+        functions are zero, this is equivalent to the covariance of the two
+        functions. The total cross-energy is the integral of the function times
+        the conjugate of the input function over all space and is 4 pi times
+        the total power. For normalized coefficients ('4pi', 'ortho', or
+        'schmidt'), the l2-cross norm is the sum of the magnitude of the
+        coefficients of the function multiplied by the conjugate of the
+        coefficients of the input function.
 
         The output spectrum can be expresed using one of three units. 'per_l'
-        returns the contribution to the total spectrum from all angular orders
-        at degree l. 'per_lm' returns the average contribution to the total
-        spectrum from a single coefficient at degree l, and is equal to the
-        'per_l' spectrum divided by (2l+1). 'per_dlogl' returns the
-        contribution to the total spectrum from all angular orders over an
-        infinitessimal logarithmic degree band. The contrubution in the band
-        dlog_a(l) is spectrum(l, 'per_dlogl')*dlog_a(l), where a is the base,
-        and where spectrum(l, 'per_dlogl) is equal to
-        spectrum(l, 'per_l')*l*log(a).
+        returns the contribution to the total power, energy or l2-norm from all
+        angular orders at degree l. 'per_lm' returns the average contribution
+        to the total power, energy or l2-norm from a single coefficient at
+        degree l, and is equal to the 'per_l' spectrum divided by (2l+1).
+        'per_dlogl' returns the contribution to the total power, energy or
+        l2-norm from all angular orders over an infinitessimal logarithmic
+        degree band. The contrubution in the band dlog_a(l) is
+        spectrum(l, 'per_dlogl')*dlog_a(l), where a is the base, and where
+        spectrum(l, 'per_dlogl) is equal to spectrum(l, 'per_l')*l*log(a).
         """
         if not isinstance(clm, SHCoeffs):
             raise ValueError('clm must be an SHCoeffs class instance. Input '
@@ -2546,15 +2550,15 @@ class SHCoeffs(object):
         is the sum of the magnitude of the coefficients squared.
 
         The output spectrum can be expresed using one of three units. 'per_l'
-        returns the contribution to the total spectrum from all angular orders
-        at degree l. 'per_lm' returns the average contribution to the total
-        spectrum from a single coefficient at degree l, which is equal to the
-        'per_l' spectrum divided by (2l+1). 'per_dlogl' returns the
-        contribution to the total spectrum from all angular orders over an
-        infinitessimal logarithmic degree band. The contrubution in the band
-        dlog_a(l) is spectrum(l, 'per_dlogl')*dlog_a(l), where a is the base,
-        and where spectrum(l, 'per_dlogl) is equal to
-        spectrum(l, 'per_l')*l*log(a).
+        returns the contribution to the total power, energy or l2-norm from all
+        angular orders at degree l. 'per_lm' returns the average contribution
+        to the total power, energy or l2-norm from a single coefficient at
+        degree l, and is equal to the 'per_l' spectrum divided by (2l+1).
+        'per_dlogl' returns the contribution to the total power, energy or
+        l2-norm from all angular orders over an infinitessimal logarithmic
+        degree band. The contrubution in the band dlog_a(l) is
+        spectrum(l, 'per_dlogl')*dlog_a(l), where a is the base, and where
+        spectrum(l, 'per_dlogl) is equal to spectrum(l, 'per_l')*l*log(a).
         """
         if lmax is None:
             lmax = self.lmax
@@ -2746,21 +2750,23 @@ class SHCoeffs(object):
         divided by the area the functions span. If the means of the functions
         are zero, this is equivalent to the covariance of the two functions.
         The total cross-energy is the integral of this function times the
-        conjugate of clm over all space and is 4pi times the total power. The
-        l2-cross-norm is the sum of this function times the conjugate of clm
-        over all angular orders as a function of spherical harmonic degree.
+        conjugate of clm over all space and is 4pi times the total power. For
+        normalized coefficients ('4pi', 'ortho', or 'schmidt'), the l2-cross
+        norm is the sum of the magnitude of the coefficients of the function
+        multiplied by the conjugate of the coefficients of the input function.
 
         The output spectrum can be expresed using one of three units. 'per_l'
-        returns the contribution to the total spectrum from all angular orders
-        at degree l. 'per_lm' returns the average contribution to the total
-        spectrum from a single coefficient at degree l, and is equal to the
-        'per_l' spectrum divided by (2l+1). 'per_dlogl' returns the
-        contribution to the total spectrum from all angular orders over an
-        infinitessimal logarithmic degree band. The contrubution in the band
-        dlog_a(l) is spectrum(l, 'per_dlogl')*dlog_a(l), where a is the base,
-        and where spectrum(l, 'per_dlogl) is equal to
-        spectrum(l, 'per_l')*l*log(a). If the input fields are complex, the
-        absolute value of the cross-spectrum will be plotted.
+        returns the contribution to the total power, energy or l2-norm from all
+        angular orders at degree l. 'per_lm' returns the average contribution
+        to the total power, energy or l2-norm from a single coefficient at
+        degree l, and is equal to the 'per_l' spectrum divided by (2l+1).
+        'per_dlogl' returns the contribution to the total power, energy or
+        l2-norm from all angular orders over an infinitessimal logarithmic
+        degree band. The contrubution in the band dlog_a(l) is
+        spectrum(l, 'per_dlogl')*dlog_a(l), where a is the base, and where
+        spectrum(l, 'per_dlogl) is equal to spectrum(l, 'per_l')*l*log(a). If
+        the input fields are complex, the absolute value of the cross-spectrum
+        will be plotted.
         """
         if not isinstance(clm, SHCoeffs):
             raise ValueError('clm must be an SHCoeffs class instance. Input '

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -1836,15 +1836,15 @@ class SHGravCoeffs(object):
         to the variance of the function.
 
         The output spectrum can be expresed using one of three units. 'per_l'
-        returns the contribution to the total spectrum from all angular orders
-        at degree l. 'per_lm' returns the average contribution to the total
-        spectrum from a single coefficient at degree l, which is equal to the
-        'per_l' spectrum divided by (2l+1). 'per_dlogl' returns the
-        contribution to the total spectrum from all angular orders over an
-        infinitessimal logarithmic degree band. The contrubution in the band
-        dlog_a(l) is spectrum(l, 'per_dlogl')*dlog_a(l), where a is the base,
-        and where spectrum(l, 'per_dlogl) is equal to
-        spectrum(l, 'per_l')*l*log(a).
+        returns the contribution to the total power, energy or l2-norm from all
+        angular orders at degree l. 'per_lm' returns the average contribution
+        to the total power, energy or l2-norm from a single coefficient at
+        degree l, and is equal to the 'per_l' spectrum divided by (2l+1).
+        'per_dlogl' returns the contribution to the total power, energy or
+        l2-norm from all angular orders over an infinitessimal logarithmic
+        degree band. The contrubution in the band dlog_a(l) is
+        spectrum(l, 'per_dlogl')*dlog_a(l), where a is the base, and where
+        spectrum(l, 'per_dlogl) is equal to spectrum(l, 'per_l')*l*log(a).
         """
         if function.lower() not in ('potential', 'geoid', 'radial', 'total'):
             raise ValueError(

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -1483,15 +1483,15 @@ class SHMagCoeffs(object):
         function is zero, this is equivalent to the variance of the function.
 
         The output spectrum can be expresed using one of three units. 'per_l'
-        returns the contribution to the total spectrum from all angular orders
-        at degree l. 'per_lm' returns the average contribution to the total
-        spectrum from a single coefficient at degree l, which is equal to the
-        'per_l' spectrum divided by (2l+1). 'per_dlogl' returns the
-        contribution to the total spectrum from all angular orders over an
-        infinitessimal logarithmic degree band. The contrubution in the band
-        dlog_a(l) is spectrum(l, 'per_dlogl')*dlog_a(l), where a is the base,
-        and where spectrum(l, 'per_dlogl) is equal to
-        spectrum(l, 'per_l')*l*log(a).
+        returns the contribution to the total power, energy or l2-norm from all
+        angular orders at degree l. 'per_lm' returns the average contribution
+        to the total power, energy or l2-norm from a single coefficient at
+        degree l, and is equal to the 'per_l' spectrum divided by (2l+1).
+        'per_dlogl' returns the contribution to the total power, energy or
+        l2-norm from all angular orders over an infinitessimal logarithmic
+        degree band. The contrubution in the band dlog_a(l) is
+        spectrum(l, 'per_dlogl')*dlog_a(l), where a is the base, and where
+        spectrum(l, 'per_dlogl) is equal to spectrum(l, 'per_l')*l*log(a).
         """
         if function.lower() not in ('potential', 'radial', 'total'):
             raise ValueError(
@@ -2254,15 +2254,15 @@ class SHMagCoeffs(object):
         variance of the function.
 
         The output spectrum can be expresed using one of three units. 'per_l'
-        returns the contribution to the total spectrum from all angular orders
-        at degree l. 'per_lm' returns the average contribution to the total
-        spectrum from a single coefficient at degree l, which is equal to the
-        'per_l' spectrum divided by (2l+1). 'per_dlogl' returns the
-        contribution to the total spectrum from all angular orders over an
-        infinitessimal logarithmic degree band. The contrubution in the band
-        dlog_a(l) is spectrum(l, 'per_dlogl')*dlog_a(l), where a is the base,
-        and where spectrum(l, 'per_dlogl) is equal to
-        spectrum(l, 'per_l')*l*log(a).
+        returns the contribution to the total power, energy or l2-norm from all
+        angular orders at degree l. 'per_lm' returns the average contribution
+        to the total power, energy or l2-norm from a single coefficient at
+        degree l, and is equal to the 'per_l' spectrum divided by (2l+1).
+        'per_dlogl' returns the contribution to the total power, energy or
+        l2-norm from all angular orders over an infinitessimal logarithmic
+        degree band. The contrubution in the band dlog_a(l) is
+        spectrum(l, 'per_dlogl')*dlog_a(l), where a is the base, and where
+        spectrum(l, 'per_dlogl) is equal to spectrum(l, 'per_l')*l*log(a).
         """
         if lmax is None:
             lmax = self.lmax

--- a/pyshtools/spectralanalysis/cross_spectrum.py
+++ b/pyshtools/spectralanalysis/cross_spectrum.py
@@ -47,25 +47,29 @@ def cross_spectrum(clm1, clm2, normalization='4pi', degrees=None, lmax=None,
 
     Notes
     -----
-    This function returns either the cross-power spectrum, cross-energy
-    spectrum, or l2-cross-norm spectrum. Total cross-power is defined as the
-    integral of the clm1 times the conjugate of clm2 over all space, divided
-    by the area the functions span. If the mean of the functions is zero,
-    this is equivalent to the covariance of the two functions. The total
-    cross-energy is the integral of clm1 times the conjugate of clm2 over all
-    space and is 4pi times the total power. The l2-cross-norm is the
-    sum of clm1 times the conjugate of clm2 over all angular orders as a
-    function of spherical harmonic degree.
+    This method returns either the cross-power spectrum, cross-energy spectrum,
+    or l2-cross-norm spectrum of two functions expressed in spherical
+    harmonics. Total cross-power is defined as the integral of the first
+    function times the conjugate of the second function over all space,
+    divided by the area the functions span. If the means of the two functions
+    are zero, this is equivalent to the covariance of the two functions. The
+    total cross-energy is the integral of the first function times the
+    conjugate of the second function over all space and is 4 pi times the total
+    power. For normalized coefficients ('4pi', 'ortho', or 'schmidt'), the
+    l2-cross norm is the sum of the magnitude of the coefficients of the first
+    function multiplied by the conjugate of the coefficients of the second
+    function.
 
     The output spectrum can be expresed using one of three units. 'per_l'
-    returns the contribution to the total spectrum from all angular orders
-    at degree l. 'per_lm' returns the average contribution to the total
-    spectrum from a single coefficient at degree l, and is equal to the
-    'per_l' spectrum divided by (2l+1). 'per_dlogl' returns the contribution to
-    the total spectrum from all angular orders over an infinitessimal
-    logarithmic degree band. The contrubution in the band dlog_a(l) is
-    spectrum(l, 'per_dlogl')*dlog_a(l), where a is the base, and where
-    spectrum(l, 'per_dlogl) is equal to spectrum(l, 'per_l')*l*log(a).
+    returns the contribution to the total power, energy or l2-norm from all
+    angular orders at degree l. 'per_lm' returns the average contribution to
+    the total power, energy or l2-norm from a single coefficient at degree l,
+    and is equal to the 'per_l' spectrum divided by (2l+1). 'per_dlogl' returns
+    the contribution to the total power, energy or l2-norm from all angular
+    orders over an infinitessimal logarithmic degree band. The contrubution in
+    the band dlog_a(l) is spectrum(l, 'per_dlogl')*dlog_a(l), where a is the
+    base, and where spectrum(l, 'per_dlogl) is equal to
+    spectrum(l, 'per_l')*l*log(a).
     """
     if normalization.lower() not in ('4pi', 'ortho', 'schmidt', 'unnorm'):
         raise ValueError("The normalization must be '4pi', 'ortho', " +
@@ -131,15 +135,11 @@ def cross_spectrum(clm1, clm2, normalization='4pi', degrees=None, lmax=None,
                 array[i] = (clm1[0, l, 0:l + 1] * clm2[0, l, 0:l + 1]).sum() \
                            + (clm1[1, l, 1:l + 1] * clm2[1, l, 1:l + 1]).sum()
 
-        if convention.lower() == 'l2norm':
-            return array
-        else:
-            if normalization.lower() == '4pi':
-                pass
-            elif normalization.lower() == 'schmidt':
-                array /= (2. * degrees + 1.)
-            elif normalization.lower() == 'ortho':
-                array /= (4. * _np.pi)
+        if normalization.lower() == 'schmidt':
+            array /= (2. * degrees + 1.)
+
+        if normalization.lower() == 'ortho':
+            array /= (4. * _np.pi)
 
     if convention.lower() == 'energy':
         array *= 4. * _np.pi

--- a/pyshtools/spectralanalysis/spectrum.py
+++ b/pyshtools/spectralanalysis/spectrum.py
@@ -45,23 +45,26 @@ def spectrum(clm, normalization='4pi', degrees=None, lmax=None,
 
     Notes
     -----
-    This function returns either the power spectrum, energy spectrum, or
-    l2-norm spectrum. Total power is defined as the integral of the
-    function squared over all space, divided by the area the function
-    spans. If the mean of the function is zero, this is equivalent to the
-    variance of the function. The total energy is the integral of the
-    function squared over all space and is 4pi times the total power. The
-    l2-norm is the sum of the magnitude of the coefficients squared.
+    This routine returns either the power spectrum, energy spectrum, or
+    l2-norm spectrum of a function that is expressed in spherical harmonics.
+    Total power is defined as the integral of the function squared over all
+    space, divided by the area the function spans. If the mean of the function
+    is zero, this is equivalent to the variance of the function. The total
+    energy is the integral of the function squared over all space and is 4 pi
+    times the total power. For normalized coefficients ('4pi', 'ortho', or
+    'schmidt'), the l2-norm is the sum of the magnitude of the coefficients
+    squared.
 
     The output spectrum can be expresed using one of three units. 'per_l'
-    returns the contribution to the total spectrum from all angular orders
-    at degree l. 'per_lm' returns the average contribution to the total
-    spectrum from a single coefficient at degree l, and is equal to the
-    'per_l' spectrum divided by (2l+1). 'per_dlogl' returns the contribution to
-    the total spectrum from all angular orders over an infinitessimal
-    logarithmic degree band. The contrubution in the band dlog_a(l) is
-    spectrum(l, 'per_dlogl')*dlog_a(l), where a is the base, and where
-    spectrum(l, 'per_dlogl) is equal to spectrum(l, 'per_l')*l*log(a).
+    returns the contribution to the total power, energy or l2-norm from all
+    angular orders at degree l. 'per_lm' returns the average contribution to
+    the total power, energy or l2-norm from a single coefficient at degree l,
+    and is equal to the 'per_l' spectrum divided by (2l+1). 'per_dlogl' returns
+    the contribution to the total power, energy or l2-norm from all angular
+    orders over an infinitessimal logarithmic degree band. The contrubution in
+    the band dlog_a(l) is spectrum(l, 'per_dlogl')*dlog_a(l), where a is the
+    base, and where spectrum(l, 'per_dlogl) is equal to
+    spectrum(l, 'per_l')*l*log(a).
     """
     if normalization.lower() not in ('4pi', 'ortho', 'schmidt', 'unnorm'):
         raise ValueError("The normalization must be '4pi', 'ortho', " +
@@ -115,15 +118,11 @@ def spectrum(clm, normalization='4pi', degrees=None, lmax=None,
                 array[i] = (clm[0, l, 0:l+1]**2).sum() + \
                            (clm[1, l, 1:l+1]**2).sum()
 
-        if convention.lower() == 'l2norm':
-            return array
-        else:
-            if normalization.lower() == '4pi':
-                pass
-            elif normalization.lower() == 'schmidt':
-                array /= (2. * degrees + 1.)
-            elif normalization.lower() == 'ortho':
-                array /= (4. * _np.pi)
+        if normalization.lower() == 'schmidt':
+            array /= (2. * degrees + 1.)
+
+        if normalization.lower() == 'ortho':
+            array /= (4. * _np.pi)
 
     if convention.lower() == 'energy':
         array *= 4. * _np.pi


### PR DESCRIPTION
* Update cibuildwheels version and stop using Mamba: see #494 
* Add the GL1800F lunar gravity model to the datasets module.
* Remove the `-m64` compiler flag that gives rise to incompatibilites with aarch64 platforms, and which probably is no longer necessary: see #507 
* Fix inconsistency with how the (cross-)spectrum is computed when using the option `l2norm`. See #506 
* Fix a bug where the optional parameter `lmax` was not treated properly for `SHCoeffs.expand()` when using `GLQ` grids with the `shtools` backend.
