### PR TITLE
Fix issue #510

### DIFF
--- a/pyshtools/backends/ducc0_wrapper.py
+++ b/pyshtools/backends/ducc0_wrapper.py
@@ -644,14 +644,14 @@ def MakeGridDHC(
     """ # noqa
     lmax, lmax_calc, cilm = _prep_lmax(lmax, lmax_calc, cilm)
     alm = _ccilm2almi(cilm)
-    alm = _apply_norm(alm, lmax, norm, csphase, False)
+    alm = _apply_norm(alm, lmax_calc, norm, csphase, False)
     res = _np.empty(
         [2 * lmax + 2 + extend, sampling * (2 * lmax + 2) + extend],
         dtype=_np.complex128,
     )
     _synthesize_DH(alm, lmax_calc, extend, res.imag)
     alm = _ccilm2almr(cilm)
-    alm = _apply_norm(alm, lmax, norm, csphase, False)
+    alm = _apply_norm(alm, lmax_calc, norm, csphase, False)
     _synthesize_DH(alm, lmax_calc, extend, res.real)
     return res
 
@@ -990,11 +990,11 @@ def MakeGridGLQC(
     """ # noqa
     lmax, lmax_calc, cilm = _prep_lmax(lmax, lmax_calc, cilm)
     alm = _ccilm2almi(cilm)
-    alm = _apply_norm(alm, lmax, norm, csphase, False)
+    alm = _apply_norm(alm, lmax_calc, norm, csphase, False)
     res = _np.empty([lmax + 1, 2 * lmax + 1 + extend], dtype=_np.complex128)
     _synthesize_GLQ(alm, lmax_calc, extend, res.imag)
     alm = _ccilm2almr(cilm)
-    alm = _apply_norm(alm, lmax, norm, csphase, False)
+    alm = _apply_norm(alm, lmax_calc, norm, csphase, False)
     _synthesize_GLQ(alm, lmax_calc, extend, res.real)
     return res
 

--- a/pyshtools/shclasses/shcoeffs.py
+++ b/pyshtools/shclasses/shcoeffs.py
@@ -2347,7 +2347,7 @@ class SHCoeffs(object):
             if lmax is None:
                 lmax = self.lmax
             if lmax_calc is None:
-                lmax_calc = lmax
+                lmax_calc = self.lmax
             if backend is None:
                 backend = preferred_backend()
             if name is None:


### PR DESCRIPTION
This hopefully fixes the incorrect handling of `lmax` in the `MakeGrid` routines of the `ducc` backend.



**Reminders**

- [ ] Base all changes on the `develop` branch: the `master` branch is used only when releasing new versions.
- [ ] Run `make check` to ensure that the python code follows standard formatting conventions.
- [ ] If adding new features, update the docstring to provide all information that is required to use the feature.
