### PR TITLE
Improve handling of lmax and lmax_calc parameters when making grids

### DIFF
--- a/pyshtools/shclasses/shcoeffs.py
+++ b/pyshtools/shclasses/shcoeffs.py
@@ -2432,7 +2432,7 @@ class SHCoeffs(object):
         if lmax is None:
             lmax = self.lmax
         if lmax_calc is None:
-            lmax_calc = lmax
+            lmax_calc = self.lmax
         if backend is None:
             backend = preferred_backend()
         if name is None:

--- a/pyshtools/shclasses/shgravcoeffs.py
+++ b/pyshtools/shclasses/shgravcoeffs.py
@@ -2534,7 +2534,7 @@ class SHGravCoeffs(object):
             if lmax is None:
                 lmax = self.lmax
             if lmax_calc is None:
-                lmax_calc = lmax
+                lmax_calc = self.lmax
             if name is None:
                 name = self.name
 
@@ -2647,7 +2647,7 @@ class SHGravCoeffs(object):
         if lmax is None:
             lmax = self.lmax
         if lmax_calc is None:
-            lmax_calc = lmax
+            lmax_calc = self.lmax
         if name is None:
             name = self.name
 
@@ -2741,7 +2741,7 @@ class SHGravCoeffs(object):
         if lmax is None:
             lmax = self.lmax
         if lmax_calc is None:
-            lmax_calc = lmax
+            lmax_calc = self.lmax
         if name is None:
             name = self.name
 

--- a/pyshtools/shclasses/shmagcoeffs.py
+++ b/pyshtools/shclasses/shmagcoeffs.py
@@ -2041,7 +2041,7 @@ class SHMagCoeffs(object):
             if lmax is None:
                 lmax = self.lmax
             if lmax_calc is None:
-                lmax_calc = lmax
+                lmax_calc = self.lmax
             if name is None:
                 name = self.name
 
@@ -2150,7 +2150,7 @@ class SHMagCoeffs(object):
         if lmax is None:
             lmax = self.lmax
         if lmax_calc is None:
-            lmax_calc = lmax
+            lmax_calc = self.lmax
         if name is None:
             name = self.name
 


### PR DESCRIPTION
* Minor changes to how the optional parameters `lmax` and `lmax_calc` are set when making grids from coefficients that could improve performance under certain circumstances.
